### PR TITLE
Add repository information to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,5 +35,9 @@
   "publishConfig": {
     "access": "public",
     "provenance": true
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Universal-Commerce-Protocol/js-sdk"
   }
 }


### PR DESCRIPTION
This change adds information on the npm.js package page and also might solve the [OIDC release problem](https://github.com/Universal-Commerce-Protocol/js-sdk/actions/runs/21001882761/job/60373795271), as described in https://github.com/npm/cli/issues/8730#issuecomment-3657780285.