### PR TITLE
docs: update README with version compatibility and usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,12 +29,54 @@ This repository contains the JavaScript SDK for the
 types and [Zod](https://zod.dev/) schemas for UCP models, making it easy to
 build UCP-compliant applications in JavaScript and TypeScript.
 
+### UCP Version Compatibility
+
+Each version of the JavaScript SDK is generated against a specific version of the UCP schema:
+
+| SDK Version | UCP Schema Version |
+| ----------- | ------------------ |
+| **`0.4.x`** | **`2026-04-08`**   |
+| `0.1.x`     | `2026-01-11`       |
+
 ## Installation
 
 To install the SDK in your project, run:
 
 ```bash
 npm install @ucp-js/sdk
+```
+
+## Usage
+
+The SDK provides Zod schemas and TypeScript types for UCP models. You can use Zod to validate incoming data or ensure your outgoing data matches the specification.
+
+### TypeScript / ES Modules
+
+```typescript
+import { CheckoutResponseSchema, CheckoutResponse } from "@ucp-js/sdk";
+
+// Validate data against UCP schemas
+const parseResult = CheckoutResponseSchema.safeParse(checkoutData);
+
+if (parseResult.success) {
+  const checkout: CheckoutResponse = parseResult.data;
+  console.log(checkout.status); // "incomplete" | "ready_for_complete" | ...
+  console.log(checkout.currency); // ISO 4217 currency code
+} else {
+  console.error(parseResult.error);
+}
+```
+
+### CommonJS
+
+```javascript
+const { CheckoutResponseSchema } = require("@ucp-js/sdk");
+
+const parseResult = CheckoutResponseSchema.safeParse(checkoutData);
+if (parseResult.success) {
+  const checkout = parseResult.data;
+  // ...
+}
 ```
 
 ## Development

--- a/README.md
+++ b/README.md
@@ -36,7 +36,8 @@ Each version of the JavaScript SDK is generated against a specific version of th
 | SDK Version | UCP Schema Version |
 | ----------- | ------------------ |
 | **`0.4.x`** | **`2026-04-08`**   |
-| `0.1.x`     | `2026-01-11`       |
+| `0.1.1`     | `2026-01-23`       |
+| `0.1.0`     | `2026-01-11`       |
 
 ## Installation
 


### PR DESCRIPTION
Update README.md to include:
- A table mapping UCP SDK version to UCP Schema version.
- Usage examples for both TypeScript (ES Modules) and JavaScript (CommonJS) using Zod.

TAG=agy
CONV=b0b2a44b-5125-4e9d-8d52-f65c701cf6fc