### PR TITLE
update js-sdk to latest ucp version

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Then, run `npm run generate` pointing to the `spec` folder of the cloned
 repository, e.g.:
 
 ```bash
-npm run generate -- ucp/spec
+npm run generate -- ucp/source
 ```
 
 ### Building

--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ Then, run `npm run generate` pointing to the `spec` folder of the cloned
 repository, e.g.:
 
 ```bash
+npm install
 npm run generate -- ucp/source
 ```
 

--- a/generate_models.sh
+++ b/generate_models.sh
@@ -9,21 +9,24 @@ fi
 
 SPEC_DIR="${1%/}"
 
-quicktype \
+npx quicktype \
   --lang typescript-zod \
   --src-lang schema \
   --src "$SPEC_DIR"/discovery/*.json \
   --src "$SPEC_DIR"/schemas/shopping/*.json \
   --src "$SPEC_DIR"/schemas/shopping/types/*.json \
-  --src "$SPEC_DIR/schemas/shopping/ap2_mandate.json#/\$defs/complete_request_with_ap2" \
-  --src "$SPEC_DIR/schemas/shopping/ap2_mandate.json#/\$defs/checkout_response_with_ap2" \
-  --src "$SPEC_DIR/schemas/shopping/buyer_consent.create_req.json#/\$defs/checkout" \
-  --src "$SPEC_DIR/schemas/shopping/buyer_consent.update_req.json#/\$defs/checkout" \
-  --src "$SPEC_DIR/schemas/shopping/buyer_consent_resp.json#/\$defs/checkout" \
-  --src "$SPEC_DIR/schemas/shopping/discount.create_req.json#/\$defs/checkout" \
-  --src "$SPEC_DIR/schemas/shopping/discount.update_req.json#/\$defs/checkout" \
-  --src "$SPEC_DIR/schemas/shopping/discount_resp.json#/\$defs/checkout" \
-  --src "$SPEC_DIR/schemas/shopping/fulfillment.create_req.json#/\$defs/checkout" \
-  --src "$SPEC_DIR/schemas/shopping/fulfillment.update_req.json#/\$defs/checkout" \
-  --src "$SPEC_DIR/schemas/shopping/fulfillment_resp.json#/\$defs/checkout" \
+  --src "$SPEC_DIR/schemas/shopping/ap2_mandate.json#/\$defs/ap2_with_checkout_mandate" \
+  --src "$SPEC_DIR/schemas/shopping/ap2_mandate.json#/\$defs/ap2_with_merchant_authorization" \
+  --src "$SPEC_DIR/schemas/shopping/ap2_mandate.json#/\$defs/checkout_mandate" \
+  --src "$SPEC_DIR/schemas/shopping/ap2_mandate.json#/\$defs/merchant_authorization" \
+  --src "$SPEC_DIR/schemas/shopping/buyer_consent.json#/\$defs/buyer" \
+  --src "$SPEC_DIR/schemas/shopping/buyer_consent.json#/\$defs/consent" \
+  --src "$SPEC_DIR/schemas/shopping/discount.json#/\$defs/allocation" \
+  --src "$SPEC_DIR/schemas/shopping/discount.json#/\$defs/applied_discount" \
+  --src "$SPEC_DIR/schemas/shopping/discount.json#/\$defs/discounts_object" \
+  --src "$SPEC_DIR/schemas/shopping/fulfillment.json#/\$defs/fulfillment" \
+  --src "$SPEC_DIR/schemas/shopping/fulfillment.json#/\$defs/fulfillment_available_method" \
+  --src "$SPEC_DIR/schemas/shopping/fulfillment.json#/\$defs/fulfillment_group" \
+  --src "$SPEC_DIR/schemas/shopping/fulfillment.json#/\$defs/fulfillment_method" \
+  --src "$SPEC_DIR/schemas/shopping/fulfillment.json#/\$defs/fulfillment_option" \
   -o src/spec_generated.ts

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,13 @@
 {
-  "name": "@ucp/sdk",
+  "name": "@ucp-js/sdk",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "@ucp/sdk",
+      "name": "@ucp-js/sdk",
       "version": "0.1.0",
+      "license": "Apache-2.0",
       "dependencies": {
         "zod": "^3.23.8"
       },

--- a/src/extensions.ts
+++ b/src/extensions.ts
@@ -1,18 +1,7 @@
 import { z } from "zod";
 
 import {
-  CheckoutCreateRequestSchema,
-  CheckoutResponseSchema,
-  CheckoutUpdateRequestSchema,
-  CheckoutWithBuyerConsentCreateRequestSchema,
-  CheckoutWithBuyerConsentResponseSchema,
-  CheckoutWithBuyerConsentUpdateRequestSchema,
-  CheckoutWithDiscountCreateRequestSchema,
-  CheckoutWithDiscountResponseSchema,
-  CheckoutWithDiscountUpdateRequestSchema,
-  CheckoutWithFulfillmentCreateRequestSchema,
-  CheckoutWithFulfillmentResponseSchema,
-  CheckoutWithFulfillmentUpdateRequestSchema,
+  CheckoutSchema,
   OrderSchema,
   PaymentCredentialSchema,
 } from "./spec_generated";
@@ -29,44 +18,21 @@ export const PlatformConfigSchema = z.object({
 });
 export type PlatformConfig = z.infer<typeof PlatformConfigSchema>;
 
-export const ExtendedCheckoutResponseSchema = CheckoutResponseSchema.extend(
-  CheckoutWithFulfillmentResponseSchema.pick({ fulfillment: true }).shape
-)
-  .extend(CheckoutWithDiscountResponseSchema.pick({ discounts: true }).shape)
-  .extend(CheckoutWithBuyerConsentResponseSchema.pick({ buyer: true }).shape)
-  .extend({
-    order_id: z.string().optional(),
-    order_permalink_url: z.string().optional(),
-    platform: PlatformConfigSchema.optional(),
-  });
+export const ExtendedCheckoutResponseSchema = CheckoutSchema.extend({
+  order_id: z.string().optional(),
+  order_permalink_url: z.string().optional(),
+  platform: PlatformConfigSchema.optional(),
+});
 export type ExtendedCheckoutResponse = z.infer<
   typeof ExtendedCheckoutResponseSchema
 >;
 
-export const ExtendedCheckoutCreateRequestSchema =
-  CheckoutCreateRequestSchema.extend(
-    CheckoutWithFulfillmentCreateRequestSchema.pick({ fulfillment: true }).shape
-  )
-    .extend(
-      CheckoutWithDiscountCreateRequestSchema.pick({ discounts: true }).shape
-    )
-    .extend(
-      CheckoutWithBuyerConsentCreateRequestSchema.pick({ buyer: true }).shape
-    );
+export const ExtendedCheckoutCreateRequestSchema = CheckoutSchema;
 export type ExtendedCheckoutCreateRequest = z.infer<
   typeof ExtendedCheckoutCreateRequestSchema
 >;
 
-export const ExtendedCheckoutUpdateRequestSchema =
-  CheckoutUpdateRequestSchema.extend(
-    CheckoutWithFulfillmentUpdateRequestSchema.pick({ fulfillment: true }).shape
-  )
-    .extend(
-      CheckoutWithDiscountUpdateRequestSchema.pick({ discounts: true }).shape
-    )
-    .extend(
-      CheckoutWithBuyerConsentUpdateRequestSchema.pick({ buyer: true }).shape
-    );
+export const ExtendedCheckoutUpdateRequestSchema = CheckoutSchema;
 export type ExtendedCheckoutUpdateRequest = z.infer<
   typeof ExtendedCheckoutUpdateRequestSchema
 >;

--- a/src/spec_generated.ts
+++ b/src/spec_generated.ts
@@ -1,104 +1,94 @@
-import * as z from 'zod';
+import * as z from "zod";
 
 // Key usage. Should be 'sig' for signing keys.
 
 export const UseSchema = z.enum([
-  'enc',
-  'sig',
+    "enc",
+    "sig",
 ]);
 export type Use = z.infer<typeof UseSchema>;
 
-// The type of card number. Network tokens are preferred with fallback to FPAN.
-// See PCI Scope for more details.
+// Transport protocol for this service binding.
 
-export const CardNumberTypeSchema = z.enum([
-  'dpan',
-  'fpan',
-  'network_token',
+export const TransportSchema = z.enum([
+    "a2a",
+    "embedded",
+    "mcp",
+    "rest",
 ]);
-export type CardNumberType = z.infer<typeof CardNumberTypeSchema>;
-
-// A URI pointing to a schema definition (e.g., JSON Schema) used to validate
-// the structure of the instrument object.
-
-export const CardPaymentInstrumentTypeSchema = z.enum([
-  'card',
-]);
-export type CardPaymentInstrumentType =
-    z.infer<typeof CardPaymentInstrumentTypeSchema>;
+export type Transport = z.infer<typeof TransportSchema>;
 
 // Type of total categorization.
 
-export const TotalResponseTypeSchema = z.enum([
-  'discount',
-  'fee',
-  'fulfillment',
-  'items_discount',
-  'subtotal',
-  'tax',
-  'total',
+export const TotalTypeSchema = z.enum([
+    "discount",
+    "fee",
+    "fulfillment",
+    "items_discount",
+    "subtotal",
+    "tax",
+    "total",
 ]);
-export type TotalResponseType = z.infer<typeof TotalResponseTypeSchema>;
+export type TotalType = z.infer<typeof TotalTypeSchema>;
 
 // Content format, default = plain.
 
 export const ContentTypeSchema = z.enum([
-  'markdown',
-  'plain',
+    "markdown",
+    "plain",
 ]);
 export type ContentType = z.infer<typeof ContentTypeSchema>;
 
 // Declares who resolves this error. 'recoverable': agent can fix via API.
-// 'requires_buyer_input': merchant requires information their API doesn't
-// support collecting programmatically (checkout incomplete).
-// 'requires_buyer_review': buyer must authorize before order placement due to
-// policy, regulatory, or entitlement rules (checkout complete). Errors with
-// 'requires_*' severity contribute to 'status: requires_escalation'.
+// 'requires_buyer_input': merchant requires information their API doesn't support
+// collecting programmatically (checkout incomplete). 'requires_buyer_review': buyer must
+// authorize before order placement due to policy, regulatory, or entitlement rules
+// (checkout complete). Errors with 'requires_*' severity contribute to 'status:
+// requires_escalation'.
 
 export const SeveritySchema = z.enum([
-  'recoverable',
-  'requires_buyer_input',
-  'requires_buyer_review',
+    "recoverable",
+    "requires_buyer_input",
+    "requires_buyer_review",
 ]);
 export type Severity = z.infer<typeof SeveritySchema>;
 
 
 export const MessageTypeSchema = z.enum([
-  'error',
-  'info',
-  'warning',
+    "error",
+    "info",
+    "warning",
 ]);
 export type MessageType = z.infer<typeof MessageTypeSchema>;
 
-// Checkout state indicating the current phase and required action. See Checkout
-// Status lifecycle documentation for state transition details.
+// Checkout state indicating the current phase and required action. See Checkout Status
+// lifecycle documentation for state transition details.
 
-export const CheckoutResponseStatusSchema = z.enum([
-  'canceled',
-  'complete_in_progress',
-  'completed',
-  'incomplete',
-  'ready_for_complete',
-  'requires_escalation',
+export const CheckoutStatusSchema = z.enum([
+    "canceled",
+    "complete_in_progress",
+    "completed",
+    "incomplete",
+    "ready_for_complete",
+    "requires_escalation",
 ]);
-export type CheckoutResponseStatus =
-    z.infer<typeof CheckoutResponseStatusSchema>;
+export type CheckoutStatus = z.infer<typeof CheckoutStatusSchema>;
 
 // Adjustment status.
 
 export const AdjustmentStatusSchema = z.enum([
-  'completed',
-  'failed',
-  'pending',
+    "completed",
+    "failed",
+    "pending",
 ]);
 export type AdjustmentStatus = z.infer<typeof AdjustmentStatusSchema>;
 
 // Delivery method type (shipping, pickup, digital).
 
 export const MethodTypeSchema = z.enum([
-  'digital',
-  'pickup',
-  'shipping',
+    "digital",
+    "pickup",
+    "shipping",
 ]);
 export type MethodType = z.infer<typeof MethodTypeSchema>;
 
@@ -106,9 +96,9 @@ export type MethodType = z.infer<typeof MethodTypeSchema>;
 // quantity.fulfilled > 0, otherwise processing.
 
 export const LineItemStatusSchema = z.enum([
-  'fulfilled',
-  'partial',
-  'processing',
+    "fulfilled",
+    "partial",
+    "processing",
 ]);
 export type LineItemStatus = z.infer<typeof LineItemStatusSchema>;
 
@@ -117,26 +107,42 @@ export type LineItemStatus = z.infer<typeof LineItemStatusSchema>;
 // Fulfillment method type.
 
 export const TypeElementSchema = z.enum([
-  'pickup',
-  'shipping',
+    "pickup",
+    "shipping",
 ]);
 export type TypeElement = z.infer<typeof TypeElementSchema>;
 
+// The type of card number. Network tokens are preferred with fallback to FPAN. See PCI
+// Scope for more details.
+
+export const CardNumberTypeSchema = z.enum([
+    "dpan",
+    "fpan",
+    "network_token",
+]);
+export type CardNumberType = z.infer<typeof CardNumberTypeSchema>;
+
+
+export const AlgSchema = z.enum([
+    "card",
+]);
+export type Alg = z.infer<typeof AlgSchema>;
+
 
 export const MessageErrorTypeSchema = z.enum([
-  'error',
+    "error",
 ]);
 export type MessageErrorType = z.infer<typeof MessageErrorTypeSchema>;
 
 
 export const MessageInfoTypeSchema = z.enum([
-  'info',
+    "info",
 ]);
 export type MessageInfoType = z.infer<typeof MessageInfoTypeSchema>;
 
 
 export const MessageWarningTypeSchema = z.enum([
-  'warning',
+    "warning",
 ]);
 export type MessageWarningType = z.infer<typeof MessageWarningTypeSchema>;
 
@@ -144,1151 +150,817 @@ export type MessageWarningType = z.infer<typeof MessageWarningTypeSchema>;
 // proportionally by value.
 
 export const MethodSchema = z.enum([
-  'across',
-  'each',
+    "across",
+    "each",
 ]);
 export type Method = z.infer<typeof MethodSchema>;
 
-export const PaymentHandlerResponseSchema = z.object({
-  'config': z.record(z.string(), z.any()),
-  'config_schema': z.string(),
-  'id': z.string(),
-  'instrument_schemas': z.array(z.string()),
-  'name': z.string(),
-  'spec': z.string(),
-  'version': z.string(),
+export const ProfileSchemaSchema = z.object({
+    "alg": z.string().optional(),
+    "crv": z.string().optional(),
+    "e": z.string().optional(),
+    "kid": z.string(),
+    "kty": z.string(),
+    "n": z.string().optional(),
+    "use": UseSchema.optional(),
+    "x": z.string().optional(),
+    "y": z.string().optional(),
 });
-export type PaymentHandlerResponse =
-    z.infer<typeof PaymentHandlerResponseSchema>;
+export type ProfileSchema = z.infer<typeof ProfileSchemaSchema>;
 
-export const SigningKeySchema = z.object({
-  'alg': z.string().optional(),
-  'crv': z.string().optional(),
-  'e': z.string().optional(),
-  'kid': z.string(),
-  'kty': z.string(),
-  'n': z.string().optional(),
-  'use': UseSchema.optional(),
-  'x': z.string().optional(),
-  'y': z.string().optional(),
+export const CapabilitySchemaSchema = z.object({
+    "config": z.record(z.string(), z.any()).optional(),
+    "id": z.string().optional(),
+    "schema": z.string().optional(),
+    "spec": z.string().optional(),
+    "version": z.string(),
+    "extends": z.union([z.array(z.string()), z.string()]).optional(),
 });
-export type SigningKey = z.infer<typeof SigningKeySchema>;
+export type CapabilitySchema = z.infer<typeof CapabilitySchemaSchema>;
 
-export const CapabilityDiscoverySchema = z.object({
-  'config': z.record(z.string(), z.any()).optional(),
-  'extends': z.string().optional(),
-  'name': z.string(),
-  'schema': z.string(),
-  'spec': z.string(),
-  'version': z.string(),
+export const PaymentHandlerSchemaSchema = z.object({
+    "config": z.record(z.string(), z.any()).optional(),
+    "id": z.string(),
+    "schema": z.string().optional(),
+    "spec": z.string().optional(),
+    "version": z.string(),
 });
-export type CapabilityDiscovery = z.infer<typeof CapabilityDiscoverySchema>;
+export type PaymentHandlerSchema = z.infer<typeof PaymentHandlerSchemaSchema>;
 
-export const A2ASchema = z.object({
-  'endpoint': z.string(),
+export const ServiceConfigSchema = z.object({
+    "delegate": z.array(z.string()).optional(),
 });
-export type A2A = z.infer<typeof A2ASchema>;
-
-export const EmbeddedSchema = z.object({
-  'schema': z.string(),
-});
-export type Embedded = z.infer<typeof EmbeddedSchema>;
-
-export const McpSchema = z.object({
-  'endpoint': z.string(),
-  'schema': z.string(),
-});
-export type Mcp = z.infer<typeof McpSchema>;
-
-export const RestSchema = z.object({
-  'endpoint': z.string(),
-  'schema': z.string(),
-});
-export type Rest = z.infer<typeof RestSchema>;
+export type ServiceConfig = z.infer<typeof ServiceConfigSchema>;
 
 export const BuyerClassSchema = z.object({
-  'email': z.string().optional(),
-  'first_name': z.string().optional(),
-  'full_name': z.string().optional(),
-  'last_name': z.string().optional(),
-  'phone_number': z.string().optional(),
+    "email": z.string().optional(),
+    "first_name": z.string().optional(),
+    "last_name": z.string().optional(),
+    "phone_number": z.string().optional(),
 });
 export type BuyerClass = z.infer<typeof BuyerClassSchema>;
 
+export const ContextClassSchema = z.object({
+    "address_country": z.string().optional(),
+    "address_region": z.string().optional(),
+    "intent": z.string().optional(),
+    "postal_code": z.string().optional(),
+});
+export type ContextClass = z.infer<typeof ContextClassSchema>;
+
 export const ItemClassSchema = z.object({
-  'id': z.string(),
+    "id": z.string(),
+    "image_url": z.string().optional(),
+    "price": z.number(),
+    "title": z.string(),
 });
 export type ItemClass = z.infer<typeof ItemClassSchema>;
 
-export const BillingAddressClassSchema = z.object({
-  'address_country': z.string().optional(),
-  'address_locality': z.string().optional(),
-  'address_region': z.string().optional(),
-  'extended_address': z.string().optional(),
-  'first_name': z.string().optional(),
-  'full_name': z.string().optional(),
-  'last_name': z.string().optional(),
-  'phone_number': z.string().optional(),
-  'postal_code': z.string().optional(),
-  'street_address': z.string().optional(),
+export const TotalElementSchema = z.object({
+    "amount": z.number(),
+    "display_text": z.string().optional(),
+    "type": TotalTypeSchema,
 });
-export type BillingAddressClass = z.infer<typeof BillingAddressClassSchema>;
-
-export const PaymentCredentialSchema = z.object({
-  'type': z.string(),
-  'card_number_type': CardNumberTypeSchema.optional(),
-  'cryptogram': z.string().optional(),
-  'cvc': z.string().optional(),
-  'eci_value': z.string().optional(),
-  'expiry_month': z.number().optional(),
-  'expiry_year': z.number().optional(),
-  'name': z.string().optional(),
-  'number': z.string().optional(),
-});
-export type PaymentCredential = z.infer<typeof PaymentCredentialSchema>;
-
-export const ItemResponseSchema = z.object({
-  'id': z.string(),
-  'image_url': z.string().optional(),
-  'price': z.number(),
-  'title': z.string(),
-});
-export type ItemResponse = z.infer<typeof ItemResponseSchema>;
-
-export const TotalResponseSchema = z.object({
-  'amount': z.number(),
-  'display_text': z.string().optional(),
-  'type': TotalResponseTypeSchema,
-});
-export type TotalResponse = z.infer<typeof TotalResponseSchema>;
+export type TotalElement = z.infer<typeof TotalElementSchema>;
 
 export const LinkElementSchema = z.object({
-  'title': z.string().optional(),
-  'type': z.string(),
-  'url': z.string(),
+    "title": z.string().optional(),
+    "type": z.string(),
+    "url": z.string(),
 });
 export type LinkElement = z.infer<typeof LinkElementSchema>;
 
 export const MessageElementSchema = z.object({
-  'code': z.string().optional(),
-  'content': z.string(),
-  'content_type': ContentTypeSchema.optional(),
-  'path': z.string().optional(),
-  'severity': SeveritySchema.optional(),
-  'type': MessageTypeSchema,
+    "code": z.string().optional(),
+    "content": z.string(),
+    "content_type": ContentTypeSchema.optional(),
+    "path": z.string().optional(),
+    "severity": SeveritySchema.optional(),
+    "type": MessageTypeSchema,
 });
 export type MessageElement = z.infer<typeof MessageElementSchema>;
 
+export const CapabilityResponseSchemaSchema = z.object({
+    "config": z.record(z.string(), z.any()).optional(),
+    "id": z.string().optional(),
+    "schema": z.string().optional(),
+    "spec": z.string().optional(),
+    "version": z.string(),
+    "extends": z.union([z.array(z.string()), z.string()]).optional(),
+});
+export type CapabilityResponseSchema = z.infer<typeof CapabilityResponseSchemaSchema>;
+
+export const PaymentHandlerResponseSchemaSchema = z.object({
+    "config": z.record(z.string(), z.any()).optional(),
+    "id": z.string(),
+    "schema": z.string().optional(),
+    "spec": z.string().optional(),
+    "version": z.string(),
+});
+export type PaymentHandlerResponseSchema = z.infer<typeof PaymentHandlerResponseSchemaSchema>;
+
+export const ServiceSchema = z.object({
+    "config": z.record(z.string(), z.any()).optional(),
+    "id": z.string().optional(),
+    "schema": z.string().optional(),
+    "spec": z.string().optional(),
+    "version": z.string(),
+    "endpoint": z.string().optional(),
+    "transport": TransportSchema,
+});
+export type Service = z.infer<typeof ServiceSchema>;
+
 export const OrderClassSchema = z.object({
-  'id': z.string(),
-  'permalink_url': z.string(),
+    "id": z.string(),
+    "permalink_url": z.string(),
 });
 export type OrderClass = z.infer<typeof OrderClassSchema>;
 
-export const CapabilityResponseSchema = z.object({
-  'config': z.record(z.string(), z.any()).optional(),
-  'extends': z.string().optional(),
-  'name': z.string(),
-  'schema': z.string().optional(),
-  'spec': z.string().optional(),
-  'version': z.string(),
+export const BillingAddressClassSchema = z.object({
+    "address_country": z.string().optional(),
+    "address_locality": z.string().optional(),
+    "address_region": z.string().optional(),
+    "extended_address": z.string().optional(),
+    "first_name": z.string().optional(),
+    "last_name": z.string().optional(),
+    "phone_number": z.string().optional(),
+    "postal_code": z.string().optional(),
+    "street_address": z.string().optional(),
 });
-export type CapabilityResponse = z.infer<typeof CapabilityResponseSchema>;
+export type BillingAddressClass = z.infer<typeof BillingAddressClassSchema>;
 
-export const LineItemItemSchema = z.object({
-  'id': z.string(),
+export const CredentialClassSchema = z.object({
+    "type": z.string(),
 });
-export type LineItemItem = z.infer<typeof LineItemItemSchema>;
+export type CredentialClass = z.infer<typeof CredentialClassSchema>;
+
+export const ServiceResponseSchemaConfigSchema = z.object({
+    "delegate": z.array(z.string()).optional(),
+});
+export type ServiceResponseSchemaConfig = z.infer<typeof ServiceResponseSchemaConfigSchema>;
 
 export const AdjustmentLineItemSchema = z.object({
-  'id': z.string(),
-  'quantity': z.number(),
+    "id": z.string(),
+    "quantity": z.number(),
 });
 export type AdjustmentLineItem = z.infer<typeof AdjustmentLineItemSchema>;
 
 export const EventLineItemSchema = z.object({
-  'id': z.string(),
-  'quantity': z.number(),
+    "id": z.string(),
+    "quantity": z.number(),
 });
 export type EventLineItem = z.infer<typeof EventLineItemSchema>;
 
 export const ExpectationLineItemSchema = z.object({
-  'id': z.string(),
-  'quantity': z.number(),
+    "id": z.string(),
+    "quantity": z.number(),
 });
 export type ExpectationLineItem = z.infer<typeof ExpectationLineItemSchema>;
 
 export const LineItemQuantitySchema = z.object({
-  'fulfilled': z.number(),
-  'total': z.number(),
+    "fulfilled": z.number(),
+    "total": z.number(),
 });
 export type LineItemQuantity = z.infer<typeof LineItemQuantitySchema>;
 
-export const UcpOrderResponseSchema = z.object({
-  'capabilities': z.array(CapabilityResponseSchema),
-  'version': z.string(),
+export const UcpOrderResponseSchemaSchema = z.object({
+    "capabilities": z.record(z.string(), z.array(CapabilityResponseSchemaSchema)).optional(),
+    "payment_handlers": z.record(z.string(), z.array(PaymentHandlerResponseSchemaSchema)).optional(),
+    "services": z.record(z.string(), z.array(ServiceSchema)).optional(),
+    "version": z.string(),
 });
-export type UcpOrderResponse = z.infer<typeof UcpOrderResponseSchema>;
+export type UcpOrderResponseSchema = z.infer<typeof UcpOrderResponseSchemaSchema>;
 
 export const PaymentAccountInfoSchema = z.object({
-  'payment_account_reference': z.string().optional(),
+    "payment_account_reference": z.string().optional(),
 });
 export type PaymentAccountInfo = z.infer<typeof PaymentAccountInfoSchema>;
 
 export const AdjustmentLineItemClassSchema = z.object({
-  'id': z.string(),
-  'quantity': z.number(),
+    "id": z.string(),
+    "quantity": z.number(),
 });
-export type AdjustmentLineItemClass =
-    z.infer<typeof AdjustmentLineItemClassSchema>;
+export type AdjustmentLineItemClass = z.infer<typeof AdjustmentLineItemClassSchema>;
 
 export const IdentityClassSchema = z.object({
-  'access_token': z.string(),
+    "access_token": z.string(),
 });
 export type IdentityClass = z.infer<typeof IdentityClassSchema>;
 
+export const BusinessFulfillmentConfigAllowsMultiDestinationSchema = z.object({
+    "pickup": z.boolean().optional(),
+    "shipping": z.boolean().optional(),
+});
+export type BusinessFulfillmentConfigAllowsMultiDestination = z.infer<typeof BusinessFulfillmentConfigAllowsMultiDestinationSchema>;
+
 export const BuyerSchema = z.object({
-  'email': z.string().optional(),
-  'first_name': z.string().optional(),
-  'full_name': z.string().optional(),
-  'last_name': z.string().optional(),
-  'phone_number': z.string().optional(),
+    "email": z.string().optional(),
+    "first_name": z.string().optional(),
+    "last_name": z.string().optional(),
+    "phone_number": z.string().optional(),
 });
 export type Buyer = z.infer<typeof BuyerSchema>;
 
 export const CardCredentialSchema = z.object({
-  'card_number_type': CardNumberTypeSchema,
-  'cryptogram': z.string().optional(),
-  'cvc': z.string().optional(),
-  'eci_value': z.string().optional(),
-  'expiry_month': z.number().optional(),
-  'expiry_year': z.number().optional(),
-  'name': z.string().optional(),
-  'number': z.string().optional(),
-  'type': CardPaymentInstrumentTypeSchema,
+    "type": AlgSchema,
+    "card_number_type": CardNumberTypeSchema,
+    "cryptogram": z.string().optional(),
+    "cvc": z.string().optional(),
+    "eci_value": z.string().optional(),
+    "expiry_month": z.number().optional(),
+    "expiry_year": z.number().optional(),
+    "name": z.string().optional(),
+    "number": z.string().optional(),
 });
 export type CardCredential = z.infer<typeof CardCredentialSchema>;
 
-export const CardPaymentInstrumentSchema = z.object({
-  'billing_address': BillingAddressClassSchema.optional(),
-  'credential': PaymentCredentialSchema.optional(),
-  'handler_id': z.string(),
-  'id': z.string(),
-  'type': CardPaymentInstrumentTypeSchema,
-  'brand': z.string(),
-  'expiry_month': z.number().optional(),
-  'expiry_year': z.number().optional(),
-  'last_digits': z.string(),
-  'rich_card_art': z.string().optional(),
-  'rich_text_description': z.string().optional(),
+export const DisplaySchema = z.object({
+    "brand": z.string().optional(),
+    "card_art": z.string().optional(),
+    "description": z.string().optional(),
+    "expiry_month": z.number().optional(),
+    "expiry_year": z.number().optional(),
+    "last_digits": z.string().optional(),
 });
-export type CardPaymentInstrument = z.infer<typeof CardPaymentInstrumentSchema>;
+export type Display = z.infer<typeof DisplaySchema>;
+
+export const ContextSchema = z.object({
+    "address_country": z.string().optional(),
+    "address_region": z.string().optional(),
+    "intent": z.string().optional(),
+    "postal_code": z.string().optional(),
+});
+export type Context = z.infer<typeof ContextSchema>;
 
 export const ExpectationLineItemClassSchema = z.object({
-  'id': z.string(),
-  'quantity': z.number(),
+    "id": z.string(),
+    "quantity": z.number(),
 });
-export type ExpectationLineItemClass =
-    z.infer<typeof ExpectationLineItemClassSchema>;
+export type ExpectationLineItemClass = z.infer<typeof ExpectationLineItemClassSchema>;
 
-export const FulfillmentDestinationRequestSchema = z.object({
-  'address_country': z.string().optional(),
-  'address_locality': z.string().optional(),
-  'address_region': z.string().optional(),
-  'extended_address': z.string().optional(),
-  'first_name': z.string().optional(),
-  'full_name': z.string().optional(),
-  'last_name': z.string().optional(),
-  'phone_number': z.string().optional(),
-  'postal_code': z.string().optional(),
-  'street_address': z.string().optional(),
-  'id': z.string().optional(),
-  'address': BillingAddressClassSchema.optional(),
-  'name': z.string().optional(),
+export const PurpleFulfillmentAvailableMethodSchema = z.object({
+    "description": z.string().optional(),
+    "fulfillable_on": z.union([z.null(), z.string()]).optional(),
+    "line_item_ids": z.array(z.string()),
+    "type": TypeElementSchema,
 });
-export type FulfillmentDestinationRequest =
-    z.infer<typeof FulfillmentDestinationRequestSchema>;
+export type PurpleFulfillmentAvailableMethod = z.infer<typeof PurpleFulfillmentAvailableMethodSchema>;
+
+export const FulfillmentDestinationSchema = z.object({
+    "address_country": z.string().optional(),
+    "address_locality": z.string().optional(),
+    "address_region": z.string().optional(),
+    "extended_address": z.string().optional(),
+    "first_name": z.string().optional(),
+    "last_name": z.string().optional(),
+    "phone_number": z.string().optional(),
+    "postal_code": z.string().optional(),
+    "street_address": z.string().optional(),
+    "id": z.string(),
+    "address": BillingAddressClassSchema.optional(),
+    "name": z.string().optional(),
+});
+export type FulfillmentDestination = z.infer<typeof FulfillmentDestinationSchema>;
 
 export const FulfillmentEventLineItemSchema = z.object({
-  'id': z.string(),
-  'quantity': z.number(),
+    "id": z.string(),
+    "quantity": z.number(),
 });
-export type FulfillmentEventLineItem =
-    z.infer<typeof FulfillmentEventLineItemSchema>;
+export type FulfillmentEventLineItem = z.infer<typeof FulfillmentEventLineItemSchema>;
 
-export const FulfillmentGroupCreateRequestSchema = z.object({
-  'selected_option_id': z.union([z.null(), z.string()]).optional(),
+export const OptionElementSchema = z.object({
+    "carrier": z.string().optional(),
+    "description": z.string().optional(),
+    "earliest_fulfillment_time": z.coerce.date().optional(),
+    "id": z.string(),
+    "latest_fulfillment_time": z.coerce.date().optional(),
+    "title": z.string(),
+    "totals": z.array(TotalElementSchema),
 });
-export type FulfillmentGroupCreateRequest =
-    z.infer<typeof FulfillmentGroupCreateRequestSchema>;
+export type OptionElement = z.infer<typeof OptionElementSchema>;
 
-export const FulfillmentGroupUpdateRequestSchema = z.object({
-  'id': z.string(),
-  'selected_option_id': z.union([z.null(), z.string()]).optional(),
+export const AvailableMethodElementSchema = z.object({
+    "description": z.string().optional(),
+    "fulfillable_on": z.union([z.null(), z.string()]).optional(),
+    "line_item_ids": z.array(z.string()),
+    "type": TypeElementSchema,
 });
-export type FulfillmentGroupUpdateRequest =
-    z.infer<typeof FulfillmentGroupUpdateRequestSchema>;
+export type AvailableMethodElement = z.infer<typeof AvailableMethodElementSchema>;
 
-export const FulfillmentDestinationRequestElementSchema = z.object({
-  'address_country': z.string().optional(),
-  'address_locality': z.string().optional(),
-  'address_region': z.string().optional(),
-  'extended_address': z.string().optional(),
-  'first_name': z.string().optional(),
-  'full_name': z.string().optional(),
-  'last_name': z.string().optional(),
-  'phone_number': z.string().optional(),
-  'postal_code': z.string().optional(),
-  'street_address': z.string().optional(),
-  'id': z.string().optional(),
-  'address': BillingAddressClassSchema.optional(),
-  'name': z.string().optional(),
+export const FulfillmentDestinationElementSchema = z.object({
+    "address_country": z.string().optional(),
+    "address_locality": z.string().optional(),
+    "address_region": z.string().optional(),
+    "extended_address": z.string().optional(),
+    "first_name": z.string().optional(),
+    "last_name": z.string().optional(),
+    "phone_number": z.string().optional(),
+    "postal_code": z.string().optional(),
+    "street_address": z.string().optional(),
+    "id": z.string(),
+    "address": BillingAddressClassSchema.optional(),
+    "name": z.string().optional(),
 });
-export type FulfillmentDestinationRequestElement =
-    z.infer<typeof FulfillmentDestinationRequestElementSchema>;
+export type FulfillmentDestinationElement = z.infer<typeof FulfillmentDestinationElementSchema>;
 
 export const GroupElementSchema = z.object({
-  'selected_option_id': z.union([z.null(), z.string()]).optional(),
+    "id": z.string(),
+    "line_item_ids": z.array(z.string()),
+    "options": z.array(OptionElementSchema).optional(),
+    "selected_option_id": z.union([z.null(), z.string()]).optional(),
 });
 export type GroupElement = z.infer<typeof GroupElementSchema>;
 
-export const GroupClassSchema = z.object({
-  'id': z.string(),
-  'selected_option_id': z.union([z.null(), z.string()]).optional(),
+export const PurpleFulfillmentMethodSchema = z.object({
+    "destinations": z.array(FulfillmentDestinationElementSchema).optional(),
+    "groups": z.array(GroupElementSchema).optional(),
+    "id": z.string(),
+    "line_item_ids": z.array(z.string()),
+    "selected_destination_id": z.union([z.null(), z.string()]).optional(),
+    "type": TypeElementSchema,
 });
-export type GroupClass = z.infer<typeof GroupClassSchema>;
+export type PurpleFulfillmentMethod = z.infer<typeof PurpleFulfillmentMethodSchema>;
 
-export const ItemCreateRequestSchema = z.object({
-  'id': z.string(),
+export const PurpleFulfillmentOptionSchema = z.object({
+    "carrier": z.string().optional(),
+    "description": z.string().optional(),
+    "earliest_fulfillment_time": z.coerce.date().optional(),
+    "id": z.string(),
+    "latest_fulfillment_time": z.coerce.date().optional(),
+    "title": z.string(),
+    "totals": z.array(TotalElementSchema),
 });
-export type ItemCreateRequest = z.infer<typeof ItemCreateRequestSchema>;
+export type PurpleFulfillmentOption = z.infer<typeof PurpleFulfillmentOptionSchema>;
 
-export const ItemUpdateRequestSchema = z.object({
-  'id': z.string(),
+export const ItemSchema = z.object({
+    "id": z.string(),
+    "image_url": z.string().optional(),
+    "price": z.number(),
+    "title": z.string(),
 });
-export type ItemUpdateRequest = z.infer<typeof ItemUpdateRequestSchema>;
+export type Item = z.infer<typeof ItemSchema>;
 
-export const LineItemCreateRequestSchema = z.object({
-  'item': ItemClassSchema,
-  'quantity': z.number(),
+export const LineItemSchema = z.object({
+    "id": z.string(),
+    "item": ItemClassSchema,
+    "parent_id": z.string().optional(),
+    "quantity": z.number(),
+    "totals": z.array(TotalElementSchema),
 });
-export type LineItemCreateRequest = z.infer<typeof LineItemCreateRequestSchema>;
-
-export const LineItemUpdateRequestSchema = z.object({
-  'id': z.string().optional(),
-  'item': LineItemItemSchema,
-  'parent_id': z.string().optional(),
-  'quantity': z.number(),
-});
-export type LineItemUpdateRequest = z.infer<typeof LineItemUpdateRequestSchema>;
+export type LineItem = z.infer<typeof LineItemSchema>;
 
 export const LinkSchema = z.object({
-  'title': z.string().optional(),
-  'type': z.string(),
-  'url': z.string(),
+    "title": z.string().optional(),
+    "type": z.string(),
+    "url": z.string(),
 });
 export type Link = z.infer<typeof LinkSchema>;
 
-export const AllowsMultiDestinationSchema = z.object({
-  'pickup': z.boolean().optional(),
-  'shipping': z.boolean().optional(),
+export const MerchantFulfillmentConfigAllowsMultiDestinationSchema = z.object({
+    "pickup": z.boolean().optional(),
+    "shipping": z.boolean().optional(),
 });
-export type AllowsMultiDestination =
-    z.infer<typeof AllowsMultiDestinationSchema>;
+export type MerchantFulfillmentConfigAllowsMultiDestination = z.infer<typeof MerchantFulfillmentConfigAllowsMultiDestinationSchema>;
 
 export const MessageErrorSchema = z.object({
-  'code': z.string(),
-  'content': z.string(),
-  'content_type': ContentTypeSchema.optional(),
-  'path': z.string().optional(),
-  'severity': SeveritySchema,
-  'type': MessageErrorTypeSchema,
+    "code": z.string(),
+    "content": z.string(),
+    "content_type": ContentTypeSchema.optional(),
+    "path": z.string().optional(),
+    "severity": SeveritySchema,
+    "type": MessageErrorTypeSchema,
 });
 export type MessageError = z.infer<typeof MessageErrorSchema>;
 
 export const MessageInfoSchema = z.object({
-  'code': z.string().optional(),
-  'content': z.string(),
-  'content_type': ContentTypeSchema.optional(),
-  'path': z.string().optional(),
-  'type': MessageInfoTypeSchema,
+    "code": z.string().optional(),
+    "content": z.string(),
+    "content_type": ContentTypeSchema.optional(),
+    "path": z.string().optional(),
+    "type": MessageInfoTypeSchema,
 });
 export type MessageInfo = z.infer<typeof MessageInfoSchema>;
 
 export const MessageSchema = z.object({
-  'code': z.string().optional(),
-  'content': z.string(),
-  'content_type': ContentTypeSchema.optional(),
-  'path': z.string().optional(),
-  'severity': SeveritySchema.optional(),
-  'type': MessageTypeSchema,
+    "code": z.string().optional(),
+    "content": z.string(),
+    "content_type": ContentTypeSchema.optional(),
+    "path": z.string().optional(),
+    "severity": SeveritySchema.optional(),
+    "type": MessageTypeSchema,
 });
 export type Message = z.infer<typeof MessageSchema>;
 
 export const MessageWarningSchema = z.object({
-  'code': z.string(),
-  'content': z.string(),
-  'content_type': ContentTypeSchema.optional(),
-  'path': z.string().optional(),
-  'type': MessageWarningTypeSchema,
+    "code": z.string(),
+    "content": z.string(),
+    "content_type": ContentTypeSchema.optional(),
+    "path": z.string().optional(),
+    "type": MessageWarningTypeSchema,
 });
 export type MessageWarning = z.infer<typeof MessageWarningSchema>;
 
 export const OrderConfirmationSchema = z.object({
-  'id': z.string(),
-  'permalink_url': z.string(),
+    "id": z.string(),
+    "permalink_url": z.string(),
 });
 export type OrderConfirmation = z.infer<typeof OrderConfirmationSchema>;
 
 export const OrderLineItemQuantitySchema = z.object({
-  'fulfilled': z.number(),
-  'total': z.number(),
+    "fulfilled": z.number(),
+    "total": z.number(),
 });
 export type OrderLineItemQuantity = z.infer<typeof OrderLineItemQuantitySchema>;
 
+export const PaymentCredentialSchema = z.object({
+    "type": z.string(),
+});
+export type PaymentCredential = z.infer<typeof PaymentCredentialSchema>;
+
 export const PaymentIdentitySchema = z.object({
-  'access_token': z.string(),
+    "access_token": z.string(),
 });
 export type PaymentIdentity = z.infer<typeof PaymentIdentitySchema>;
 
-export const PaymentInstrumentBaseSchema = z.object({
-  'billing_address': BillingAddressClassSchema.optional(),
-  'credential': PaymentCredentialSchema.optional(),
-  'handler_id': z.string(),
-  'id': z.string(),
-  'type': z.string(),
-});
-export type PaymentInstrumentBase = z.infer<typeof PaymentInstrumentBaseSchema>;
-
-export const PlatformFulfillmentConfigSchema = z.object({
-  'supports_multi_group': z.boolean().optional(),
-});
-export type PlatformFulfillmentConfig =
-    z.infer<typeof PlatformFulfillmentConfigSchema>;
-
-export const PostalAddressSchema = z.object({
-  'address_country': z.string().optional(),
-  'address_locality': z.string().optional(),
-  'address_region': z.string().optional(),
-  'extended_address': z.string().optional(),
-  'first_name': z.string().optional(),
-  'full_name': z.string().optional(),
-  'last_name': z.string().optional(),
-  'phone_number': z.string().optional(),
-  'postal_code': z.string().optional(),
-  'street_address': z.string().optional(),
-});
-export type PostalAddress = z.infer<typeof PostalAddressSchema>;
-
-export const RetailLocationRequestSchema = z.object({
-  'address': BillingAddressClassSchema.optional(),
-  'name': z.string(),
-});
-export type RetailLocationRequest = z.infer<typeof RetailLocationRequestSchema>;
-
-export const RetailLocationResponseSchema = z.object({
-  'address': BillingAddressClassSchema.optional(),
-  'id': z.string(),
-  'name': z.string(),
-});
-export type RetailLocationResponse =
-    z.infer<typeof RetailLocationResponseSchema>;
-
-export const ShippingDestinationRequestSchema = z.object({
-  'address_country': z.string().optional(),
-  'address_locality': z.string().optional(),
-  'address_region': z.string().optional(),
-  'extended_address': z.string().optional(),
-  'first_name': z.string().optional(),
-  'full_name': z.string().optional(),
-  'last_name': z.string().optional(),
-  'phone_number': z.string().optional(),
-  'postal_code': z.string().optional(),
-  'street_address': z.string().optional(),
-  'id': z.string().optional(),
-});
-export type ShippingDestinationRequest =
-    z.infer<typeof ShippingDestinationRequestSchema>;
-
-export const ShippingDestinationResponseSchema = z.object({
-  'address_country': z.string().optional(),
-  'address_locality': z.string().optional(),
-  'address_region': z.string().optional(),
-  'extended_address': z.string().optional(),
-  'first_name': z.string().optional(),
-  'full_name': z.string().optional(),
-  'last_name': z.string().optional(),
-  'phone_number': z.string().optional(),
-  'postal_code': z.string().optional(),
-  'street_address': z.string().optional(),
-  'id': z.string(),
-});
-export type ShippingDestinationResponse =
-    z.infer<typeof ShippingDestinationResponseSchema>;
-
-export const TokenCredentialCreateRequestSchema = z.object({
-  'token': z.string(),
-  'type': z.string(),
-});
-export type TokenCredentialCreateRequest =
-    z.infer<typeof TokenCredentialCreateRequestSchema>;
-
-export const TokenCredentialResponseSchema = z.object({
-  'type': z.string(),
-});
-export type TokenCredentialResponse =
-    z.infer<typeof TokenCredentialResponseSchema>;
-
-export const TokenCredentialUpdateRequestSchema = z.object({
-  'token': z.string(),
-  'type': z.string(),
-});
-export type TokenCredentialUpdateRequest =
-    z.infer<typeof TokenCredentialUpdateRequestSchema>;
-
-export const Ap2CompleteRequestObjectSchema = z.object({
-  'checkout_mandate': z.string(),
-});
-export type Ap2CompleteRequestObject =
-    z.infer<typeof Ap2CompleteRequestObjectSchema>;
-
-export const Ap2CheckoutResponseObjectSchema = z.object({
-  'merchant_authorization': z.string(),
-});
-export type Ap2CheckoutResponseObject =
-    z.infer<typeof Ap2CheckoutResponseObjectSchema>;
-
-export const PurpleConsentSchema = z.object({
-  'analytics': z.boolean().optional(),
-  'marketing': z.boolean().optional(),
-  'preferences': z.boolean().optional(),
-  'sale_of_data': z.boolean().optional(),
-});
-export type PurpleConsent = z.infer<typeof PurpleConsentSchema>;
-
-export const FluffyConsentSchema = z.object({
-  'analytics': z.boolean().optional(),
-  'marketing': z.boolean().optional(),
-  'preferences': z.boolean().optional(),
-  'sale_of_data': z.boolean().optional(),
-});
-export type FluffyConsent = z.infer<typeof FluffyConsentSchema>;
-
-export const TentacledConsentSchema = z.object({
-  'analytics': z.boolean().optional(),
-  'marketing': z.boolean().optional(),
-  'preferences': z.boolean().optional(),
-  'sale_of_data': z.boolean().optional(),
-});
-export type TentacledConsent = z.infer<typeof TentacledConsentSchema>;
-
-export const AllocationElementSchema = z.object({
-  'amount': z.number(),
-  'path': z.string(),
-});
-export type AllocationElement = z.infer<typeof AllocationElementSchema>;
-
-export const AllocationClassSchema = z.object({
-  'amount': z.number(),
-  'path': z.string(),
-});
-export type AllocationClass = z.infer<typeof AllocationClassSchema>;
-
-export const AppliedAllocationSchema = z.object({
-  'amount': z.number(),
-  'path': z.string(),
-});
-export type AppliedAllocation = z.infer<typeof AppliedAllocationSchema>;
-
-export const MethodElementSchema = z.object({
-  'destinations':
-      z.array(FulfillmentDestinationRequestElementSchema).optional(),
-  'groups': z.array(GroupElementSchema).optional(),
-  'line_item_ids': z.array(z.string()).optional(),
-  'selected_destination_id': z.union([z.null(), z.string()]).optional(),
-  'type': TypeElementSchema,
-});
-export type MethodElement = z.infer<typeof MethodElementSchema>;
-
-export const FulfillmentAvailableMethodResponseSchema = z.object({
-  'description': z.string().optional(),
-  'fulfillable_on': z.union([z.null(), z.string()]).optional(),
-  'line_item_ids': z.array(z.string()),
-  'type': TypeElementSchema,
-});
-export type FulfillmentAvailableMethodResponse =
-    z.infer<typeof FulfillmentAvailableMethodResponseSchema>;
-
-export const FulfillmentDestinationResponseSchema = z.object({
-  'address_country': z.string().optional(),
-  'address_locality': z.string().optional(),
-  'address_region': z.string().optional(),
-  'extended_address': z.string().optional(),
-  'first_name': z.string().optional(),
-  'full_name': z.string().optional(),
-  'last_name': z.string().optional(),
-  'phone_number': z.string().optional(),
-  'postal_code': z.string().optional(),
-  'street_address': z.string().optional(),
-  'id': z.string(),
-  'address': BillingAddressClassSchema.optional(),
-  'name': z.string().optional(),
-});
-export type FulfillmentDestinationResponse =
-    z.infer<typeof FulfillmentDestinationResponseSchema>;
-
-export const FulfillmentOptionResponseSchema = z.object({
-  'carrier': z.string().optional(),
-  'description': z.string().optional(),
-  'earliest_fulfillment_time': z.coerce.date().optional(),
-  'id': z.string(),
-  'latest_fulfillment_time': z.coerce.date().optional(),
-  'title': z.string(),
-  'totals': z.array(TotalResponseSchema),
-});
-export type FulfillmentOptionResponse =
-    z.infer<typeof FulfillmentOptionResponseSchema>;
-
-export const PaymentSchema = z.object({
-  'handlers': z.array(PaymentHandlerResponseSchema).optional(),
-});
-export type Payment = z.infer<typeof PaymentSchema>;
-
-export const UcpServiceSchema = z.object({
-  'a2a': A2ASchema.optional(),
-  'embedded': EmbeddedSchema.optional(),
-  'mcp': McpSchema.optional(),
-  'rest': RestSchema.optional(),
-  'spec': z.string(),
-  'version': z.string(),
-});
-export type UcpService = z.infer<typeof UcpServiceSchema>;
-
-export const LineItemElementSchema = z.object({
-  'item': ItemClassSchema,
-  'quantity': z.number(),
-});
-export type LineItemElement = z.infer<typeof LineItemElementSchema>;
-
 export const PaymentInstrumentSchema = z.object({
-  'billing_address': BillingAddressClassSchema.optional(),
-  'credential': PaymentCredentialSchema.optional(),
-  'handler_id': z.string(),
-  'id': z.string(),
-  'type': CardPaymentInstrumentTypeSchema,
-  'brand': z.string(),
-  'expiry_month': z.number().optional(),
-  'expiry_year': z.number().optional(),
-  'last_digits': z.string(),
-  'rich_card_art': z.string().optional(),
-  'rich_text_description': z.string().optional(),
+    "billing_address": BillingAddressClassSchema.optional(),
+    "credential": CredentialClassSchema.optional(),
+    "display": z.record(z.string(), z.any()).optional(),
+    "handler_id": z.string(),
+    "id": z.string(),
+    "type": z.string(),
 });
 export type PaymentInstrument = z.infer<typeof PaymentInstrumentSchema>;
 
-export const LineItemResponseSchema = z.object({
-  'id': z.string(),
-  'item': ItemResponseSchema,
-  'parent_id': z.string().optional(),
-  'quantity': z.number(),
-  'totals': z.array(TotalResponseSchema),
+export const PlatformFulfillmentConfigSchema = z.object({
+    "supports_multi_group": z.boolean().optional(),
 });
-export type LineItemResponse = z.infer<typeof LineItemResponseSchema>;
+export type PlatformFulfillmentConfig = z.infer<typeof PlatformFulfillmentConfigSchema>;
 
-export const PaymentResponseSchema = z.object({
-  'handlers': z.array(PaymentHandlerResponseSchema),
-  'instruments': z.array(PaymentInstrumentSchema).optional(),
-  'selected_instrument_id': z.string().optional(),
+export const PostalAddressSchema = z.object({
+    "address_country": z.string().optional(),
+    "address_locality": z.string().optional(),
+    "address_region": z.string().optional(),
+    "extended_address": z.string().optional(),
+    "first_name": z.string().optional(),
+    "last_name": z.string().optional(),
+    "phone_number": z.string().optional(),
+    "postal_code": z.string().optional(),
+    "street_address": z.string().optional(),
 });
-export type PaymentResponse = z.infer<typeof PaymentResponseSchema>;
+export type PostalAddress = z.infer<typeof PostalAddressSchema>;
 
-export const UcpCheckoutResponseSchema = z.object({
-  'capabilities': z.array(CapabilityResponseSchema),
-  'version': z.string(),
+export const RetailLocationSchema = z.object({
+    "address": BillingAddressClassSchema.optional(),
+    "id": z.string(),
+    "name": z.string(),
 });
-export type UcpCheckoutResponse = z.infer<typeof UcpCheckoutResponseSchema>;
+export type RetailLocation = z.infer<typeof RetailLocationSchema>;
 
-export const LineItemClassSchema = z.object({
-  'id': z.string().optional(),
-  'item': LineItemItemSchema,
-  'parent_id': z.string().optional(),
-  'quantity': z.number(),
+export const ShippingDestinationSchema = z.object({
+    "address_country": z.string().optional(),
+    "address_locality": z.string().optional(),
+    "address_region": z.string().optional(),
+    "extended_address": z.string().optional(),
+    "first_name": z.string().optional(),
+    "last_name": z.string().optional(),
+    "phone_number": z.string().optional(),
+    "postal_code": z.string().optional(),
+    "street_address": z.string().optional(),
+    "id": z.string(),
 });
-export type LineItemClass = z.infer<typeof LineItemClassSchema>;
+export type ShippingDestination = z.infer<typeof ShippingDestinationSchema>;
 
-export const CheckoutUpdateRequestPaymentSchema = z.object({
-  'instruments': z.array(PaymentInstrumentSchema).optional(),
-  'selected_instrument_id': z.string().optional(),
+export const TokenCredentialSchema = z.object({
+    "type": z.string(),
+    "token": z.string(),
 });
-export type CheckoutUpdateRequestPayment =
-    z.infer<typeof CheckoutUpdateRequestPaymentSchema>;
+export type TokenCredential = z.infer<typeof TokenCredentialSchema>;
+
+export const TotalSchema = z.object({
+    "amount": z.number(),
+    "display_text": z.string().optional(),
+    "type": TotalTypeSchema,
+});
+export type Total = z.infer<typeof TotalSchema>;
+
+export const Ap2WithCheckoutMandateSchema = z.object({
+    "checkout_mandate": z.string().optional(),
+});
+export type Ap2WithCheckoutMandate = z.infer<typeof Ap2WithCheckoutMandateSchema>;
+
+export const Ap2WithMerchantAuthorizationSchema = z.object({
+    "merchant_authorization": z.string().optional(),
+});
+export type Ap2WithMerchantAuthorization = z.infer<typeof Ap2WithMerchantAuthorizationSchema>;
+
+export const ConsentSchema = z.object({
+    "analytics": z.boolean().optional(),
+    "marketing": z.boolean().optional(),
+    "preferences": z.boolean().optional(),
+    "sale_of_data": z.boolean().optional(),
+});
+export type Consent = z.infer<typeof ConsentSchema>;
+
+export const AllocationSchema = z.object({
+    "amount": z.number(),
+    "path": z.string(),
+});
+export type Allocation = z.infer<typeof AllocationSchema>;
+
+export const ServiceSchemaSchema = z.object({
+    "config": ServiceConfigSchema.optional(),
+    "id": z.string().optional(),
+    "schema": z.string().optional(),
+    "spec": z.string().optional(),
+    "version": z.string(),
+    "endpoint": z.string().optional(),
+    "transport": TransportSchema,
+});
+export type ServiceSchema = z.infer<typeof ServiceSchemaSchema>;
+
+export const CartLineItemSchema = z.object({
+    "id": z.string(),
+    "item": ItemClassSchema,
+    "parent_id": z.string().optional(),
+    "quantity": z.number(),
+    "totals": z.array(TotalElementSchema),
+});
+export type CartLineItem = z.infer<typeof CartLineItemSchema>;
+
+export const UcpCartResponseSchemaSchema = z.object({
+    "capabilities": z.record(z.string(), z.array(CapabilityResponseSchemaSchema)).optional(),
+    "payment_handlers": z.record(z.string(), z.array(PaymentHandlerResponseSchemaSchema)).optional(),
+    "services": z.record(z.string(), z.array(ServiceSchema)).optional(),
+    "version": z.string(),
+});
+export type UcpCartResponseSchema = z.infer<typeof UcpCartResponseSchemaSchema>;
+
+export const SelectedPaymentInstrumentSchema = z.object({
+    "billing_address": BillingAddressClassSchema.optional(),
+    "credential": CredentialClassSchema.optional(),
+    "display": z.record(z.string(), z.any()).optional(),
+    "handler_id": z.string(),
+    "id": z.string(),
+    "type": z.string(),
+    "selected": z.boolean().optional(),
+});
+export type SelectedPaymentInstrument = z.infer<typeof SelectedPaymentInstrumentSchema>;
+
+export const ServiceResponseSchemaSchema = z.object({
+    "config": ServiceResponseSchemaConfigSchema.optional(),
+    "id": z.string().optional(),
+    "schema": z.string().optional(),
+    "spec": z.string().optional(),
+    "version": z.string(),
+    "endpoint": z.string().optional(),
+    "transport": TransportSchema,
+});
+export type ServiceResponseSchema = z.infer<typeof ServiceResponseSchemaSchema>;
 
 export const AdjustmentElementSchema = z.object({
-  'amount': z.number().optional(),
-  'description': z.string().optional(),
-  'id': z.string(),
-  'line_items': z.array(AdjustmentLineItemSchema).optional(),
-  'occurred_at': z.coerce.date(),
-  'status': AdjustmentStatusSchema,
-  'type': z.string(),
+    "amount": z.number().optional(),
+    "description": z.string().optional(),
+    "id": z.string(),
+    "line_items": z.array(AdjustmentLineItemSchema).optional(),
+    "occurred_at": z.coerce.date(),
+    "status": AdjustmentStatusSchema,
+    "type": z.string(),
 });
 export type AdjustmentElement = z.infer<typeof AdjustmentElementSchema>;
 
 export const EventElementSchema = z.object({
-  'carrier': z.string().optional(),
-  'description': z.string().optional(),
-  'id': z.string(),
-  'line_items': z.array(EventLineItemSchema),
-  'occurred_at': z.coerce.date(),
-  'tracking_number': z.string().optional(),
-  'tracking_url': z.string().optional(),
-  'type': z.string(),
+    "carrier": z.string().optional(),
+    "description": z.string().optional(),
+    "id": z.string(),
+    "line_items": z.array(EventLineItemSchema),
+    "occurred_at": z.coerce.date(),
+    "tracking_number": z.string().optional(),
+    "tracking_url": z.string().optional(),
+    "type": z.string(),
 });
 export type EventElement = z.infer<typeof EventElementSchema>;
 
 export const ExpectationElementSchema = z.object({
-  'description': z.string().optional(),
-  'destination': BillingAddressClassSchema,
-  'fulfillable_on': z.string().optional(),
-  'id': z.string(),
-  'line_items': z.array(ExpectationLineItemSchema),
-  'method_type': MethodTypeSchema,
+    "description": z.string().optional(),
+    "destination": BillingAddressClassSchema,
+    "fulfillable_on": z.string().optional(),
+    "id": z.string(),
+    "line_items": z.array(ExpectationLineItemSchema),
+    "method_type": MethodTypeSchema,
 });
 export type ExpectationElement = z.infer<typeof ExpectationElementSchema>;
 
-export const OrderLineItemClassSchema = z.object({
-  'id': z.string(),
-  'item': ItemResponseSchema,
-  'parent_id': z.string().optional(),
-  'quantity': LineItemQuantitySchema,
-  'status': LineItemStatusSchema,
-  'totals': z.array(TotalResponseSchema),
+export const LineItemElementSchema = z.object({
+    "id": z.string(),
+    "item": ItemClassSchema,
+    "parent_id": z.string().optional(),
+    "quantity": LineItemQuantitySchema,
+    "status": LineItemStatusSchema,
+    "totals": z.array(TotalElementSchema),
 });
-export type OrderLineItemClass = z.infer<typeof OrderLineItemClassSchema>;
+export type LineItemElement = z.infer<typeof LineItemElementSchema>;
 
-export const PaymentCreateRequestSchema = z.object({
-  'instruments': z.array(PaymentInstrumentSchema).optional(),
-  'selected_instrument_id': z.string().optional(),
+export const PaymentSchema = z.object({
+    "instruments": z.array(SelectedPaymentInstrumentSchema).optional(),
 });
-export type PaymentCreateRequest = z.infer<typeof PaymentCreateRequestSchema>;
-
-export const PaymentDataSchema = z.object({
-  'payment_data': PaymentInstrumentSchema,
-});
-export type PaymentData = z.infer<typeof PaymentDataSchema>;
-
-export const PaymentUpdateRequestSchema = z.object({
-  'instruments': z.array(PaymentInstrumentSchema).optional(),
-  'selected_instrument_id': z.string().optional(),
-});
-export type PaymentUpdateRequest = z.infer<typeof PaymentUpdateRequestSchema>;
+export type Payment = z.infer<typeof PaymentSchema>;
 
 export const AdjustmentSchema = z.object({
-  'amount': z.number().optional(),
-  'description': z.string().optional(),
-  'id': z.string(),
-  'line_items': z.array(AdjustmentLineItemClassSchema).optional(),
-  'occurred_at': z.coerce.date(),
-  'status': AdjustmentStatusSchema,
-  'type': z.string(),
+    "amount": z.number().optional(),
+    "description": z.string().optional(),
+    "id": z.string(),
+    "line_items": z.array(AdjustmentLineItemClassSchema).optional(),
+    "occurred_at": z.coerce.date(),
+    "status": AdjustmentStatusSchema,
+    "type": z.string(),
 });
 export type Adjustment = z.infer<typeof AdjustmentSchema>;
 
 export const BindingSchema = z.object({
-  'checkout_id': z.string(),
-  'identity': IdentityClassSchema.optional(),
+    "checkout_id": z.string(),
+    "identity": IdentityClassSchema.optional(),
 });
 export type Binding = z.infer<typeof BindingSchema>;
 
+export const BusinessFulfillmentConfigSchema = z.object({
+    "allows_method_combinations": z.array(z.array(TypeElementSchema)).optional(),
+    "allows_multi_destination": BusinessFulfillmentConfigAllowsMultiDestinationSchema.optional(),
+});
+export type BusinessFulfillmentConfig = z.infer<typeof BusinessFulfillmentConfigSchema>;
+
+export const CardPaymentInstrumentSchema = z.object({
+    "billing_address": BillingAddressClassSchema.optional(),
+    "credential": CredentialClassSchema.optional(),
+    "display": DisplaySchema.optional(),
+    "handler_id": z.string(),
+    "id": z.string(),
+    "type": AlgSchema,
+});
+export type CardPaymentInstrument = z.infer<typeof CardPaymentInstrumentSchema>;
+
 export const ExpectationSchema = z.object({
-  'description': z.string().optional(),
-  'destination': BillingAddressClassSchema,
-  'fulfillable_on': z.string().optional(),
-  'id': z.string(),
-  'line_items': z.array(ExpectationLineItemClassSchema),
-  'method_type': MethodTypeSchema,
+    "description": z.string().optional(),
+    "destination": BillingAddressClassSchema,
+    "fulfillable_on": z.string().optional(),
+    "id": z.string(),
+    "line_items": z.array(ExpectationLineItemClassSchema),
+    "method_type": MethodTypeSchema,
 });
 export type Expectation = z.infer<typeof ExpectationSchema>;
 
 export const FulfillmentEventSchema = z.object({
-  'carrier': z.string().optional(),
-  'description': z.string().optional(),
-  'id': z.string(),
-  'line_items': z.array(FulfillmentEventLineItemSchema),
-  'occurred_at': z.coerce.date(),
-  'tracking_number': z.string().optional(),
-  'tracking_url': z.string().optional(),
-  'type': z.string(),
+    "carrier": z.string().optional(),
+    "description": z.string().optional(),
+    "id": z.string(),
+    "line_items": z.array(FulfillmentEventLineItemSchema),
+    "occurred_at": z.coerce.date(),
+    "tracking_number": z.string().optional(),
+    "tracking_url": z.string().optional(),
+    "type": z.string(),
 });
 export type FulfillmentEvent = z.infer<typeof FulfillmentEventSchema>;
 
-export const FulfillmentMethodCreateRequestSchema = z.object({
-  'destinations':
-      z.array(FulfillmentDestinationRequestElementSchema).optional(),
-  'groups': z.array(GroupElementSchema).optional(),
-  'line_item_ids': z.array(z.string()).optional(),
-  'selected_destination_id': z.union([z.null(), z.string()]).optional(),
-  'type': TypeElementSchema,
+export const PurpleFulfillmentGroupSchema = z.object({
+    "id": z.string(),
+    "line_item_ids": z.array(z.string()),
+    "options": z.array(OptionElementSchema).optional(),
+    "selected_option_id": z.union([z.null(), z.string()]).optional(),
 });
-export type FulfillmentMethodCreateRequest =
-    z.infer<typeof FulfillmentMethodCreateRequestSchema>;
+export type PurpleFulfillmentGroup = z.infer<typeof PurpleFulfillmentGroupSchema>;
 
-export const FulfillmentMethodUpdateRequestSchema = z.object({
-  'destinations':
-      z.array(FulfillmentDestinationRequestElementSchema).optional(),
-  'groups': z.array(GroupClassSchema).optional(),
-  'id': z.string(),
-  'line_item_ids': z.array(z.string()),
-  'selected_destination_id': z.union([z.null(), z.string()]).optional(),
+export const MethodElementSchema = z.object({
+    "destinations": z.array(FulfillmentDestinationElementSchema).optional(),
+    "groups": z.array(GroupElementSchema).optional(),
+    "id": z.string(),
+    "line_item_ids": z.array(z.string()),
+    "selected_destination_id": z.union([z.null(), z.string()]).optional(),
+    "type": TypeElementSchema,
 });
-export type FulfillmentMethodUpdateRequest =
-    z.infer<typeof FulfillmentMethodUpdateRequestSchema>;
+export type MethodElement = z.infer<typeof MethodElementSchema>;
 
 export const MerchantFulfillmentConfigSchema = z.object({
-  'allows_method_combinations': z.array(z.array(TypeElementSchema)).optional(),
-  'allows_multi_destination': AllowsMultiDestinationSchema.optional(),
+    "allows_method_combinations": z.array(z.array(TypeElementSchema)).optional(),
+    "allows_multi_destination": MerchantFulfillmentConfigAllowsMultiDestinationSchema.optional(),
 });
-export type MerchantFulfillmentConfig =
-    z.infer<typeof MerchantFulfillmentConfigSchema>;
+export type MerchantFulfillmentConfig = z.infer<typeof MerchantFulfillmentConfigSchema>;
 
 export const OrderLineItemSchema = z.object({
-  'id': z.string(),
-  'item': ItemResponseSchema,
-  'parent_id': z.string().optional(),
-  'quantity': OrderLineItemQuantitySchema,
-  'status': LineItemStatusSchema,
-  'totals': z.array(TotalResponseSchema),
+    "id": z.string(),
+    "item": ItemClassSchema,
+    "parent_id": z.string().optional(),
+    "quantity": OrderLineItemQuantitySchema,
+    "status": LineItemStatusSchema,
+    "totals": z.array(TotalElementSchema),
 });
 export type OrderLineItem = z.infer<typeof OrderLineItemSchema>;
 
-export const CompleteCheckoutRequestWithAp2Schema = z.object({
-  'ap2': Ap2CompleteRequestObjectSchema.optional(),
+export const BuyerWithConsentSchema = z.object({
+    "email": z.string().optional(),
+    "first_name": z.string().optional(),
+    "last_name": z.string().optional(),
+    "phone_number": z.string().optional(),
+    "consent": ConsentSchema.optional(),
 });
-export type CompleteCheckoutRequestWithAp2 =
-    z.infer<typeof CompleteCheckoutRequestWithAp2Schema>;
+export type BuyerWithConsent = z.infer<typeof BuyerWithConsentSchema>;
 
-export const CheckoutWithAp2MandateSchema = z.object({
-  'buyer': BuyerClassSchema.optional(),
-  'continue_url': z.string().optional(),
-  'currency': z.string(),
-  'expires_at': z.coerce.date().optional(),
-  'id': z.string(),
-  'line_items': z.array(LineItemResponseSchema),
-  'links': z.array(LinkElementSchema),
-  'messages': z.array(MessageElementSchema).optional(),
-  'order': OrderClassSchema.optional(),
-  'payment': PaymentResponseSchema,
-  'status': CheckoutResponseStatusSchema,
-  'totals': z.array(TotalResponseSchema),
-  'ucp': UcpCheckoutResponseSchema,
-  'ap2': Ap2CheckoutResponseObjectSchema.optional(),
+export const AppliedDiscountSchema = z.object({
+    "allocations": z.array(AllocationSchema).optional(),
+    "amount": z.number(),
+    "automatic": z.boolean().optional(),
+    "code": z.string().optional(),
+    "method": MethodSchema.optional(),
+    "priority": z.number().optional(),
+    "title": z.string(),
 });
-export type CheckoutWithAp2Mandate =
-    z.infer<typeof CheckoutWithAp2MandateSchema>;
+export type AppliedDiscount = z.infer<typeof AppliedDiscountSchema>;
 
-export const BuyerWithConsentCreateRequestSchema = z.object({
-  'email': z.string().optional(),
-  'first_name': z.string().optional(),
-  'full_name': z.string().optional(),
-  'last_name': z.string().optional(),
-  'phone_number': z.string().optional(),
-  'consent': PurpleConsentSchema.optional(),
+export const UcpSchemaSchema = z.object({
+    "capabilities": z.record(z.string(), z.array(CapabilitySchemaSchema)).optional(),
+    "payment_handlers": z.record(z.string(), z.array(PaymentHandlerSchemaSchema)),
+    "services": z.record(z.string(), z.array(ServiceSchemaSchema)),
+    "version": z.string(),
 });
-export type BuyerWithConsentCreateRequest =
-    z.infer<typeof BuyerWithConsentCreateRequestSchema>;
+export type UcpSchema = z.infer<typeof UcpSchemaSchema>;
 
-export const BuyerWithConsentUpdateRequestSchema = z.object({
-  'email': z.string().optional(),
-  'first_name': z.string().optional(),
-  'full_name': z.string().optional(),
-  'last_name': z.string().optional(),
-  'phone_number': z.string().optional(),
-  'consent': FluffyConsentSchema.optional(),
+export const CartSchema = z.object({
+    "buyer": BuyerClassSchema.optional(),
+    "context": ContextClassSchema.optional(),
+    "continue_url": z.string().optional(),
+    "currency": z.string(),
+    "expires_at": z.coerce.date().optional(),
+    "id": z.string(),
+    "line_items": z.array(CartLineItemSchema),
+    "links": z.array(LinkElementSchema).optional(),
+    "messages": z.array(MessageElementSchema).optional(),
+    "totals": z.array(TotalElementSchema),
+    "ucp": UcpCartResponseSchemaSchema,
 });
-export type BuyerWithConsentUpdateRequest =
-    z.infer<typeof BuyerWithConsentUpdateRequestSchema>;
-
-export const BuyerWithConsentResponseSchema = z.object({
-  'email': z.string().optional(),
-  'first_name': z.string().optional(),
-  'full_name': z.string().optional(),
-  'last_name': z.string().optional(),
-  'phone_number': z.string().optional(),
-  'consent': TentacledConsentSchema.optional(),
-});
-export type BuyerWithConsentResponse =
-    z.infer<typeof BuyerWithConsentResponseSchema>;
-
-export const AppliedElementSchema = z.object({
-  'allocations': z.array(AllocationElementSchema).optional(),
-  'amount': z.number(),
-  'automatic': z.boolean().optional(),
-  'code': z.string().optional(),
-  'method': MethodSchema.optional(),
-  'priority': z.number().optional(),
-  'title': z.string(),
-});
-export type AppliedElement = z.infer<typeof AppliedElementSchema>;
-
-export const AppliedClassSchema = z.object({
-  'allocations': z.array(AllocationClassSchema).optional(),
-  'amount': z.number(),
-  'automatic': z.boolean().optional(),
-  'code': z.string().optional(),
-  'method': MethodSchema.optional(),
-  'priority': z.number().optional(),
-  'title': z.string(),
-});
-export type AppliedClass = z.infer<typeof AppliedClassSchema>;
-
-export const DiscountsAppliedSchema = z.object({
-  'allocations': z.array(AppliedAllocationSchema).optional(),
-  'amount': z.number(),
-  'automatic': z.boolean().optional(),
-  'code': z.string().optional(),
-  'method': MethodSchema.optional(),
-  'priority': z.number().optional(),
-  'title': z.string(),
-});
-export type DiscountsApplied = z.infer<typeof DiscountsAppliedSchema>;
-
-export const FulfillmentRequestSchema = z.object({
-  'methods': z.array(MethodElementSchema).optional(),
-});
-export type FulfillmentRequest = z.infer<typeof FulfillmentRequestSchema>;
-
-export const CheckoutWithFulfillmentUpdateRequestSchema = z.object({
-  'buyer': BuyerClassSchema.optional(),
-  'currency': z.string(),
-  'id': z.string(),
-  'line_items': z.array(LineItemClassSchema),
-  'payment': CheckoutUpdateRequestPaymentSchema,
-  'fulfillment': FulfillmentRequestSchema.optional(),
-});
-export type CheckoutWithFulfillmentUpdateRequest =
-    z.infer<typeof CheckoutWithFulfillmentUpdateRequestSchema>;
-
-export const FulfillmentGroupResponseSchema = z.object({
-  'id': z.string(),
-  'line_item_ids': z.array(z.string()),
-  'options': z.array(FulfillmentOptionResponseSchema).optional(),
-  'selected_option_id': z.union([z.null(), z.string()]).optional(),
-});
-export type FulfillmentGroupResponse =
-    z.infer<typeof FulfillmentGroupResponseSchema>;
-
-export const UcpClassSchema = z.object({
-  'capabilities': z.array(CapabilityDiscoverySchema),
-  'services': z.record(z.string(), UcpServiceSchema),
-  'version': z.string(),
-});
-export type UcpClass = z.infer<typeof UcpClassSchema>;
+export type Cart = z.infer<typeof CartSchema>;
 
 export const PaymentClassSchema = z.object({
-  'instruments': z.array(PaymentInstrumentSchema).optional(),
-  'selected_instrument_id': z.string().optional(),
+    "instruments": z.array(SelectedPaymentInstrumentSchema).optional(),
 });
 export type PaymentClass = z.infer<typeof PaymentClassSchema>;
 
-export const CheckoutResponseSchema = z.object({
-  'buyer': BuyerClassSchema.optional(),
-  'continue_url': z.string().optional(),
-  'currency': z.string(),
-  'expires_at': z.coerce.date().optional(),
-  'id': z.string(),
-  'line_items': z.array(LineItemResponseSchema),
-  'links': z.array(LinkElementSchema),
-  'messages': z.array(MessageElementSchema).optional(),
-  'order': OrderClassSchema.optional(),
-  'payment': PaymentResponseSchema,
-  'status': CheckoutResponseStatusSchema,
-  'totals': z.array(TotalResponseSchema),
-  'ucp': UcpCheckoutResponseSchema,
+export const UcpCheckoutResponseSchemaSchema = z.object({
+    "capabilities": z.record(z.string(), z.array(CapabilityResponseSchemaSchema)).optional(),
+    "payment_handlers": z.record(z.string(), z.array(PaymentHandlerResponseSchemaSchema)),
+    "services": z.record(z.string(), z.array(ServiceResponseSchemaSchema)).optional(),
+    "version": z.string(),
 });
-export type CheckoutResponse = z.infer<typeof CheckoutResponseSchema>;
+export type UcpCheckoutResponseSchema = z.infer<typeof UcpCheckoutResponseSchemaSchema>;
 
-export const CheckoutUpdateRequestSchema = z.object({
-  'buyer': BuyerClassSchema.optional(),
-  'currency': z.string(),
-  'id': z.string(),
-  'line_items': z.array(LineItemClassSchema),
-  'payment': CheckoutUpdateRequestPaymentSchema,
+export const FulfillmentClassSchema = z.object({
+    "events": z.array(EventElementSchema).optional(),
+    "expectations": z.array(ExpectationElementSchema).optional(),
 });
-export type CheckoutUpdateRequest = z.infer<typeof CheckoutUpdateRequestSchema>;
+export type FulfillmentClass = z.infer<typeof FulfillmentClassSchema>;
 
-export const FulfillmentSchema = z.object({
-  'events': z.array(EventElementSchema).optional(),
-  'expectations': z.array(ExpectationElementSchema).optional(),
+export const PurpleFulfillmentSchema = z.object({
+    "available_methods": z.array(AvailableMethodElementSchema).optional(),
+    "methods": z.array(MethodElementSchema).optional(),
 });
-export type Fulfillment = z.infer<typeof FulfillmentSchema>;
+export type PurpleFulfillment = z.infer<typeof PurpleFulfillmentSchema>;
 
-export const CheckoutWithBuyerConsentCreateRequestSchema = z.object({
-  'buyer': BuyerWithConsentCreateRequestSchema.optional(),
-  'currency': z.string(),
-  'line_items': z.array(LineItemElementSchema),
-  'payment': PaymentClassSchema,
+export const DiscountsObjectSchema = z.object({
+    "applied": z.array(AppliedDiscountSchema).optional(),
+    "codes": z.array(z.string()).optional(),
 });
-export type CheckoutWithBuyerConsentCreateRequest =
-    z.infer<typeof CheckoutWithBuyerConsentCreateRequestSchema>;
-
-export const CheckoutWithBuyerConsentUpdateRequestSchema = z.object({
-  'buyer': BuyerWithConsentUpdateRequestSchema.optional(),
-  'currency': z.string(),
-  'id': z.string(),
-  'line_items': z.array(LineItemClassSchema),
-  'payment': CheckoutUpdateRequestPaymentSchema,
-});
-export type CheckoutWithBuyerConsentUpdateRequest =
-    z.infer<typeof CheckoutWithBuyerConsentUpdateRequestSchema>;
-
-export const CheckoutWithBuyerConsentResponseSchema = z.object({
-  'buyer': BuyerWithConsentResponseSchema.optional(),
-  'continue_url': z.string().optional(),
-  'currency': z.string(),
-  'expires_at': z.coerce.date().optional(),
-  'id': z.string(),
-  'line_items': z.array(LineItemResponseSchema),
-  'links': z.array(LinkElementSchema),
-  'messages': z.array(MessageElementSchema).optional(),
-  'order': OrderClassSchema.optional(),
-  'payment': PaymentResponseSchema,
-  'status': CheckoutResponseStatusSchema,
-  'totals': z.array(TotalResponseSchema),
-  'ucp': UcpCheckoutResponseSchema,
-});
-export type CheckoutWithBuyerConsentResponse =
-    z.infer<typeof CheckoutWithBuyerConsentResponseSchema>;
-
-export const CheckoutWithDiscountCreateRequestDiscountsSchema = z.object({
-  'applied': z.array(AppliedElementSchema).optional(),
-  'codes': z.array(z.string()).optional(),
-});
-export type CheckoutWithDiscountCreateRequestDiscounts =
-    z.infer<typeof CheckoutWithDiscountCreateRequestDiscountsSchema>;
-
-export const CheckoutWithDiscountUpdateRequestDiscountsSchema = z.object({
-  'applied': z.array(AppliedClassSchema).optional(),
-  'codes': z.array(z.string()).optional(),
-});
-export type CheckoutWithDiscountUpdateRequestDiscounts =
-    z.infer<typeof CheckoutWithDiscountUpdateRequestDiscountsSchema>;
-
-export const CheckoutWithDiscountResponseDiscountsSchema = z.object({
-  'applied': z.array(DiscountsAppliedSchema).optional(),
-  'codes': z.array(z.string()).optional(),
-});
-export type CheckoutWithDiscountResponseDiscounts =
-    z.infer<typeof CheckoutWithDiscountResponseDiscountsSchema>;
-
-export const CheckoutWithFulfillmentCreateRequestSchema = z.object({
-  'buyer': BuyerClassSchema.optional(),
-  'currency': z.string(),
-  'line_items': z.array(LineItemElementSchema),
-  'payment': PaymentClassSchema,
-  'fulfillment': FulfillmentRequestSchema.optional(),
-});
-export type CheckoutWithFulfillmentCreateRequest =
-    z.infer<typeof CheckoutWithFulfillmentCreateRequestSchema>;
-
-export const FulfillmentMethodResponseSchema = z.object({
-  'destinations': z.array(FulfillmentDestinationResponseSchema).optional(),
-  'groups': z.array(FulfillmentGroupResponseSchema).optional(),
-  'id': z.string(),
-  'line_item_ids': z.array(z.string()),
-  'selected_destination_id': z.union([z.null(), z.string()]).optional(),
-  'type': TypeElementSchema,
-});
-export type FulfillmentMethodResponse =
-    z.infer<typeof FulfillmentMethodResponseSchema>;
+export type DiscountsObject = z.infer<typeof DiscountsObjectSchema>;
 
 export const UcpDiscoveryProfileSchema = z.object({
-  'payment': PaymentSchema.optional(),
-  'signing_keys': z.array(SigningKeySchema).optional(),
-  'ucp': UcpClassSchema,
+    "signing_keys": z.array(ProfileSchemaSchema).optional(),
+    "ucp": UcpSchemaSchema,
 });
 export type UcpDiscoveryProfile = z.infer<typeof UcpDiscoveryProfileSchema>;
 
-export const CheckoutCreateRequestSchema = z.object({
-  'buyer': BuyerClassSchema.optional(),
-  'currency': z.string(),
-  'line_items': z.array(LineItemElementSchema),
-  'payment': PaymentClassSchema,
+export const CheckoutSchema = z.object({
+    "buyer": BuyerClassSchema.optional(),
+    "context": ContextClassSchema.optional(),
+    "continue_url": z.string().optional(),
+    "currency": z.string(),
+    "expires_at": z.coerce.date().optional(),
+    "id": z.string(),
+    "line_items": z.array(CartLineItemSchema),
+    "links": z.array(LinkElementSchema),
+    "messages": z.array(MessageElementSchema).optional(),
+    "order": OrderClassSchema.optional(),
+    "payment": PaymentClassSchema.optional(),
+    "status": CheckoutStatusSchema,
+    "totals": z.array(TotalElementSchema),
+    "ucp": UcpCheckoutResponseSchemaSchema,
 });
-export type CheckoutCreateRequest = z.infer<typeof CheckoutCreateRequestSchema>;
+export type Checkout = z.infer<typeof CheckoutSchema>;
 
 export const OrderSchema = z.object({
-  'adjustments': z.array(AdjustmentElementSchema).optional(),
-  'checkout_id': z.string(),
-  'fulfillment': FulfillmentSchema,
-  'id': z.string(),
-  'line_items': z.array(OrderLineItemClassSchema),
-  'permalink_url': z.string(),
-  'totals': z.array(TotalResponseSchema),
-  'ucp': UcpOrderResponseSchema,
+    "adjustments": z.array(AdjustmentElementSchema).optional(),
+    "checkout_id": z.string(),
+    "fulfillment": FulfillmentClassSchema,
+    "id": z.string(),
+    "line_items": z.array(LineItemElementSchema),
+    "permalink_url": z.string(),
+    "totals": z.array(TotalElementSchema),
+    "ucp": UcpOrderResponseSchemaSchema,
 });
 export type Order = z.infer<typeof OrderSchema>;
-
-export const CheckoutWithDiscountCreateRequestSchema = z.object({
-  'buyer': BuyerClassSchema.optional(),
-  'currency': z.string(),
-  'line_items': z.array(LineItemElementSchema),
-  'payment': PaymentClassSchema,
-  'discounts': CheckoutWithDiscountCreateRequestDiscountsSchema.optional(),
-});
-export type CheckoutWithDiscountCreateRequest =
-    z.infer<typeof CheckoutWithDiscountCreateRequestSchema>;
-
-export const CheckoutWithDiscountUpdateRequestSchema = z.object({
-  'buyer': BuyerClassSchema.optional(),
-  'currency': z.string(),
-  'id': z.string(),
-  'line_items': z.array(LineItemClassSchema),
-  'payment': CheckoutUpdateRequestPaymentSchema,
-  'discounts': CheckoutWithDiscountUpdateRequestDiscountsSchema.optional(),
-});
-export type CheckoutWithDiscountUpdateRequest =
-    z.infer<typeof CheckoutWithDiscountUpdateRequestSchema>;
-
-export const CheckoutWithDiscountResponseSchema = z.object({
-  'buyer': BuyerClassSchema.optional(),
-  'continue_url': z.string().optional(),
-  'currency': z.string(),
-  'expires_at': z.coerce.date().optional(),
-  'id': z.string(),
-  'line_items': z.array(LineItemResponseSchema),
-  'links': z.array(LinkElementSchema),
-  'messages': z.array(MessageElementSchema).optional(),
-  'order': OrderClassSchema.optional(),
-  'payment': PaymentResponseSchema,
-  'status': CheckoutResponseStatusSchema,
-  'totals': z.array(TotalResponseSchema),
-  'ucp': UcpCheckoutResponseSchema,
-  'discounts': CheckoutWithDiscountResponseDiscountsSchema.optional(),
-});
-export type CheckoutWithDiscountResponse =
-    z.infer<typeof CheckoutWithDiscountResponseSchema>;
-
-export const FulfillmentResponseSchema = z.object({
-  'available_methods':
-      z.array(FulfillmentAvailableMethodResponseSchema).optional(),
-  'methods': z.array(FulfillmentMethodResponseSchema).optional(),
-});
-export type FulfillmentResponse = z.infer<typeof FulfillmentResponseSchema>;
-
-export const CheckoutWithFulfillmentResponseSchema = z.object({
-  'buyer': BuyerClassSchema.optional(),
-  'continue_url': z.string().optional(),
-  'currency': z.string(),
-  'expires_at': z.coerce.date().optional(),
-  'id': z.string(),
-  'line_items': z.array(LineItemResponseSchema),
-  'links': z.array(LinkElementSchema),
-  'messages': z.array(MessageElementSchema).optional(),
-  'order': OrderClassSchema.optional(),
-  'payment': PaymentResponseSchema,
-  'status': CheckoutResponseStatusSchema,
-  'totals': z.array(TotalResponseSchema),
-  'ucp': UcpCheckoutResponseSchema,
-  'fulfillment': FulfillmentResponseSchema.optional(),
-});
-export type CheckoutWithFulfillmentResponse =
-    z.infer<typeof CheckoutWithFulfillmentResponseSchema>;


### PR DESCRIPTION
This pull request refactors how checkout-related schemas are generated and used, simplifying the codebase and updating the schema generation process. The main changes include switching to a unified `CheckoutSchema`, updating the schema generation script to use new JSON schema definitions, and updating documentation to reflect these changes.

**Schema usage and code simplification:**

* Replaced multiple specialized checkout schemas (e.g., `CheckoutWithFulfillmentResponseSchema`, `CheckoutWithDiscountCreateRequestSchema`) with a single, unified `CheckoutSchema` throughout `src/extensions.ts`, significantly simplifying type composition and schema extension. [[1]](diffhunk://#diff-de840a82747bdc501daa4ab1afc31e258e02d0cb613d3521f503882f24e54df9L4-R4) [[2]](diffhunk://#diff-de840a82747bdc501daa4ab1afc31e258e02d0cb613d3521f503882f24e54df9L32-R21) [[3]](diffhunk://#diff-de840a82747bdc501daa4ab1afc31e258e02d0cb613d3521f503882f24e54df9L46-R35)

**Schema generation process:**

* Updated the `generate_models.sh` script to use `npx quicktype` instead of `quicktype` directly, and switched to new JSON schema definitions and $defs for generating TypeScript types, aligning the generated models with the latest schema structure.

**Documentation:**

* Updated the `README.md` to instruct users to generate models from the `ucp/source` directory instead of `ucp/spec`, reflecting the new schema location.