### PR TITLE
Remove registry URL from Node installation step

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,6 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 'lts/*'
-          registry-url: 'https://registry.npmjs.org'
 
       - name: Install dependencies
         run: npm ci

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,7 @@ jobs:
   release:
     name: Upload release to NPM
     runs-on: ubuntu-latest
+    environment: "release"
     permissions:
       id-token: write
       contents: read


### PR DESCRIPTION
Removed registry URL from Node setup step. If not provided, the default one is used.

Added job environment.