### PR TITLE
fix: enforce JSON Schema value constraints in generated zod schemas (#33)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 node_modules/
 dist/
+tests/.dist/
 .DS_Store
 *.log
 temp_projected/

--- a/generate_models.sh
+++ b/generate_models.sh
@@ -31,6 +31,11 @@ else
   exit 1
 fi
 
+# Schema tree (with intact $refs) used to recover the value constraints
+# quicktype's typescript-zod target drops. Captured before any projection so
+# cross-file $refs resolve as authored.
+CONSTRAINT_SCHEMA_DIR="$SPEC_DIR/schemas"
+
 TMP_OUTPUT="$(mktemp "${TMPDIR:-/tmp}/ucp-spec-generated.XXXXXX.ts")"
 PROJECTED_SPEC_DIR=""
 cleanup() {
@@ -95,3 +100,7 @@ fi
 npx quicktype "${QUICKTYPE_ARGS[@]}"
 
 node scripts/normalize-generated-schemas.mjs "$TMP_OUTPUT" src/spec_generated.ts
+
+# Re-attach the value constraints (minimum, pattern, type: integer, ...) that
+# quicktype's typescript-zod target drops. See scripts/inject-schema-constraints.mjs.
+node scripts/inject-schema-constraints.mjs "$CONSTRAINT_SCHEMA_DIR" src/spec_generated.ts

--- a/generate_models.sh
+++ b/generate_models.sh
@@ -1,4 +1,17 @@
 #!/bin/bash
+# Copyright 2026 UCP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 set -euo pipefail
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@ucp-js/sdk",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@ucp-js/sdk",
-      "version": "0.4.1",
+      "version": "0.4.2",
       "license": "Apache-2.0",
       "dependencies": {
         "zod": "^3.23.8"

--- a/package.json
+++ b/package.json
@@ -23,6 +23,8 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:noEmit": "tsc --noEmit",
     "generate": "./generate_models.sh",
+    "pretest": "tsc src/spec_generated.ts --outDir tests/.dist --module commonjs --moduleResolution node --target ES2020 --strict --esModuleInterop --skipLibCheck",
+    "test": "node --test \"tests/**/*.test.js\"",
     "prepublishOnly": "npm run build"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ucp-js/sdk",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "UCP SDK for JavaScript",
   "license": "Apache-2.0",
   "main": "./dist/cjs/index.js",

--- a/scripts/inject-schema-constraints.mjs
+++ b/scripts/inject-schema-constraints.mjs
@@ -1,0 +1,571 @@
+/**
+ * Post-generation fixes for value constraints quicktype's `typescript-zod`
+ * target ignores.
+ *
+ * quicktype emits object shape + `z.enum` only. It drops every JSON Schema
+ * value constraint (`minimum`, `maximum`, `pattern`, `minLength`, `minItems`,
+ * `type: integer`, ...), so the generated schemas accept spec-invalid data
+ * (e.g. `PriceSchema.parse({ amount: -50 })` succeeds, though `amount` is
+ * `{ type: integer, minimum: 0 }`). See js-sdk#33. The python-sdk enforces the
+ * same constraints (datamodel-code-generator emits most natively); this script
+ * is the JS-side analogue of python-sdk's `postprocess_models.py`.
+ *
+ * Approach (object-scoped, zero-false-positive by construction):
+ *   1. Scan the UCP JSON Schemas, resolving `$ref`/`allOf`, and index every
+ *      object schema by the sorted set of its property names. For each such
+ *      property-set, record each property's value constraints.
+ *   2. Discard any property whose constraints are ambiguous within a
+ *      property-set (the same shape appearing with conflicting constraints);
+ *      those are reported and left untouched.
+ *   3. Parse the generated TS (TypeScript compiler API) and, for each
+ *      top-level `z.object({...})` whose property-name set exactly matches an
+ *      indexed set, splice the corresponding zod constraint methods onto the
+ *      matching fields -- only when the generated field's base type agrees
+ *      with the constraint (number/string/array), so schema drift can never
+ *      produce a wrong or ill-typed injection.
+ *
+ * Runs from generate_models.sh after normalize-generated-schemas.mjs.
+ * Idempotent: constraints already present are detected and skipped.
+ *
+ * Usage: node scripts/inject-schema-constraints.mjs <schema_dir> <file.ts>
+ */
+
+import fs from "node:fs";
+import path from "node:path";
+import ts from "typescript";
+
+const [, , schemaDirArg, targetArg] = process.argv;
+
+if (!schemaDirArg || !targetArg) {
+  console.error(
+    "Usage: node scripts/inject-schema-constraints.mjs <schema_dir> <generated.ts>"
+  );
+  process.exit(1);
+}
+
+const schemaDir = path.resolve(schemaDirArg);
+const targetPath = path.resolve(targetArg);
+
+// --- JSON Schema loading + $ref resolution ---------------------------------
+
+const documentCache = new Map();
+
+function loadDocument(file) {
+  const absolute = path.resolve(file);
+  if (documentCache.has(absolute)) {
+    return documentCache.get(absolute);
+  }
+  const parsed = JSON.parse(fs.readFileSync(absolute, "utf8"));
+  documentCache.set(absolute, parsed);
+  return parsed;
+}
+
+function resolvePointer(document, pointer) {
+  let node = document;
+  for (const rawSegment of pointer.split("/").filter(Boolean)) {
+    const segment = rawSegment.replace(/~1/g, "/").replace(/~0/g, "~");
+    node = node?.[segment];
+  }
+  return node;
+}
+
+function resolveRef(ref, baseFile) {
+  const hashIndex = ref.indexOf("#");
+  const filePart = hashIndex >= 0 ? ref.slice(0, hashIndex) : ref;
+  const pointer = hashIndex >= 0 ? ref.slice(hashIndex + 1) : "";
+  const targetFile = filePart
+    ? path.resolve(path.dirname(baseFile), filePart)
+    : baseFile;
+  const document = loadDocument(targetFile);
+  const node = pointer ? resolvePointer(document, pointer) : document;
+  return { node, file: targetFile };
+}
+
+// Constraint keywords we can express in zod today.
+const CONSTRAINT_KEYS = [
+  "type",
+  "minimum",
+  "maximum",
+  "exclusiveMinimum",
+  "exclusiveMaximum",
+  "minLength",
+  "maxLength",
+  "pattern",
+  "minItems",
+  "maxItems",
+];
+
+/** Effective value constraints for a schema node, following $ref + allOf. */
+function effectiveConstraints(node, file, seen = new Set(), depth = 0) {
+  if (!node || typeof node !== "object" || depth > 32) {
+    return {};
+  }
+  if (typeof node.$ref === "string") {
+    const key = `${file}|${node.$ref}`;
+    if (seen.has(key)) {
+      return {};
+    }
+    seen.add(key);
+    const resolved = resolveRef(node.$ref, file);
+    const base = effectiveConstraints(
+      resolved.node,
+      resolved.file,
+      seen,
+      depth + 1
+    );
+    const local = {};
+    for (const keyword of CONSTRAINT_KEYS) {
+      if (keyword in node) {
+        local[keyword] = node[keyword];
+      }
+    }
+    return { ...base, ...local };
+  }
+  const out = {};
+  for (const keyword of CONSTRAINT_KEYS) {
+    if (keyword in node) {
+      out[keyword] = node[keyword];
+    }
+  }
+  if (Array.isArray(node.allOf)) {
+    for (const sub of node.allOf) {
+      const merged = effectiveConstraints(sub, file, new Set(seen), depth + 1);
+      for (const keyword of CONSTRAINT_KEYS) {
+        if (keyword in merged && !(keyword in out)) {
+          out[keyword] = merged[keyword];
+        }
+      }
+    }
+  }
+  return out;
+}
+
+/** Resolve a node to its object form (own properties + allOf-merged ones). */
+function resolveObject(node, file, seen = new Set(), depth = 0) {
+  if (!node || typeof node !== "object" || depth > 32) {
+    return null;
+  }
+  if (typeof node.$ref === "string") {
+    const key = `${file}|${node.$ref}`;
+    if (seen.has(key)) {
+      return null;
+    }
+    seen.add(key);
+    const resolved = resolveRef(node.$ref, file);
+    return resolveObject(resolved.node, resolved.file, seen, depth + 1);
+  }
+  let properties = {};
+  if (Array.isArray(node.allOf)) {
+    for (const sub of node.allOf) {
+      const resolved = resolveObject(sub, file, new Set(seen), depth + 1);
+      if (resolved) {
+        properties = { ...resolved.properties, ...properties };
+      }
+    }
+  }
+  if (node.properties && typeof node.properties === "object") {
+    properties = { ...properties, ...node.properties };
+  }
+  return Object.keys(properties).length ? { properties, file } : null;
+}
+
+/** Normalize a node's constraints into a canonical descriptor + signature. */
+function describeConstraint(propertyNode, file) {
+  const eff = effectiveConstraints(propertyNode, file);
+  const type = Array.isArray(eff.type)
+    ? eff.type.find((entry) => entry !== "null")
+    : eff.type;
+  const descriptor = {};
+  if (type === "integer") descriptor.int = true;
+  if (eff.minimum !== undefined) descriptor.minimum = eff.minimum;
+  if (eff.maximum !== undefined) descriptor.maximum = eff.maximum;
+  if (eff.exclusiveMinimum !== undefined)
+    descriptor.exclusiveMinimum = eff.exclusiveMinimum;
+  if (eff.exclusiveMaximum !== undefined)
+    descriptor.exclusiveMaximum = eff.exclusiveMaximum;
+  if (eff.minLength !== undefined) descriptor.minLength = eff.minLength;
+  if (eff.maxLength !== undefined) descriptor.maxLength = eff.maxLength;
+  if (eff.pattern !== undefined) descriptor.pattern = eff.pattern;
+  if (eff.minItems !== undefined) descriptor.minItems = eff.minItems;
+  if (eff.maxItems !== undefined) descriptor.maxItems = eff.maxItems;
+  const signature = JSON.stringify(descriptor);
+  return Object.keys(descriptor).length ? { descriptor, signature } : null;
+}
+
+// --- Build the property-set -> property -> constraint index ----------------
+
+// setKey -> Map(propertyName -> Map(signature -> descriptor))
+const constraintIndex = new Map();
+
+function recordObject(properties, file) {
+  const setKey = Object.keys(properties).sort().join(",");
+  if (!constraintIndex.has(setKey)) {
+    constraintIndex.set(setKey, new Map());
+  }
+  const byProperty = constraintIndex.get(setKey);
+  for (const [name, propertyNode] of Object.entries(properties)) {
+    const described = describeConstraint(propertyNode, file);
+    if (!described) {
+      continue;
+    }
+    if (!byProperty.has(name)) {
+      byProperty.set(name, new Map());
+    }
+    byProperty.get(name).set(described.signature, described.descriptor);
+  }
+}
+
+function walkSchema(node, file, seen = new Set(), depth = 0) {
+  if (!node || typeof node !== "object" || depth > 64) {
+    return;
+  }
+  if (typeof node.$ref === "string") {
+    const key = `${file}|${node.$ref}`;
+    if (seen.has(key)) {
+      return;
+    }
+    seen.add(key);
+    const resolved = resolveRef(node.$ref, file);
+    walkSchema(resolved.node, resolved.file, seen, depth + 1);
+    return;
+  }
+  const resolvedObject = resolveObject(node, file);
+  if (resolvedObject) {
+    recordObject(resolvedObject.properties, resolvedObject.file);
+  }
+  if (node.properties && typeof node.properties === "object") {
+    for (const child of Object.values(node.properties)) {
+      walkSchema(child, file, new Set(seen), depth + 1);
+    }
+  }
+  for (const key of ["items", "additionalProperties", "not"]) {
+    if (node[key] && typeof node[key] === "object") {
+      walkSchema(node[key], file, new Set(seen), depth + 1);
+    }
+  }
+  for (const key of ["allOf", "anyOf", "oneOf"]) {
+    if (Array.isArray(node[key])) {
+      for (const child of node[key]) {
+        walkSchema(child, file, new Set(seen), depth + 1);
+      }
+    }
+  }
+  if (node.$defs && typeof node.$defs === "object") {
+    for (const child of Object.values(node.$defs)) {
+      walkSchema(child, file, new Set(seen), depth + 1);
+    }
+  }
+}
+
+function collectSchemaFiles(directory) {
+  const out = [];
+  for (const entry of fs.readdirSync(directory, { withFileTypes: true })) {
+    const full = path.join(directory, entry.name);
+    if (entry.isDirectory()) {
+      out.push(...collectSchemaFiles(full));
+    } else if (entry.name.endsWith(".json")) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+for (const file of collectSchemaFiles(schemaDir)) {
+  try {
+    walkSchema(loadDocument(file), file);
+  } catch {
+    // Ignore unreadable / non-schema JSON files.
+  }
+}
+
+// Resolve each (setKey, property) to a single unambiguous descriptor.
+// setKey -> Map(propertyName -> descriptor)
+const resolvedIndex = new Map();
+const ambiguous = [];
+for (const [setKey, byProperty] of constraintIndex) {
+  const resolvedProperties = new Map();
+  for (const [name, bySignature] of byProperty) {
+    if (bySignature.size === 1) {
+      resolvedProperties.set(name, [...bySignature.values()][0]);
+    } else {
+      ambiguous.push({ setKey, name, count: bySignature.size });
+    }
+  }
+  if (resolvedProperties.size) {
+    resolvedIndex.set(setKey, resolvedProperties);
+  }
+}
+
+// --- Zod method rendering --------------------------------------------------
+
+function toRegexLiteral(pattern) {
+  // Escape unescaped forward slashes so the pattern is a valid regex literal.
+  let out = "";
+  for (let i = 0; i < pattern.length; i += 1) {
+    const ch = pattern[i];
+    if (ch === "\\") {
+      out += ch + (pattern[i + 1] ?? "");
+      i += 1;
+      continue;
+    }
+    if (ch === "/") {
+      out += "\\/";
+      continue;
+    }
+    out += ch;
+  }
+  return `/${out}/`;
+}
+
+/**
+ * Zod methods for a descriptor given the generated field's base kind.
+ * Returns null when the base kind is incompatible with the constraint
+ * (schema drift guard) so nothing is injected.
+ */
+function methodsFor(descriptor, baseKind) {
+  const methods = [];
+  const isNumeric =
+    descriptor.int !== undefined ||
+    descriptor.minimum !== undefined ||
+    descriptor.maximum !== undefined ||
+    descriptor.exclusiveMinimum !== undefined ||
+    descriptor.exclusiveMaximum !== undefined;
+  const isString =
+    descriptor.minLength !== undefined ||
+    descriptor.maxLength !== undefined ||
+    descriptor.pattern !== undefined;
+  const isArray =
+    descriptor.minItems !== undefined || descriptor.maxItems !== undefined;
+
+  if (isNumeric) {
+    if (baseKind !== "number") return null;
+    if (descriptor.int) methods.push(".int()");
+    if (descriptor.minimum !== undefined)
+      methods.push(`.gte(${descriptor.minimum})`);
+    if (descriptor.maximum !== undefined)
+      methods.push(`.lte(${descriptor.maximum})`);
+    if (descriptor.exclusiveMinimum !== undefined)
+      methods.push(`.gt(${descriptor.exclusiveMinimum})`);
+    if (descriptor.exclusiveMaximum !== undefined)
+      methods.push(`.lt(${descriptor.exclusiveMaximum})`);
+  } else if (isString) {
+    if (baseKind !== "string") return null;
+    if (
+      descriptor.minLength !== undefined &&
+      descriptor.minLength === descriptor.maxLength
+    ) {
+      methods.push(`.length(${descriptor.minLength})`);
+    } else {
+      if (descriptor.minLength !== undefined)
+        methods.push(`.min(${descriptor.minLength})`);
+      if (descriptor.maxLength !== undefined)
+        methods.push(`.max(${descriptor.maxLength})`);
+    }
+    if (descriptor.pattern !== undefined)
+      methods.push(`.regex(${toRegexLiteral(descriptor.pattern)})`);
+  } else if (isArray) {
+    if (baseKind !== "array") return null;
+    if (descriptor.minItems !== undefined)
+      methods.push(`.min(${descriptor.minItems})`);
+    if (descriptor.maxItems !== undefined)
+      methods.push(`.max(${descriptor.maxItems})`);
+  }
+  return methods.length ? methods : null;
+}
+
+// --- Locate the base zod constructor call in a field expression ------------
+
+/**
+ * Given a property initializer expression, find the leftmost base call
+ * (`z.number()`, `z.string()`, `z.array(...)`, ...) and its base kind.
+ * Returns { end, kind } where `end` is the position just after the base
+ * call's closing paren -- the splice point for constraint methods.
+ */
+function findBaseCall(expression, sourceFile) {
+  // Descend the call/property-access chain to the innermost `z.<name>(...)`.
+  let node = expression;
+  const callStack = [];
+  while (ts.isCallExpression(node)) {
+    callStack.push(node);
+    const callee = node.expression;
+    if (ts.isPropertyAccessExpression(callee)) {
+      node = callee.expression;
+    } else {
+      break;
+    }
+  }
+  // The base call is the last one pushed (deepest / leftmost).
+  const baseCall = callStack[callStack.length - 1];
+  if (!baseCall || !ts.isCallExpression(baseCall)) {
+    return null;
+  }
+  const callee = baseCall.expression;
+  if (!ts.isPropertyAccessExpression(callee)) {
+    return null;
+  }
+  if (!ts.isIdentifier(callee.expression) || callee.expression.text !== "z") {
+    return null;
+  }
+  const method = callee.name.text;
+  let kind = null;
+  if (method === "number") kind = "number";
+  else if (method === "string") kind = "string";
+  else if (method === "array") kind = "array";
+  else return null;
+  return { end: baseCall.getEnd(), kind, baseCall };
+}
+
+/**
+ * Detect whether constraint methods are already present immediately after the
+ * base call (idempotency): look at the chain wrapping the base call.
+ */
+function alreadyConstrained(baseCall) {
+  const parent = baseCall.parent;
+  // base is `z.number()`; wrapped as PropertyAccess(base).name
+  if (parent && ts.isPropertyAccessExpression(parent)) {
+    const method = parent.name.text;
+    const CONSTRAINT_METHODS = new Set([
+      "int",
+      "gte",
+      "lte",
+      "gt",
+      "lt",
+      "min",
+      "max",
+      "length",
+      "regex",
+    ]);
+    if (CONSTRAINT_METHODS.has(method)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+// --- Parse the generated file and compute edits ----------------------------
+
+const sourceText = fs.readFileSync(targetPath, "utf8");
+const sourceFile = ts.createSourceFile(
+  targetPath,
+  sourceText,
+  ts.ScriptTarget.Latest,
+  true,
+  ts.ScriptKind.TS
+);
+
+const edits = []; // { pos, text }
+const report = {
+  objectsMatched: 0,
+  fieldsInjected: 0,
+  fieldsSkippedType: 0,
+  fieldsAlreadyDone: 0,
+  injections: [],
+};
+
+function objectLiteralPropertySet(objectLiteral) {
+  const names = [];
+  for (const prop of objectLiteral.properties) {
+    if (ts.isPropertyAssignment(prop) && ts.isIdentifier(prop.name)) {
+      names.push(prop.name.text);
+    } else if (ts.isPropertyAssignment(prop) && ts.isStringLiteral(prop.name)) {
+      names.push(prop.name.text);
+    } else {
+      return null; // spreads / computed / shorthand -> bail out
+    }
+  }
+  return names;
+}
+
+function handleObjectLiteral(objectLiteral) {
+  const names = objectLiteralPropertySet(objectLiteral);
+  if (!names) {
+    return;
+  }
+  const setKey = [...names].sort().join(",");
+  const resolvedProperties = resolvedIndex.get(setKey);
+  if (!resolvedProperties) {
+    return;
+  }
+  let matchedAny = false;
+  for (const prop of objectLiteral.properties) {
+    if (!ts.isPropertyAssignment(prop)) {
+      continue;
+    }
+    const name =
+      ts.isIdentifier(prop.name) || ts.isStringLiteral(prop.name)
+        ? prop.name.text
+        : null;
+    if (!name) {
+      continue;
+    }
+    const descriptor = resolvedProperties.get(name);
+    if (!descriptor) {
+      continue;
+    }
+    const base = findBaseCall(prop.initializer, sourceFile);
+    if (!base) {
+      report.fieldsSkippedType += 1;
+      continue;
+    }
+    if (alreadyConstrained(base.baseCall)) {
+      report.fieldsAlreadyDone += 1;
+      matchedAny = true;
+      continue;
+    }
+    const methods = methodsFor(descriptor, base.kind);
+    if (!methods) {
+      report.fieldsSkippedType += 1;
+      continue;
+    }
+    edits.push({ pos: base.end, text: methods.join("") });
+    report.fieldsInjected += 1;
+    report.injections.push(`${setKey} :: ${name} ${methods.join("")}`);
+    matchedAny = true;
+  }
+  if (matchedAny) {
+    report.objectsMatched += 1;
+  }
+}
+
+function visit(node) {
+  if (
+    ts.isCallExpression(node) &&
+    ts.isPropertyAccessExpression(node.expression) &&
+    ts.isIdentifier(node.expression.expression) &&
+    node.expression.expression.text === "z" &&
+    node.expression.name.text === "object" &&
+    node.arguments.length === 1 &&
+    ts.isObjectLiteralExpression(node.arguments[0])
+  ) {
+    handleObjectLiteral(node.arguments[0]);
+  }
+  ts.forEachChild(node, visit);
+}
+
+visit(sourceFile);
+
+// Apply edits back-to-front so positions stay valid.
+edits.sort((a, b) => b.pos - a.pos);
+let output = sourceText;
+for (const edit of edits) {
+  output = output.slice(0, edit.pos) + edit.text + output.slice(edit.pos);
+}
+
+fs.writeFileSync(targetPath, output);
+
+// --- Report ----------------------------------------------------------------
+
+process.stdout.write(
+  `inject-schema-constraints: ${report.fieldsInjected} field(s) constrained ` +
+    `across ${report.objectsMatched} object schema(s); ` +
+    `${report.fieldsAlreadyDone} already constrained; ` +
+    `${report.fieldsSkippedType} skipped (base-type mismatch).\n`
+);
+if (ambiguous.length) {
+  process.stdout.write(
+    `inject-schema-constraints: ${ambiguous.length} property(ies) left ` +
+      `untouched (ambiguous constraints within a property-set): ` +
+      ambiguous.map((a) => `${a.name}@{${a.setKey}}`).join(", ") +
+      "\n"
+  );
+}

--- a/scripts/inject-schema-constraints.mjs
+++ b/scripts/inject-schema-constraints.mjs
@@ -1,3 +1,17 @@
+// Copyright 2026 UCP Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 /**
  * Post-generation fixes for value constraints quicktype's `typescript-zod`
  * target ignores.

--- a/scripts/project-current-ucp-schemas.mjs
+++ b/scripts/project-current-ucp-schemas.mjs
@@ -1,3 +1,17 @@
+// Copyright 2026 UCP Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 import fs from "node:fs";
 import path from "node:path";
 

--- a/src/extensions.ts
+++ b/src/extensions.ts
@@ -1,3 +1,17 @@
+// Copyright 2026 UCP Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 import { z } from "zod";
 
 import {

--- a/src/spec_generated.ts
+++ b/src/spec_generated.ts
@@ -1,18 +1,11 @@
 import * as z from "zod";
 
-
-export const UseSchema = z.enum([
-    "enc",
-    "sig",
-]);
+export const UseSchema = z.enum(["enc", "sig"]);
 export type Use = z.infer<typeof UseSchema>;
 
 // Content format, default = plain.
 
-export const ContentTypeSchema = z.enum([
-    "markdown",
-    "plain",
-]);
+export const ContentTypeSchema = z.enum(["markdown", "plain"]);
 export type ContentType = z.infer<typeof ContentTypeSchema>;
 
 // Reflects the resource state and recommended action. 'recoverable': platform can resolve
@@ -25,40 +18,37 @@ export type ContentType = z.infer<typeof ContentTypeSchema>;
 // 'status: requires_escalation'.
 
 export const SeveritySchema = z.enum([
-    "recoverable",
-    "requires_buyer_input",
-    "requires_buyer_review",
-    "unrecoverable",
+  "recoverable",
+  "requires_buyer_input",
+  "requires_buyer_review",
+  "unrecoverable",
 ]);
 export type Severity = z.infer<typeof SeveritySchema>;
 
-
-export const TypeSchema = z.enum([
-    "error",
-    "info",
-    "warning",
-]);
+export const TypeSchema = z.enum(["error", "info", "warning"]);
 export type Type = z.infer<typeof TypeSchema>;
 
 // Checkout state indicating the current phase and required processing. See Checkout Status
 // lifecycle documentation for state transition details.
 
 export const CheckoutResponseStatusSchema = z.enum([
-    "canceled",
-    "complete_in_progress",
-    "completed",
-    "incomplete",
-    "ready_for_complete",
-    "requires_escalation",
+  "canceled",
+  "complete_in_progress",
+  "completed",
+  "incomplete",
+  "ready_for_complete",
+  "requires_escalation",
 ]);
-export type CheckoutResponseStatus = z.infer<typeof CheckoutResponseStatusSchema>;
+export type CheckoutResponseStatus = z.infer<
+  typeof CheckoutResponseStatusSchema
+>;
 
 // Adjustment status.
 
 export const AdjustmentStatusSchema = z.enum([
-    "completed",
-    "failed",
-    "pending",
+  "completed",
+  "failed",
+  "pending",
 ]);
 export type AdjustmentStatus = z.infer<typeof AdjustmentStatusSchema>;
 
@@ -67,10 +57,10 @@ export type AdjustmentStatus = z.infer<typeof AdjustmentStatusSchema>;
 // quantity.fulfilled > 0, otherwise processing.
 
 export const LineItemStatusSchema = z.enum([
-    "fulfilled",
-    "partial",
-    "processing",
-    "removed",
+  "fulfilled",
+  "partial",
+  "processing",
+  "removed",
 ]);
 export type LineItemStatus = z.infer<typeof LineItemStatusSchema>;
 
@@ -82,68 +72,66 @@ export type LineItemStatus = z.infer<typeof LineItemStatusSchema>;
 // value reflects the business's default policy; `platform` means the value reflects an
 // explicit buyer decision captured by the platform.
 
-export const SourceSchema = z.enum([
-    "business",
-    "platform",
-]);
+export const SourceSchema = z.enum(["business", "platform"]);
 export type Source = z.infer<typeof SourceSchema>;
 
 // Allocation method. 'each' = applied independently per item. 'across' = split
 // proportionally by value.
 
-export const MethodSchema = z.enum([
-    "across",
-    "each",
-]);
+export const MethodSchema = z.enum(["across", "each"]);
 export type Method = z.infer<typeof MethodSchema>;
 
 export const PaymentHandlerResponseSchema = z.object({
-    "config": z.record(z.string(), z.any()),
-    "config_schema": z.string(),
-    "id": z.string(),
-    "instrument_schemas": z.array(z.string()),
-    "name": z.string(),
-    "spec": z.string(),
-    "version": z.string(),
+  config: z.record(z.string(), z.any()),
+  config_schema: z.string(),
+  id: z.string(),
+  instrument_schemas: z.array(z.string()),
+  name: z.string(),
+  spec: z.string(),
+  version: z.string(),
 });
-export type PaymentHandlerResponse = z.infer<typeof PaymentHandlerResponseSchema>;
+export type PaymentHandlerResponse = z.infer<
+  typeof PaymentHandlerResponseSchema
+>;
 
 export const SigningKeySchema = z.object({
-    "alg": z.string().optional(),
-    "crv": z.string().optional(),
-    "e": z.string().optional(),
-    "kid": z.string(),
-    "kty": z.string(),
-    "n": z.string().optional(),
-    "use": UseSchema.optional(),
-    "x": z.string().optional(),
-    "y": z.string().optional(),
+  alg: z.string().optional(),
+  crv: z.string().optional(),
+  e: z.string().optional(),
+  kid: z.string(),
+  kty: z.string(),
+  n: z.string().optional(),
+  use: UseSchema.optional(),
+  x: z.string().optional(),
+  y: z.string().optional(),
 });
 export type SigningKey = z.infer<typeof SigningKeySchema>;
 
 export const CapabilityDiscoverySchema = z.object({
-    "config": z.record(z.string(), z.any()).optional(),
-    "extends": z.string().optional(),
-    "name": z.string(),
-    "schema": z.string(),
-    "spec": z.string(),
-    "version": z.string(),
+  config: z.record(z.string(), z.any()).optional(),
+  extends: z.string().optional(),
+  name: z.string(),
+  schema: z.string(),
+  spec: z.string(),
+  version: z.string(),
 });
 export type CapabilityDiscovery = z.infer<typeof CapabilityDiscoverySchema>;
 
 export const A2ASchema = z.object({
-    "endpoint": z.string().regex(/^https:\/\/[^\/?#\s\\@]+(?:\/[^?#\s\\]*[^\/?#\s\\])?$/),
+  endpoint: z
+    .string()
+    .regex(/^https:\/\/[^\/?#\s\\@]+(?:\/[^?#\s\\]*[^\/?#\s\\])?$/),
 });
 export type A2A = z.infer<typeof A2ASchema>;
 
 export const EmbeddedSchema = z.object({
-    "schema": z.string(),
+  schema: z.string(),
 });
 export type Embedded = z.infer<typeof EmbeddedSchema>;
 
 export const SchemaEndpointSchema = z.object({
-    "endpoint": z.string(),
-    "schema": z.string(),
+  endpoint: z.string(),
+  schema: z.string(),
 });
 export type SchemaEndpoint = z.infer<typeof SchemaEndpointSchema>;
 export const McpSchema = SchemaEndpointSchema;
@@ -151,28 +139,28 @@ export type Mcp = SchemaEndpoint;
 export const RestSchema = SchemaEndpointSchema;
 export type Rest = SchemaEndpoint;
 
-
-
-
 export const BuyerSchema = z.object({
-    "email": z.string().optional(),
-    "first_name": z.string().optional(),
-    "last_name": z.string().optional(),
-    "phone_number": z.string().optional(),
+  email: z.string().optional(),
+  first_name: z.string().optional(),
+  last_name: z.string().optional(),
+  phone_number: z.string().optional(),
 });
 export type Buyer = z.infer<typeof BuyerSchema>;
 
 export const PurplePaymentSchema = z.object({
-    "handler": z.string().regex(/^[a-z](?:[a-z0-9-]*[a-z0-9])?(?:\.[a-z0-9](?:[a-z0-9_-]*[a-z0-9_])?)+$/),
-    "types": z.array(z.string()).optional(),
+  handler: z
+    .string()
+    .regex(
+      /^[a-z](?:[a-z0-9-]*[a-z0-9])?(?:\.[a-z0-9](?:[a-z0-9_-]*[a-z0-9_])?)+$/
+    ),
+  types: z.array(z.string()).optional(),
 });
 export type PurplePayment = z.infer<typeof PurplePaymentSchema>;
 export const FluffyPaymentSchema = PurplePaymentSchema;
 export type FluffyPayment = PurplePayment;
 
-
 export const ItemReferenceSchema = z.object({
-    "id": z.string(),
+  id: z.string(),
 });
 export type ItemReference = z.infer<typeof ItemReferenceSchema>;
 export const ItemCreateRequestSchema = ItemReferenceSchema;
@@ -180,116 +168,114 @@ export type ItemCreateRequest = ItemReference;
 export const ItemUpdateRequestSchema = ItemReferenceSchema;
 export type ItemUpdateRequest = ItemReference;
 
-
 export const PostalAddressSchema = z.object({
-    "address_country": z.string().optional(),
-    "address_locality": z.string().optional(),
-    "address_region": z.string().optional(),
-    "extended_address": z.string().optional(),
-    "first_name": z.string().optional(),
-    "last_name": z.string().optional(),
-    "phone_number": z.string().optional(),
-    "postal_code": z.string().optional(),
-    "street_address": z.string().optional(),
+  address_country: z.string().optional(),
+  address_locality: z.string().optional(),
+  address_region: z.string().optional(),
+  extended_address: z.string().optional(),
+  first_name: z.string().optional(),
+  last_name: z.string().optional(),
+  phone_number: z.string().optional(),
+  postal_code: z.string().optional(),
+  street_address: z.string().optional(),
 });
 export type PostalAddress = z.infer<typeof PostalAddressSchema>;
 
 export const PaymentCredentialSchema = z.object({
-    "type": z.string(),
+  type: z.string(),
 });
 export type PaymentCredential = z.infer<typeof PaymentCredentialSchema>;
 
 export const CheckoutCreateRequestSignalsSchema = z.object({
-    "dev.ucp.buyer_ip": z.string().optional(),
-    "dev.ucp.user_agent": z.string().optional(),
+  "dev.ucp.buyer_ip": z.string().optional(),
+  "dev.ucp.user_agent": z.string().optional(),
 });
-export type CheckoutCreateRequestSignals = z.infer<typeof CheckoutCreateRequestSignalsSchema>;
+export type CheckoutCreateRequestSignals = z.infer<
+  typeof CheckoutCreateRequestSignalsSchema
+>;
 export const LookupRequestSignalsSchema = CheckoutCreateRequestSignalsSchema;
 export type LookupRequestSignals = CheckoutCreateRequestSignals;
 
-
-
-
 export const ActionsSchema = z.object({
-    "config": z.record(z.string(), z.any()).optional(),
-    "id": z.string().min(1),
+  config: z.record(z.string(), z.any()).optional(),
+  id: z.string().min(1),
 });
 export type Actions = z.infer<typeof ActionsSchema>;
 
 export const ItemResponseSchema = z.object({
-    "id": z.string(),
-    "image_url": z.string().optional(),
-    "price": z.number().int().gte(0),
-    "title": z.string(),
+  id: z.string(),
+  image_url: z.string().optional(),
+  price: z.number().int().gte(0),
+  title: z.string(),
 });
 export type ItemResponse = z.infer<typeof ItemResponseSchema>;
 
 export const TotalResponseSchema = z.object({
-    "amount": z.number().int(),
-    "display_text": z.string().optional(),
-    "type": z.string(),
+  amount: z.number().int(),
+  display_text: z.string().optional(),
+  type: z.string(),
 });
 export type TotalResponse = z.infer<typeof TotalResponseSchema>;
 
 export const CheckoutResponseLinkSchema = z.object({
-    "title": z.string().optional(),
-    "type": z.string(),
-    "url": z.string(),
+  title: z.string().optional(),
+  type: z.string(),
+  url: z.string(),
 });
 export type CheckoutResponseLink = z.infer<typeof CheckoutResponseLinkSchema>;
 export const ConsentLinkSchema = CheckoutResponseLinkSchema;
 export type ConsentLink = CheckoutResponseLink;
 
-
 export const CheckoutResponseMessageSchema = z.object({
-    "code": z.string().optional(),
-    "content": z.string(),
-    "content_type": ContentTypeSchema.optional(),
-    "path": z.string().optional(),
-    "severity": SeveritySchema.optional(),
-    "type": TypeSchema,
-    "image_url": z.string().optional(),
-    "presentation": z.string().optional(),
-    "url": z.string().optional(),
+  code: z.string().optional(),
+  content: z.string(),
+  content_type: ContentTypeSchema.optional(),
+  path: z.string().optional(),
+  severity: SeveritySchema.optional(),
+  type: TypeSchema,
+  image_url: z.string().optional(),
+  presentation: z.string().optional(),
+  url: z.string().optional(),
 });
-export type CheckoutResponseMessage = z.infer<typeof CheckoutResponseMessageSchema>;
+export type CheckoutResponseMessage = z.infer<
+  typeof CheckoutResponseMessageSchema
+>;
 export const LookupResponseMessageSchema = CheckoutResponseMessageSchema;
 export type LookupResponseMessage = CheckoutResponseMessage;
 
-
 export const OrderConfirmationSchema = z.object({
-    "id": z.string(),
-    "label": z.string().optional(),
-    "permalink_url": z.string(),
+  id: z.string(),
+  label: z.string().optional(),
+  permalink_url: z.string(),
 });
 export type OrderConfirmation = z.infer<typeof OrderConfirmationSchema>;
 
 export const DescriptionSchema = z.object({
-    "html": z.string().optional(),
-    "markdown": z.string().optional(),
-    "plain": z.string().optional(),
+  html: z.string().optional(),
+  markdown: z.string().optional(),
+  plain: z.string().optional(),
 });
 export type Description = z.infer<typeof DescriptionSchema>;
 
 export const LineSchema = z.object({
-    "amount": z.number().int(),
-    "display_text": z.string(),
+  amount: z.number().int(),
+  display_text: z.string(),
 });
 export type Line = z.infer<typeof LineSchema>;
 
 export const CapabilityResponseSchema = z.object({
-    "config": z.record(z.string(), z.any()).optional(),
-    "extends": z.string().optional(),
-    "name": z.string(),
-    "schema": z.string().optional(),
-    "spec": z.string().optional(),
-    "version": z.string(),
+  config: z.record(z.string(), z.any()).optional(),
+  extends: z.string().optional(),
+  name: z.string(),
+  schema: z.string().optional(),
+  spec: z.string().optional(),
+  version: z.string(),
 });
 export type CapabilityResponse = z.infer<typeof CapabilityResponseSchema>;
 
 export const LineItemQuantityRefSchema = z.object({
-    "id": z.string(),
-    "quantity": z.number(),
+  id: z.string(),
+  quantity: z.number(),
 });
 export type LineItemQuantityRef = z.infer<typeof LineItemQuantityRefSchema>;
 export const AdjustmentLineItemSchema = LineItemQuantityRefSchema;
@@ -299,228 +285,234 @@ export type EventLineItem = LineItemQuantityRef;
 export const ExpectationLineItemSchema = LineItemQuantityRefSchema;
 export type ExpectationLineItem = LineItemQuantityRef;
 
-
-
-
-
-
 export const QuantitySchema = z.object({
-    "fulfilled": z.number().int().gte(0),
-    "original": z.number().int().gte(0).optional(),
-    "total": z.number().int().gte(0),
+  fulfilled: z.number().int().gte(0),
+  original: z.number().int().gte(0).optional(),
+  total: z.number().int().gte(0),
 });
 export type Quantity = z.infer<typeof QuantitySchema>;
 
 export const PaymentInstrumentSchema = z.object({
-    "billing_address": PostalAddressSchema.optional(),
-    "credential": PaymentCredentialSchema.optional(),
-    "display": z.record(z.string(), z.any()).optional(),
-    "handler_id": z.string(),
-    "id": z.string(),
-    "type": z.string(),
+  billing_address: PostalAddressSchema.optional(),
+  credential: PaymentCredentialSchema.optional(),
+  display: z.record(z.string(), z.any()).optional(),
+  handler_id: z.string(),
+  id: z.string(),
+  type: z.string(),
 });
 export type PaymentInstrument = z.infer<typeof PaymentInstrumentSchema>;
 
 export const CompleteCheckoutRequestWithAp2Ap2Schema = z.object({
-    "checkout_mandate": z.string().regex(/^[A-Za-z0-9_-]+\.[A-Za-z0-9_-]*\.[A-Za-z0-9_-]+(~[A-Za-z0-9_-]+)*$/),
+  checkout_mandate: z
+    .string()
+    .regex(
+      /^[A-Za-z0-9_-]+\.[A-Za-z0-9_-]*\.[A-Za-z0-9_-]+(~[A-Za-z0-9_-]+)*$/
+    ),
 });
-export type CompleteCheckoutRequestWithAp2Ap2 = z.infer<typeof CompleteCheckoutRequestWithAp2Ap2Schema>;
+export type CompleteCheckoutRequestWithAp2Ap2 = z.infer<
+  typeof CompleteCheckoutRequestWithAp2Ap2Schema
+>;
 
 export const CheckoutWithAp2MandateAp2Schema = z.object({
-    "merchant_authorization": z.string().regex(/^[A-Za-z0-9_-]+\.\.[A-Za-z0-9_-]+$/).optional(),
-    "checkout_mandate": z.string().regex(/^[A-Za-z0-9_-]+\.[A-Za-z0-9_-]*\.[A-Za-z0-9_-]+(~[A-Za-z0-9_-]+)*$/),
+  merchant_authorization: z
+    .string()
+    .regex(/^[A-Za-z0-9_-]+\.\.[A-Za-z0-9_-]+$/)
+    .optional(),
+  checkout_mandate: z
+    .string()
+    .regex(
+      /^[A-Za-z0-9_-]+\.[A-Za-z0-9_-]*\.[A-Za-z0-9_-]+(~[A-Za-z0-9_-]+)*$/
+    ),
 });
-export type CheckoutWithAp2MandateAp2 = z.infer<typeof CheckoutWithAp2MandateAp2Schema>;
+export type CheckoutWithAp2MandateAp2 = z.infer<
+  typeof CheckoutWithAp2MandateAp2Schema
+>;
 
 export const SegmentValueSchema = z.object({
-    "granted": z.boolean(),
-    "source": SourceSchema,
+  granted: z.boolean(),
+  source: SourceSchema,
 });
 export type SegmentValue = z.infer<typeof SegmentValueSchema>;
 export const SegmentClassSchema = SegmentValueSchema;
 export type SegmentClass = SegmentValue;
 
-
-
-
-
-
 export const ConsentSegmentSchema = z.object({
-    "description": z.string(),
-    "granted": z.boolean(),
-    "links": z.array(ConsentLinkSchema).optional(),
-    "source": SourceSchema,
+  description: z.string(),
+  granted: z.boolean(),
+  links: z.array(ConsentLinkSchema).optional(),
+  source: SourceSchema,
 });
 export type ConsentSegment = z.infer<typeof ConsentSegmentSchema>;
 
 export const CheckoutWithDiscountCreateRequestDiscountsSchema = z.object({
-    "codes": z.array(z.string()).optional(),
+  codes: z.array(z.string()).optional(),
 });
-export type CheckoutWithDiscountCreateRequestDiscounts = z.infer<typeof CheckoutWithDiscountCreateRequestDiscountsSchema>;
-export const CheckoutWithDiscountUpdateRequestDiscountsSchema = CheckoutWithDiscountCreateRequestDiscountsSchema;
-export type CheckoutWithDiscountUpdateRequestDiscounts = CheckoutWithDiscountCreateRequestDiscounts;
-
-
-
+export type CheckoutWithDiscountCreateRequestDiscounts = z.infer<
+  typeof CheckoutWithDiscountCreateRequestDiscountsSchema
+>;
+export const CheckoutWithDiscountUpdateRequestDiscountsSchema =
+  CheckoutWithDiscountCreateRequestDiscountsSchema;
+export type CheckoutWithDiscountUpdateRequestDiscounts =
+  CheckoutWithDiscountCreateRequestDiscounts;
 
 export const AllocationElementSchema = z.object({
-    "amount": z.number().int().gte(0),
-    "path": z.string(),
+  amount: z.number().int().gte(0),
+  path: z.string(),
 });
 export type AllocationElement = z.infer<typeof AllocationElementSchema>;
 
 export const FulfillmentDestinationRequestSchema = z.object({
-    "address_country": z.string().optional(),
-    "address_locality": z.string().optional(),
-    "address_region": z.string().optional(),
-    "extended_address": z.string().optional(),
-    "first_name": z.string().optional(),
-    "last_name": z.string().optional(),
-    "phone_number": z.string().optional(),
-    "postal_code": z.string().optional(),
-    "street_address": z.string().optional(),
-    "id": z.string().optional(),
-    "address": PostalAddressSchema.optional(),
-    "name": z.string().optional(),
+  address_country: z.string().optional(),
+  address_locality: z.string().optional(),
+  address_region: z.string().optional(),
+  extended_address: z.string().optional(),
+  first_name: z.string().optional(),
+  last_name: z.string().optional(),
+  phone_number: z.string().optional(),
+  postal_code: z.string().optional(),
+  street_address: z.string().optional(),
+  id: z.string().optional(),
+  address: PostalAddressSchema.optional(),
+  name: z.string().optional(),
 });
-export type FulfillmentDestinationRequest = z.infer<typeof FulfillmentDestinationRequestSchema>;
+export type FulfillmentDestinationRequest = z.infer<
+  typeof FulfillmentDestinationRequestSchema
+>;
 
 export const FulfillmentOptionSchema = z.object({
-    "description": DescriptionSchema.optional(),
-    "id": z.string(),
-    "title": z.string(),
-    "carrier": z.string().optional(),
-    "earliest_fulfillment_time": z.coerce.date().optional(),
-    "latest_fulfillment_time": z.coerce.date().optional(),
-    "totals": z.array(TotalResponseSchema),
+  description: DescriptionSchema.optional(),
+  id: z.string(),
+  title: z.string(),
+  carrier: z.string().optional(),
+  earliest_fulfillment_time: z.coerce.date().optional(),
+  latest_fulfillment_time: z.coerce.date().optional(),
+  totals: z.array(TotalResponseSchema),
 });
 export type FulfillmentOption = z.infer<typeof FulfillmentOptionSchema>;
 
 export const FulfillmentAvailableMethodSchema = z.object({
-    "description": z.string().optional(),
-    "fulfillable_on": z.union([z.null(), z.string()]).optional(),
-    "line_item_ids": z.array(z.string()),
-    "type": z.string(),
+  description: z.string().optional(),
+  fulfillable_on: z.union([z.null(), z.string()]).optional(),
+  line_item_ids: z.array(z.string()),
+  type: z.string(),
 });
-export type FulfillmentAvailableMethod = z.infer<typeof FulfillmentAvailableMethodSchema>;
+export type FulfillmentAvailableMethod = z.infer<
+  typeof FulfillmentAvailableMethodSchema
+>;
 
 export const FulfillmentDestinationResponseSchema = z.object({
-    "address_country": z.string().optional(),
-    "address_locality": z.string().optional(),
-    "address_region": z.string().optional(),
-    "extended_address": z.string().optional(),
-    "first_name": z.string().optional(),
-    "last_name": z.string().optional(),
-    "phone_number": z.string().optional(),
-    "postal_code": z.string().optional(),
-    "street_address": z.string().optional(),
-    "id": z.string(),
-    "address": PostalAddressSchema.optional(),
-    "name": z.string().optional(),
+  address_country: z.string().optional(),
+  address_locality: z.string().optional(),
+  address_region: z.string().optional(),
+  extended_address: z.string().optional(),
+  first_name: z.string().optional(),
+  last_name: z.string().optional(),
+  phone_number: z.string().optional(),
+  postal_code: z.string().optional(),
+  street_address: z.string().optional(),
+  id: z.string(),
+  address: PostalAddressSchema.optional(),
+  name: z.string().optional(),
 });
-export type FulfillmentDestinationResponse = z.infer<typeof FulfillmentDestinationResponseSchema>;
-
-
+export type FulfillmentDestinationResponse = z.infer<
+  typeof FulfillmentDestinationResponseSchema
+>;
 
 export const PriceFilterSchema = z.object({
-    "max": z.number().optional(),
-    "min": z.number().optional(),
+  max: z.number().optional(),
+  min: z.number().optional(),
 });
 export type PriceFilter = z.infer<typeof PriceFilterSchema>;
 
-
-
-
-
 export const LookupResponsePolicySchema = z.object({
-    "applies_to": z.array(z.string()).optional(),
-    "description": DescriptionSchema,
-    "type": z.string().regex(/^[a-z](?:[a-z0-9-]*[a-z0-9])?(?:\.[a-z0-9](?:[a-z0-9_-]*[a-z0-9_])?)+$/),
-    "url": z.string().optional(),
+  applies_to: z.array(z.string()).optional(),
+  description: DescriptionSchema,
+  type: z
+    .string()
+    .regex(
+      /^[a-z](?:[a-z0-9-]*[a-z0-9])?(?:\.[a-z0-9](?:[a-z0-9_-]*[a-z0-9_])?)+$/
+    ),
+  url: z.string().optional(),
 });
 export type LookupResponsePolicy = z.infer<typeof LookupResponsePolicySchema>;
 export const CheckoutResponsePolicySchema = LookupResponsePolicySchema;
 export type CheckoutResponsePolicy = LookupResponsePolicy;
 
-
 export const CategorySchema = z.object({
-    "taxonomy": z.string().optional(),
-    "value": z.string(),
+  taxonomy: z.string().optional(),
+  value: z.string(),
 });
 export type Category = z.infer<typeof CategorySchema>;
 
 export const PriceSchema = z.object({
-    "amount": z.number().int().gte(0),
-    "currency": z.string().regex(/^[A-Z]{3}$/),
+  amount: z.number().int().gte(0),
+  currency: z.string().regex(/^[A-Z]{3}$/),
 });
 export type Price = z.infer<typeof PriceSchema>;
 
 export const MediaSchema = z.object({
-    "alt_text": z.string().optional(),
-    "height": z.number().int().gte(1).optional(),
-    "type": z.string(),
-    "url": z.string(),
-    "width": z.number().int().gte(1).optional(),
+  alt_text: z.string().optional(),
+  height: z.number().int().gte(1).optional(),
+  type: z.string(),
+  url: z.string(),
+  width: z.number().int().gte(1).optional(),
 });
 export type Media = z.infer<typeof MediaSchema>;
 
 export const OptionValueSchema = z.object({
-    "id": z.string().optional(),
-    "label": z.string(),
+  id: z.string().optional(),
+  label: z.string(),
 });
 export type OptionValue = z.infer<typeof OptionValueSchema>;
 
 export const RatingSchema = z.object({
-    "count": z.number().int().gte(0).optional(),
-    "scale_max": z.number().gte(1),
-    "scale_min": z.number().gte(0).optional(),
-    "value": z.number().gte(0),
+  count: z.number().int().gte(0).optional(),
+  scale_max: z.number().gte(1),
+  scale_min: z.number().gte(0).optional(),
+  value: z.number().gte(0),
 });
 export type Rating = z.infer<typeof RatingSchema>;
 
 export const AvailabilitySchema = z.object({
-    "available": z.boolean().optional(),
-    "status": z.string().optional(),
+  available: z.boolean().optional(),
+  status: z.string().optional(),
 });
 export type Availability = z.infer<typeof AvailabilitySchema>;
 
 export const PurpleBarcodeSchema = z.object({
-    "type": z.string(),
-    "value": z.string(),
+  type: z.string(),
+  value: z.string(),
 });
 export type PurpleBarcode = z.infer<typeof PurpleBarcodeSchema>;
 export const FluffyBarcodeSchema = PurpleBarcodeSchema;
 export type FluffyBarcode = PurpleBarcode;
 
-
 export const InputCorrelationSchema = z.object({
-    "id": z.string(),
-    "match": z.string().optional(),
+  id: z.string(),
+  match: z.string().optional(),
 });
 export type InputCorrelation = z.infer<typeof InputCorrelationSchema>;
 
 export const OptionElementSchema = z.object({
-    "id": z.string().optional(),
-    "label": z.string(),
-    "name": z.string(),
+  id: z.string().optional(),
+  label: z.string(),
+  name: z.string(),
 });
 export type OptionElement = z.infer<typeof OptionElementSchema>;
 export const SelectedElementSchema = OptionElementSchema;
 export type SelectedElement = OptionElement;
 
-
 export const PurpleSellerSchema = z.object({
-    "links": z.array(CheckoutResponseLinkSchema).optional(),
-    "name": z.string().optional(),
+  links: z.array(CheckoutResponseLinkSchema).optional(),
+  name: z.string().optional(),
 });
 export type PurpleSeller = z.infer<typeof PurpleSellerSchema>;
 export const FluffySellerSchema = PurpleSellerSchema;
 export type FluffySeller = PurpleSeller;
 
-
 export const PurpleMeasureSchema = z.object({
-    "unit": z.string(),
-    "value": z.number().int(),
+  unit: z.string(),
+  value: z.number().int(),
 });
 export type PurpleMeasure = z.infer<typeof PurpleMeasureSchema>;
 export const FluffyMeasureSchema = PurpleMeasureSchema;
@@ -530,89 +522,85 @@ export type FluffyReference = PurpleMeasure;
 export const PurpleReferenceSchema = PurpleMeasureSchema;
 export type PurpleReference = PurpleMeasure;
 
-
-
-
-
-
-
-
-
-
-
-
-
-
 export const SearchRequestPaginationSchema = z.object({
-    "cursor": z.string().optional(),
-    "limit": z.number().int().gte(1).optional(),
+  cursor: z.string().optional(),
+  limit: z.number().int().gte(1).optional(),
 });
-export type SearchRequestPagination = z.infer<typeof SearchRequestPaginationSchema>;
+export type SearchRequestPagination = z.infer<
+  typeof SearchRequestPaginationSchema
+>;
 
 export const SearchResponsePaginationSchema = z.object({
-    "cursor": z.string().optional(),
-    "has_next_page": z.boolean(),
-    "total_count": z.number().int().gte(0).optional(),
+  cursor: z.string().optional(),
+  has_next_page: z.boolean(),
+  total_count: z.number().int().gte(0).optional(),
 });
-export type SearchResponsePagination = z.infer<typeof SearchResponsePaginationSchema>;
+export type SearchResponsePagination = z.infer<
+  typeof SearchResponsePaginationSchema
+>;
 
 export const UcpDiscoveryProfilePaymentSchema = z.object({
-    "handlers": z.array(PaymentHandlerResponseSchema).optional(),
+  handlers: z.array(PaymentHandlerResponseSchema).optional(),
 });
-export type UcpDiscoveryProfilePayment = z.infer<typeof UcpDiscoveryProfilePaymentSchema>;
+export type UcpDiscoveryProfilePayment = z.infer<
+  typeof UcpDiscoveryProfilePaymentSchema
+>;
 
 export const UcpServiceSchema = z.object({
-    "a2a": A2ASchema.optional(),
-    "embedded": EmbeddedSchema.optional(),
-    "mcp": McpSchema.optional(),
-    "rest": RestSchema.optional(),
-    "spec": z.string(),
-    "version": z.string(),
+  a2a: A2ASchema.optional(),
+  embedded: EmbeddedSchema.optional(),
+  mcp: McpSchema.optional(),
+  rest: RestSchema.optional(),
+  spec: z.string(),
+  version: z.string(),
 });
 export type UcpService = z.infer<typeof UcpServiceSchema>;
 
 export const CheckoutCreateRequestContextSchema = z.object({
-    "address_country": z.string().optional(),
-    "address_region": z.string().optional(),
-    "postal_code": z.string().optional(),
-    "currency": z.string().optional(),
-    "eligibility": z.array(z.string()).optional(),
-    "intent": z.string().optional(),
-    "language": z.string().optional(),
-    "payment": z.array(PurplePaymentSchema).optional(),
+  address_country: z.string().optional(),
+  address_region: z.string().optional(),
+  postal_code: z.string().optional(),
+  currency: z.string().optional(),
+  eligibility: z.array(z.string()).optional(),
+  intent: z.string().optional(),
+  language: z.string().optional(),
+  payment: z.array(PurplePaymentSchema).optional(),
 });
-export type CheckoutCreateRequestContext = z.infer<typeof CheckoutCreateRequestContextSchema>;
+export type CheckoutCreateRequestContext = z.infer<
+  typeof CheckoutCreateRequestContextSchema
+>;
 export const LookupRequestContextSchema = CheckoutCreateRequestContextSchema;
 export type LookupRequestContext = CheckoutCreateRequestContext;
 
-
 export const LineItemCreateRequestSchema = z.object({
-    "item": ItemCreateRequestSchema,
-    "quantity": z.number(),
+  item: ItemCreateRequestSchema,
+  quantity: z.number(),
 });
 export type LineItemCreateRequest = z.infer<typeof LineItemCreateRequestSchema>;
 
 export const SelectedPaymentInstrumentSchema = z.object({
-    "billing_address": PostalAddressSchema.optional(),
-    "credential": PaymentCredentialSchema.optional(),
-    "display": z.record(z.string(), z.any()).optional(),
-    "handler_id": z.string(),
-    "id": z.string(),
-    "type": z.string(),
-    "selected": z.boolean().optional(),
+  billing_address: PostalAddressSchema.optional(),
+  credential: PaymentCredentialSchema.optional(),
+  display: z.record(z.string(), z.any()).optional(),
+  handler_id: z.string(),
+  id: z.string(),
+  type: z.string(),
+  selected: z.boolean().optional(),
 });
-export type SelectedPaymentInstrument = z.infer<typeof SelectedPaymentInstrumentSchema>;
+export type SelectedPaymentInstrument = z.infer<
+  typeof SelectedPaymentInstrumentSchema
+>;
 
 export const LineItemUpdateRequestSchema = z.object({
-    "id": z.string().optional(),
-    "item": ItemUpdateRequestSchema,
-    "parent_id": z.string().optional(),
-    "quantity": z.number(),
+  id: z.string().optional(),
+  item: ItemUpdateRequestSchema,
+  parent_id: z.string().optional(),
+  quantity: z.number(),
 });
 export type LineItemUpdateRequest = z.infer<typeof LineItemUpdateRequestSchema>;
 
 export const PaymentSelectionSchema = z.object({
-    "instruments": z.array(SelectedPaymentInstrumentSchema).optional(),
+  instruments: z.array(SelectedPaymentInstrumentSchema).optional(),
 });
 export type PaymentSelection = z.infer<typeof PaymentSelectionSchema>;
 export const PaymentCompleteRequestSchema = PaymentSelectionSchema;
@@ -624,701 +612,728 @@ export type PaymentResponse = PaymentSelection;
 export const PaymentUpdateRequestSchema = PaymentSelectionSchema;
 export type PaymentUpdateRequest = PaymentSelection;
 
-
-
-
 export const LineItemResponseSchema = z.object({
-    "id": z.string(),
-    "item": ItemResponseSchema,
-    "parent_id": z.string().optional(),
-    "quantity": z.number().int().gte(1),
-    "totals": z.array(TotalResponseSchema),
+  id: z.string(),
+  item: ItemResponseSchema,
+  parent_id: z.string().optional(),
+  quantity: z.number().int().gte(1),
+  totals: z.array(TotalResponseSchema),
 });
 export type LineItemResponse = z.infer<typeof LineItemResponseSchema>;
 
-
-
-
-
 export const TotalsResponseSchema = z.object({
-    "amount": z.number().int(),
-    "display_text": z.string().optional(),
-    "type": z.string(),
-    "lines": z.array(LineSchema).optional(),
+  amount: z.number().int(),
+  display_text: z.string().optional(),
+  type: z.string(),
+  lines: z.array(LineSchema).optional(),
 });
 export type TotalsResponse = z.infer<typeof TotalsResponseSchema>;
 
 export const UcpResponseSchema = z.object({
-    "capabilities": z.record(z.string(), z.array(CapabilityResponseSchema)),
-    "version": z.string(),
+  capabilities: z.record(z.string(), z.array(CapabilityResponseSchema)),
+  version: z.string(),
 });
 export type UcpResponse = z.infer<typeof UcpResponseSchema>;
 
 export const AdjustmentSchema = z.object({
-    "description": z.string().optional(),
-    "id": z.string(),
-    "line_items": z.array(AdjustmentLineItemSchema).optional(),
-    "occurred_at": z.coerce.date(),
-    "status": AdjustmentStatusSchema,
-    "totals": z.array(TotalResponseSchema).optional(),
-    "type": z.string(),
+  description: z.string().optional(),
+  id: z.string(),
+  line_items: z.array(AdjustmentLineItemSchema).optional(),
+  occurred_at: z.coerce.date(),
+  status: AdjustmentStatusSchema,
+  totals: z.array(TotalResponseSchema).optional(),
+  type: z.string(),
 });
 export type Adjustment = z.infer<typeof AdjustmentSchema>;
 
 export const FulfillmentEventSchema = z.object({
-    "carrier": z.string().optional(),
-    "description": z.string().optional(),
-    "id": z.string(),
-    "line_items": z.array(EventLineItemSchema),
-    "occurred_at": z.coerce.date(),
-    "tracking_number": z.string().optional(),
-    "tracking_url": z.string().optional(),
-    "type": z.string(),
+  carrier: z.string().optional(),
+  description: z.string().optional(),
+  id: z.string(),
+  line_items: z.array(EventLineItemSchema),
+  occurred_at: z.coerce.date(),
+  tracking_number: z.string().optional(),
+  tracking_url: z.string().optional(),
+  type: z.string(),
 });
 export type FulfillmentEvent = z.infer<typeof FulfillmentEventSchema>;
 
 export const ExpectationSchema = z.object({
-    "description": z.string().optional(),
-    "destination": PostalAddressSchema,
-    "fulfillable_on": z.string().optional(),
-    "id": z.string(),
-    "line_items": z.array(ExpectationLineItemSchema),
-    "method_type": z.string(),
+  description: z.string().optional(),
+  destination: PostalAddressSchema,
+  fulfillable_on: z.string().optional(),
+  id: z.string(),
+  line_items: z.array(ExpectationLineItemSchema),
+  method_type: z.string(),
 });
 export type Expectation = z.infer<typeof ExpectationSchema>;
 
 export const OrderLineItemSchema = z.object({
-    "id": z.string(),
-    "item": ItemResponseSchema,
-    "parent_id": z.string().optional(),
-    "quantity": QuantitySchema,
-    "status": LineItemStatusSchema,
-    "totals": z.array(TotalResponseSchema),
+  id: z.string(),
+  item: ItemResponseSchema,
+  parent_id: z.string().optional(),
+  quantity: QuantitySchema,
+  status: LineItemStatusSchema,
+  totals: z.array(TotalResponseSchema),
 });
 export type OrderLineItem = z.infer<typeof OrderLineItemSchema>;
 
 export const PaymentDataSchema = z.object({
-    "payment_data": PaymentInstrumentSchema,
+  payment_data: PaymentInstrumentSchema,
 });
 export type PaymentData = z.infer<typeof PaymentDataSchema>;
 
 export const CompleteCheckoutRequestWithAp2Schema = z.object({
-    "ap2": CompleteCheckoutRequestWithAp2Ap2Schema.optional(),
+  ap2: CompleteCheckoutRequestWithAp2Ap2Schema.optional(),
 });
-export type CompleteCheckoutRequestWithAp2 = z.infer<typeof CompleteCheckoutRequestWithAp2Schema>;
+export type CompleteCheckoutRequestWithAp2 = z.infer<
+  typeof CompleteCheckoutRequestWithAp2Schema
+>;
 
 export const CheckoutWithAp2MandateSchema = z.object({
-    "actions": z.record(z.string(), z.array(ActionsSchema)).optional(),
-    "attribution": z.record(z.string(), z.string()).optional(),
-    "buyer": BuyerSchema.optional(),
-    "context": CheckoutCreateRequestContextSchema.optional(),
-    "continue_url": z.string().optional(),
-    "currency": z.string(),
-    "expires_at": z.coerce.date().optional(),
-    "id": z.string(),
-    "line_items": z.array(LineItemResponseSchema),
-    "links": z.array(CheckoutResponseLinkSchema),
-    "messages": z.array(CheckoutResponseMessageSchema).optional(),
-    "order": OrderConfirmationSchema.optional(),
-    "payment": PaymentResponseSchema.optional(),
-    "policies": z.array(CheckoutResponsePolicySchema).optional(),
-    "signals": CheckoutCreateRequestSignalsSchema.optional(),
-    "status": CheckoutResponseStatusSchema,
-    "totals": z.array(TotalsResponseSchema),
-    "ucp": UcpResponseSchema,
-    "ap2": CheckoutWithAp2MandateAp2Schema.optional(),
+  actions: z.record(z.string(), z.array(ActionsSchema)).optional(),
+  attribution: z.record(z.string(), z.string()).optional(),
+  buyer: BuyerSchema.optional(),
+  context: CheckoutCreateRequestContextSchema.optional(),
+  continue_url: z.string().optional(),
+  currency: z.string(),
+  expires_at: z.coerce.date().optional(),
+  id: z.string(),
+  line_items: z.array(LineItemResponseSchema),
+  links: z.array(CheckoutResponseLinkSchema),
+  messages: z.array(CheckoutResponseMessageSchema).optional(),
+  order: OrderConfirmationSchema.optional(),
+  payment: PaymentResponseSchema.optional(),
+  policies: z.array(CheckoutResponsePolicySchema).optional(),
+  signals: CheckoutCreateRequestSignalsSchema.optional(),
+  status: CheckoutResponseStatusSchema,
+  totals: z.array(TotalsResponseSchema),
+  ucp: UcpResponseSchema,
+  ap2: CheckoutWithAp2MandateAp2Schema.optional(),
 });
-export type CheckoutWithAp2Mandate = z.infer<typeof CheckoutWithAp2MandateSchema>;
+export type CheckoutWithAp2Mandate = z.infer<
+  typeof CheckoutWithAp2MandateSchema
+>;
 
 export const ConsentValueSchema = z.object({
-    "granted": z.boolean(),
-    "segments": z.record(z.string(), SegmentValueSchema).optional(),
-    "source": SourceSchema,
+  granted: z.boolean(),
+  segments: z.record(z.string(), SegmentValueSchema).optional(),
+  source: SourceSchema,
 });
 export type ConsentValue = z.infer<typeof ConsentValueSchema>;
 export const ConsentClassSchema = ConsentValueSchema;
 export type ConsentClass = ConsentValue;
 
-
-
-
 export const BuyerConsentSchema = z.object({
-    "description": z.string(),
-    "granted": z.boolean(),
-    "links": z.array(ConsentLinkSchema).optional(),
-    "segments": z.record(z.string(), ConsentSegmentSchema).optional(),
-    "source": SourceSchema,
+  description: z.string(),
+  granted: z.boolean(),
+  links: z.array(ConsentLinkSchema).optional(),
+  segments: z.record(z.string(), ConsentSegmentSchema).optional(),
+  source: SourceSchema,
 });
 export type BuyerConsent = z.infer<typeof BuyerConsentSchema>;
 
 export const CheckoutWithDiscountUpdateRequestSchema = z.object({
-    "attribution": z.record(z.string(), z.string()).optional(),
-    "buyer": BuyerSchema.optional(),
-    "context": CheckoutCreateRequestContextSchema.optional(),
-    "line_items": z.array(LineItemUpdateRequestSchema),
-    "payment": PaymentUpdateRequestSchema.optional(),
-    "signals": CheckoutCreateRequestSignalsSchema.optional(),
-    "discounts": CheckoutWithDiscountUpdateRequestDiscountsSchema.optional(),
+  attribution: z.record(z.string(), z.string()).optional(),
+  buyer: BuyerSchema.optional(),
+  context: CheckoutCreateRequestContextSchema.optional(),
+  line_items: z.array(LineItemUpdateRequestSchema),
+  payment: PaymentUpdateRequestSchema.optional(),
+  signals: CheckoutCreateRequestSignalsSchema.optional(),
+  discounts: CheckoutWithDiscountUpdateRequestDiscountsSchema.optional(),
 });
-export type CheckoutWithDiscountUpdateRequest = z.infer<typeof CheckoutWithDiscountUpdateRequestSchema>;
+export type CheckoutWithDiscountUpdateRequest = z.infer<
+  typeof CheckoutWithDiscountUpdateRequestSchema
+>;
 
 export const AppliedElementSchema = z.object({
-    "allocations": z.array(AllocationElementSchema).optional(),
-    "amount": z.number().int().gte(0),
-    "automatic": z.boolean().optional(),
-    "code": z.string().optional(),
-    "eligibility": z.string().regex(/^[a-z](?:[a-z0-9-]*[a-z0-9])?(?:\.[a-z0-9](?:[a-z0-9_-]*[a-z0-9_])?)+$/).optional(),
-    "method": MethodSchema.optional(),
-    "priority": z.number().int().gte(1).optional(),
-    "provisional": z.boolean().optional(),
-    "title": z.string(),
+  allocations: z.array(AllocationElementSchema).optional(),
+  amount: z.number().int().gte(0),
+  automatic: z.boolean().optional(),
+  code: z.string().optional(),
+  eligibility: z
+    .string()
+    .regex(
+      /^[a-z](?:[a-z0-9-]*[a-z0-9])?(?:\.[a-z0-9](?:[a-z0-9_-]*[a-z0-9_])?)+$/
+    )
+    .optional(),
+  method: MethodSchema.optional(),
+  priority: z.number().int().gte(1).optional(),
+  provisional: z.boolean().optional(),
+  title: z.string(),
 });
 export type AppliedElement = z.infer<typeof AppliedElementSchema>;
 
 export const FulfillmentGroupSchema = z.object({
-    "id": z.string(),
-    "line_item_ids": z.array(z.string()),
-    "options": z.array(FulfillmentOptionSchema).optional(),
-    "selected_option_id": z.union([z.null(), z.string()]).optional(),
+  id: z.string(),
+  line_item_ids: z.array(z.string()),
+  options: z.array(FulfillmentOptionSchema).optional(),
+  selected_option_id: z.union([z.null(), z.string()]).optional(),
 });
 export type FulfillmentGroup = z.infer<typeof FulfillmentGroupSchema>;
 
 export const FulfillmentMethodResponseSchema = z.object({
-    "destinations": z.array(FulfillmentDestinationResponseSchema).optional(),
-    "groups": z.array(FulfillmentGroupSchema).optional(),
-    "id": z.string(),
-    "line_item_ids": z.array(z.string()),
-    "selected_destination_id": z.union([z.null(), z.string()]).optional(),
-    "type": z.string(),
+  destinations: z.array(FulfillmentDestinationResponseSchema).optional(),
+  groups: z.array(FulfillmentGroupSchema).optional(),
+  id: z.string(),
+  line_item_ids: z.array(z.string()),
+  selected_destination_id: z.union([z.null(), z.string()]).optional(),
+  type: z.string(),
 });
-export type FulfillmentMethodResponse = z.infer<typeof FulfillmentMethodResponseSchema>;
+export type FulfillmentMethodResponse = z.infer<
+  typeof FulfillmentMethodResponseSchema
+>;
 
 export const CartCreateRequestSchema = z.object({
-    "attribution": z.record(z.string(), z.string()).optional(),
-    "buyer": BuyerSchema.optional(),
-    "context": CheckoutCreateRequestContextSchema.optional(),
-    "line_items": z.array(LineItemCreateRequestSchema),
-    "signals": CheckoutCreateRequestSignalsSchema.optional(),
+  attribution: z.record(z.string(), z.string()).optional(),
+  buyer: BuyerSchema.optional(),
+  context: CheckoutCreateRequestContextSchema.optional(),
+  line_items: z.array(LineItemCreateRequestSchema),
+  signals: CheckoutCreateRequestSignalsSchema.optional(),
 });
 export type CartCreateRequest = z.infer<typeof CartCreateRequestSchema>;
 
 export const CartUpdateRequestSchema = z.object({
-    "attribution": z.record(z.string(), z.string()).optional(),
-    "buyer": BuyerSchema.optional(),
-    "context": CheckoutCreateRequestContextSchema.optional(),
-    "id": z.string(),
-    "line_items": z.array(LineItemUpdateRequestSchema),
-    "signals": CheckoutCreateRequestSignalsSchema.optional(),
+  attribution: z.record(z.string(), z.string()).optional(),
+  buyer: BuyerSchema.optional(),
+  context: CheckoutCreateRequestContextSchema.optional(),
+  id: z.string(),
+  line_items: z.array(LineItemUpdateRequestSchema),
+  signals: CheckoutCreateRequestSignalsSchema.optional(),
 });
 export type CartUpdateRequest = z.infer<typeof CartUpdateRequestSchema>;
 
 export const CartResponseSchema = z.object({
-    "actions": z.record(z.string(), z.array(ActionsSchema)).optional(),
-    "attribution": z.record(z.string(), z.string()).optional(),
-    "buyer": BuyerSchema.optional(),
-    "context": CheckoutCreateRequestContextSchema.optional(),
-    "continue_url": z.string().optional(),
-    "currency": z.string(),
-    "expires_at": z.coerce.date().optional(),
-    "id": z.string(),
-    "line_items": z.array(LineItemResponseSchema),
-    "links": z.array(CheckoutResponseLinkSchema).optional(),
-    "messages": z.array(CheckoutResponseMessageSchema).optional(),
-    "policies": z.array(CheckoutResponsePolicySchema).optional(),
-    "signals": CheckoutCreateRequestSignalsSchema.optional(),
-    "totals": z.array(TotalsResponseSchema),
-    "ucp": UcpResponseSchema,
+  actions: z.record(z.string(), z.array(ActionsSchema)).optional(),
+  attribution: z.record(z.string(), z.string()).optional(),
+  buyer: BuyerSchema.optional(),
+  context: CheckoutCreateRequestContextSchema.optional(),
+  continue_url: z.string().optional(),
+  currency: z.string(),
+  expires_at: z.coerce.date().optional(),
+  id: z.string(),
+  line_items: z.array(LineItemResponseSchema),
+  links: z.array(CheckoutResponseLinkSchema).optional(),
+  messages: z.array(CheckoutResponseMessageSchema).optional(),
+  policies: z.array(CheckoutResponsePolicySchema).optional(),
+  signals: CheckoutCreateRequestSignalsSchema.optional(),
+  totals: z.array(TotalsResponseSchema),
+  ucp: UcpResponseSchema,
 });
 export type CartResponse = z.infer<typeof CartResponseSchema>;
 
 export const CheckoutWithCartUpdateRequestSchema = z.object({
-    "attribution": z.record(z.string(), z.string()).optional(),
-    "buyer": BuyerSchema.optional(),
-    "context": CheckoutCreateRequestContextSchema.optional(),
-    "line_items": z.array(LineItemUpdateRequestSchema),
-    "payment": PaymentUpdateRequestSchema.optional(),
-    "signals": CheckoutCreateRequestSignalsSchema.optional(),
+  attribution: z.record(z.string(), z.string()).optional(),
+  buyer: BuyerSchema.optional(),
+  context: CheckoutCreateRequestContextSchema.optional(),
+  line_items: z.array(LineItemUpdateRequestSchema),
+  payment: PaymentUpdateRequestSchema.optional(),
+  signals: CheckoutCreateRequestSignalsSchema.optional(),
 });
-export type CheckoutWithCartUpdateRequest = z.infer<typeof CheckoutWithCartUpdateRequestSchema>;
+export type CheckoutWithCartUpdateRequest = z.infer<
+  typeof CheckoutWithCartUpdateRequestSchema
+>;
 export const CheckoutUpdateRequestSchema = CheckoutWithCartUpdateRequestSchema;
 export type CheckoutUpdateRequest = CheckoutWithCartUpdateRequest;
 
-
 export const CheckoutWithCartResponseSchema = z.object({
-    "actions": z.record(z.string(), z.array(ActionsSchema)).optional(),
-    "attribution": z.record(z.string(), z.string()).optional(),
-    "buyer": BuyerSchema.optional(),
-    "context": CheckoutCreateRequestContextSchema.optional(),
-    "continue_url": z.string().optional(),
-    "currency": z.string(),
-    "expires_at": z.coerce.date().optional(),
-    "id": z.string(),
-    "line_items": z.array(LineItemResponseSchema),
-    "links": z.array(CheckoutResponseLinkSchema),
-    "messages": z.array(CheckoutResponseMessageSchema).optional(),
-    "order": OrderConfirmationSchema.optional(),
-    "payment": PaymentResponseSchema.optional(),
-    "policies": z.array(CheckoutResponsePolicySchema).optional(),
-    "signals": CheckoutCreateRequestSignalsSchema.optional(),
-    "status": CheckoutResponseStatusSchema,
-    "totals": z.array(TotalsResponseSchema),
-    "ucp": UcpResponseSchema,
-    "cart_id": z.string().optional(),
+  actions: z.record(z.string(), z.array(ActionsSchema)).optional(),
+  attribution: z.record(z.string(), z.string()).optional(),
+  buyer: BuyerSchema.optional(),
+  context: CheckoutCreateRequestContextSchema.optional(),
+  continue_url: z.string().optional(),
+  currency: z.string(),
+  expires_at: z.coerce.date().optional(),
+  id: z.string(),
+  line_items: z.array(LineItemResponseSchema),
+  links: z.array(CheckoutResponseLinkSchema),
+  messages: z.array(CheckoutResponseMessageSchema).optional(),
+  order: OrderConfirmationSchema.optional(),
+  payment: PaymentResponseSchema.optional(),
+  policies: z.array(CheckoutResponsePolicySchema).optional(),
+  signals: CheckoutCreateRequestSignalsSchema.optional(),
+  status: CheckoutResponseStatusSchema,
+  totals: z.array(TotalsResponseSchema),
+  ucp: UcpResponseSchema,
+  cart_id: z.string().optional(),
 });
-export type CheckoutWithCartResponse = z.infer<typeof CheckoutWithCartResponseSchema>;
-
-
+export type CheckoutWithCartResponse = z.infer<
+  typeof CheckoutWithCartResponseSchema
+>;
 
 export const SearchFiltersSchema = z.object({
-    "categories": z.array(z.string()).optional(),
-    "price": PriceFilterSchema.optional(),
+  categories: z.array(z.string()).optional(),
+  price: PriceFilterSchema.optional(),
 });
 export type SearchFilters = z.infer<typeof SearchFiltersSchema>;
 
 export const PriceRangeSchema = z.object({
-    "max": PriceSchema,
-    "min": PriceSchema,
+  max: PriceSchema,
+  min: PriceSchema,
 });
 export type PriceRange = z.infer<typeof PriceRangeSchema>;
 
 export const ProductOptionSchema = z.object({
-    "name": z.string(),
-    "values": z.array(OptionValueSchema).min(1),
+  name: z.string(),
+  values: z.array(OptionValueSchema).min(1),
 });
 export type ProductOption = z.infer<typeof ProductOptionSchema>;
 
 export const PurpleUnitPriceSchema = z.object({
-    "amount": z.number().int().gte(0),
-    "currency": z.string().regex(/^[A-Z]{3}$/),
-    "measure": PurpleMeasureSchema,
-    "reference": PurpleReferenceSchema,
+  amount: z.number().int().gte(0),
+  currency: z.string().regex(/^[A-Z]{3}$/),
+  measure: PurpleMeasureSchema,
+  reference: PurpleReferenceSchema,
 });
 export type PurpleUnitPrice = z.infer<typeof PurpleUnitPriceSchema>;
 export const FluffyUnitPriceSchema = PurpleUnitPriceSchema;
 export type FluffyUnitPrice = PurpleUnitPrice;
 
-
 export const GetProductRequestSchema = z.object({
-    "attribution": z.record(z.string(), z.string()).optional(),
-    "context": LookupRequestContextSchema.optional(),
-    "filters": SearchFiltersSchema.optional(),
-    "id": z.string(),
-    "preferences": z.array(z.string()).optional(),
-    "selected": z.array(SelectedElementSchema).optional(),
-    "signals": LookupRequestSignalsSchema.optional(),
+  attribution: z.record(z.string(), z.string()).optional(),
+  context: LookupRequestContextSchema.optional(),
+  filters: SearchFiltersSchema.optional(),
+  id: z.string(),
+  preferences: z.array(z.string()).optional(),
+  selected: z.array(SelectedElementSchema).optional(),
+  signals: LookupRequestSignalsSchema.optional(),
 });
 export type GetProductRequest = z.infer<typeof GetProductRequestSchema>;
 
-
-
 export const SearchRequestSchema = z.object({
-    "attribution": z.record(z.string(), z.string()).optional(),
-    "context": LookupRequestContextSchema.optional(),
-    "filters": SearchFiltersSchema.optional(),
-    "pagination": SearchRequestPaginationSchema.optional(),
-    "query": z.string().optional(),
-    "signals": LookupRequestSignalsSchema.optional(),
+  attribution: z.record(z.string(), z.string()).optional(),
+  context: LookupRequestContextSchema.optional(),
+  filters: SearchFiltersSchema.optional(),
+  pagination: SearchRequestPaginationSchema.optional(),
+  query: z.string().optional(),
+  signals: LookupRequestSignalsSchema.optional(),
 });
 export type SearchRequest = z.infer<typeof SearchRequestSchema>;
 
 export const UcpSchema = z.object({
-    "capabilities": z.array(CapabilityDiscoverySchema),
-    "services": z.record(z.string(), UcpServiceSchema),
-    "version": z.string(),
+  capabilities: z.array(CapabilityDiscoverySchema),
+  services: z.record(z.string(), UcpServiceSchema),
+  version: z.string(),
 });
 export type Ucp = z.infer<typeof UcpSchema>;
 
-
-
-
-
 export const CheckoutCompleteRequestSchema = z.object({
-    "attribution": z.record(z.string(), z.string()).optional(),
-    "payment": PaymentCompleteRequestSchema,
-    "signals": CheckoutCreateRequestSignalsSchema.optional(),
+  attribution: z.record(z.string(), z.string()).optional(),
+  payment: PaymentCompleteRequestSchema,
+  signals: CheckoutCreateRequestSignalsSchema.optional(),
 });
-export type CheckoutCompleteRequest = z.infer<typeof CheckoutCompleteRequestSchema>;
+export type CheckoutCompleteRequest = z.infer<
+  typeof CheckoutCompleteRequestSchema
+>;
 
 export const CheckoutResponseSchema = z.object({
-    "actions": z.record(z.string(), z.array(ActionsSchema)).optional(),
-    "attribution": z.record(z.string(), z.string()).optional(),
-    "buyer": BuyerSchema.optional(),
-    "context": CheckoutCreateRequestContextSchema.optional(),
-    "continue_url": z.string().optional(),
-    "currency": z.string(),
-    "expires_at": z.coerce.date().optional(),
-    "id": z.string(),
-    "line_items": z.array(LineItemResponseSchema),
-    "links": z.array(CheckoutResponseLinkSchema),
-    "messages": z.array(CheckoutResponseMessageSchema).optional(),
-    "order": OrderConfirmationSchema.optional(),
-    "payment": PaymentResponseSchema.optional(),
-    "policies": z.array(CheckoutResponsePolicySchema).optional(),
-    "signals": CheckoutCreateRequestSignalsSchema.optional(),
-    "status": CheckoutResponseStatusSchema,
-    "totals": z.array(TotalsResponseSchema),
-    "ucp": UcpResponseSchema,
+  actions: z.record(z.string(), z.array(ActionsSchema)).optional(),
+  attribution: z.record(z.string(), z.string()).optional(),
+  buyer: BuyerSchema.optional(),
+  context: CheckoutCreateRequestContextSchema.optional(),
+  continue_url: z.string().optional(),
+  currency: z.string(),
+  expires_at: z.coerce.date().optional(),
+  id: z.string(),
+  line_items: z.array(LineItemResponseSchema),
+  links: z.array(CheckoutResponseLinkSchema),
+  messages: z.array(CheckoutResponseMessageSchema).optional(),
+  order: OrderConfirmationSchema.optional(),
+  payment: PaymentResponseSchema.optional(),
+  policies: z.array(CheckoutResponsePolicySchema).optional(),
+  signals: CheckoutCreateRequestSignalsSchema.optional(),
+  status: CheckoutResponseStatusSchema,
+  totals: z.array(TotalsResponseSchema),
+  ucp: UcpResponseSchema,
 });
 export type CheckoutResponse = z.infer<typeof CheckoutResponseSchema>;
 
 export const FulfillmentSchema = z.object({
-    "events": z.array(FulfillmentEventSchema).optional(),
-    "expectations": z.array(ExpectationSchema).optional(),
+  events: z.array(FulfillmentEventSchema).optional(),
+  expectations: z.array(ExpectationSchema).optional(),
 });
 export type Fulfillment = z.infer<typeof FulfillmentSchema>;
 
 export const BuyerWithConsentCreateRequestSchema = z.object({
-    "email": z.string().optional(),
-    "first_name": z.string().optional(),
-    "last_name": z.string().optional(),
-    "phone_number": z.string().optional(),
-    "consent": z.record(z.string(), ConsentValueSchema).optional(),
+  email: z.string().optional(),
+  first_name: z.string().optional(),
+  last_name: z.string().optional(),
+  phone_number: z.string().optional(),
+  consent: z.record(z.string(), ConsentValueSchema).optional(),
 });
-export type BuyerWithConsentCreateRequest = z.infer<typeof BuyerWithConsentCreateRequestSchema>;
+export type BuyerWithConsentCreateRequest = z.infer<
+  typeof BuyerWithConsentCreateRequestSchema
+>;
 
 export const BuyerWithConsentUpdateRequestSchema = z.object({
-    "email": z.string().optional(),
-    "first_name": z.string().optional(),
-    "last_name": z.string().optional(),
-    "phone_number": z.string().optional(),
-    "consent": z.record(z.string(), ConsentClassSchema).optional(),
+  email: z.string().optional(),
+  first_name: z.string().optional(),
+  last_name: z.string().optional(),
+  phone_number: z.string().optional(),
+  consent: z.record(z.string(), ConsentClassSchema).optional(),
 });
-export type BuyerWithConsentUpdateRequest = z.infer<typeof BuyerWithConsentUpdateRequestSchema>;
+export type BuyerWithConsentUpdateRequest = z.infer<
+  typeof BuyerWithConsentUpdateRequestSchema
+>;
 
 export const BuyerWithConsentResponseSchema = z.object({
-    "email": z.string().optional(),
-    "first_name": z.string().optional(),
-    "last_name": z.string().optional(),
-    "phone_number": z.string().optional(),
-    "consent": z.record(z.string(), BuyerConsentSchema).optional(),
+  email: z.string().optional(),
+  first_name: z.string().optional(),
+  last_name: z.string().optional(),
+  phone_number: z.string().optional(),
+  consent: z.record(z.string(), BuyerConsentSchema).optional(),
 });
-export type BuyerWithConsentResponse = z.infer<typeof BuyerWithConsentResponseSchema>;
+export type BuyerWithConsentResponse = z.infer<
+  typeof BuyerWithConsentResponseSchema
+>;
 
 export const CheckoutWithDiscountCreateRequestSchema = z.object({
-    "attribution": z.record(z.string(), z.string()).optional(),
-    "buyer": BuyerSchema.optional(),
-    "context": CheckoutCreateRequestContextSchema.optional(),
-    "line_items": z.array(LineItemCreateRequestSchema),
-    "payment": PaymentCreateRequestSchema.optional(),
-    "signals": CheckoutCreateRequestSignalsSchema.optional(),
-    "discounts": CheckoutWithDiscountCreateRequestDiscountsSchema.optional(),
+  attribution: z.record(z.string(), z.string()).optional(),
+  buyer: BuyerSchema.optional(),
+  context: CheckoutCreateRequestContextSchema.optional(),
+  line_items: z.array(LineItemCreateRequestSchema),
+  payment: PaymentCreateRequestSchema.optional(),
+  signals: CheckoutCreateRequestSignalsSchema.optional(),
+  discounts: CheckoutWithDiscountCreateRequestDiscountsSchema.optional(),
 });
-export type CheckoutWithDiscountCreateRequest = z.infer<typeof CheckoutWithDiscountCreateRequestSchema>;
+export type CheckoutWithDiscountCreateRequest = z.infer<
+  typeof CheckoutWithDiscountCreateRequestSchema
+>;
 
 export const CheckoutWithDiscountResponseDiscountsSchema = z.object({
-    "applied": z.array(AppliedElementSchema).optional(),
-    "codes": z.array(z.string()).optional(),
+  applied: z.array(AppliedElementSchema).optional(),
+  codes: z.array(z.string()).optional(),
 });
-export type CheckoutWithDiscountResponseDiscounts = z.infer<typeof CheckoutWithDiscountResponseDiscountsSchema>;
+export type CheckoutWithDiscountResponseDiscounts = z.infer<
+  typeof CheckoutWithDiscountResponseDiscountsSchema
+>;
 
 export const FulfillmentMethodCreateRequestSchema = z.object({
-    "destinations": z.array(FulfillmentDestinationRequestSchema).optional(),
-    "groups": z.array(FulfillmentGroupSchema).optional(),
-    "line_item_ids": z.array(z.string()).optional(),
-    "selected_destination_id": z.union([z.null(), z.string()]).optional(),
-    "type": z.string(),
+  destinations: z.array(FulfillmentDestinationRequestSchema).optional(),
+  groups: z.array(FulfillmentGroupSchema).optional(),
+  line_item_ids: z.array(z.string()).optional(),
+  selected_destination_id: z.union([z.null(), z.string()]).optional(),
+  type: z.string(),
 });
-export type FulfillmentMethodCreateRequest = z.infer<typeof FulfillmentMethodCreateRequestSchema>;
+export type FulfillmentMethodCreateRequest = z.infer<
+  typeof FulfillmentMethodCreateRequestSchema
+>;
 
 export const FulfillmentResponseSchema = z.object({
-    "available_methods": z.array(FulfillmentAvailableMethodSchema).optional(),
-    "methods": z.array(FulfillmentMethodResponseSchema).optional(),
+  available_methods: z.array(FulfillmentAvailableMethodSchema).optional(),
+  methods: z.array(FulfillmentMethodResponseSchema).optional(),
 });
 export type FulfillmentResponse = z.infer<typeof FulfillmentResponseSchema>;
 
 export const CheckoutWithCartCreateRequestSchema = z.object({
-    "attribution": z.record(z.string(), z.string()).optional(),
-    "buyer": BuyerSchema.optional(),
-    "context": CheckoutCreateRequestContextSchema.optional(),
-    "line_items": z.array(LineItemCreateRequestSchema),
-    "payment": PaymentCreateRequestSchema.optional(),
-    "signals": CheckoutCreateRequestSignalsSchema.optional(),
-    "cart_id": z.string().optional(),
+  attribution: z.record(z.string(), z.string()).optional(),
+  buyer: BuyerSchema.optional(),
+  context: CheckoutCreateRequestContextSchema.optional(),
+  line_items: z.array(LineItemCreateRequestSchema),
+  payment: PaymentCreateRequestSchema.optional(),
+  signals: CheckoutCreateRequestSignalsSchema.optional(),
+  cart_id: z.string().optional(),
 });
-export type CheckoutWithCartCreateRequest = z.infer<typeof CheckoutWithCartCreateRequestSchema>;
+export type CheckoutWithCartCreateRequest = z.infer<
+  typeof CheckoutWithCartCreateRequestSchema
+>;
 
 export const LookupRequestSchema = z.object({
-    "attribution": z.record(z.string(), z.string()).optional(),
-    "context": LookupRequestContextSchema.optional(),
-    "filters": SearchFiltersSchema.optional(),
-    "ids": z.array(z.string()),
-    "signals": LookupRequestSignalsSchema.optional(),
+  attribution: z.record(z.string(), z.string()).optional(),
+  context: LookupRequestContextSchema.optional(),
+  filters: SearchFiltersSchema.optional(),
+  ids: z.array(z.string()),
+  signals: LookupRequestSignalsSchema.optional(),
 });
 export type LookupRequest = z.infer<typeof LookupRequestSchema>;
 
 export const CatalogLookupSchema = z.object({
-    "availability": AvailabilitySchema.optional(),
-    "barcodes": z.array(PurpleBarcodeSchema).optional(),
-    "categories": z.array(CategorySchema).optional(),
-    "description": DescriptionSchema,
-    "handle": z.string().optional(),
-    "id": z.string(),
-    "list_price": PriceSchema.optional(),
-    "media": z.array(MediaSchema).optional(),
-    "metadata": z.record(z.string(), z.any()).optional(),
-    "options": z.array(OptionElementSchema).optional(),
-    "price": PriceSchema,
-    "rating": RatingSchema.optional(),
-    "seller": PurpleSellerSchema.optional(),
-    "sku": z.string().optional(),
-    "tags": z.array(z.string()).optional(),
-    "title": z.string(),
-    "unit_price": PurpleUnitPriceSchema.optional(),
-    "url": z.string().optional(),
-    "inputs": z.array(InputCorrelationSchema).min(1),
+  availability: AvailabilitySchema.optional(),
+  barcodes: z.array(PurpleBarcodeSchema).optional(),
+  categories: z.array(CategorySchema).optional(),
+  description: DescriptionSchema,
+  handle: z.string().optional(),
+  id: z.string(),
+  list_price: PriceSchema.optional(),
+  media: z.array(MediaSchema).optional(),
+  metadata: z.record(z.string(), z.any()).optional(),
+  options: z.array(OptionElementSchema).optional(),
+  price: PriceSchema,
+  rating: RatingSchema.optional(),
+  seller: PurpleSellerSchema.optional(),
+  sku: z.string().optional(),
+  tags: z.array(z.string()).optional(),
+  title: z.string(),
+  unit_price: PurpleUnitPriceSchema.optional(),
+  url: z.string().optional(),
+  inputs: z.array(InputCorrelationSchema).min(1),
 });
 export type CatalogLookup = z.infer<typeof CatalogLookupSchema>;
 
 export const VariantSchema = z.object({
-    "availability": AvailabilitySchema.optional(),
-    "barcodes": z.array(FluffyBarcodeSchema).optional(),
-    "categories": z.array(CategorySchema).optional(),
-    "description": DescriptionSchema,
-    "handle": z.string().optional(),
-    "id": z.string(),
-    "list_price": PriceSchema.optional(),
-    "media": z.array(MediaSchema).optional(),
-    "metadata": z.record(z.string(), z.any()).optional(),
-    "options": z.array(OptionElementSchema).optional(),
-    "price": PriceSchema,
-    "rating": RatingSchema.optional(),
-    "seller": FluffySellerSchema.optional(),
-    "sku": z.string().optional(),
-    "tags": z.array(z.string()).optional(),
-    "title": z.string(),
-    "unit_price": FluffyUnitPriceSchema.optional(),
-    "url": z.string().optional(),
+  availability: AvailabilitySchema.optional(),
+  barcodes: z.array(FluffyBarcodeSchema).optional(),
+  categories: z.array(CategorySchema).optional(),
+  description: DescriptionSchema,
+  handle: z.string().optional(),
+  id: z.string(),
+  list_price: PriceSchema.optional(),
+  media: z.array(MediaSchema).optional(),
+  metadata: z.record(z.string(), z.any()).optional(),
+  options: z.array(OptionElementSchema).optional(),
+  price: PriceSchema,
+  rating: RatingSchema.optional(),
+  seller: FluffySellerSchema.optional(),
+  sku: z.string().optional(),
+  tags: z.array(z.string()).optional(),
+  title: z.string(),
+  unit_price: FluffyUnitPriceSchema.optional(),
+  url: z.string().optional(),
 });
 export type Variant = z.infer<typeof VariantSchema>;
 
 export const SearchResponseProductSchema = z.object({
-    "categories": z.array(CategorySchema).optional(),
-    "description": DescriptionSchema,
-    "handle": z.string().optional(),
-    "id": z.string(),
-    "list_price_range": PriceRangeSchema.optional(),
-    "media": z.array(MediaSchema).optional(),
-    "metadata": z.record(z.string(), z.any()).optional(),
-    "options": z.array(ProductOptionSchema).optional(),
-    "price_range": PriceRangeSchema,
-    "rating": RatingSchema.optional(),
-    "tags": z.array(z.string()).optional(),
-    "title": z.string(),
-    "url": z.string().optional(),
-    "variants": z.array(VariantSchema).min(1),
+  categories: z.array(CategorySchema).optional(),
+  description: DescriptionSchema,
+  handle: z.string().optional(),
+  id: z.string(),
+  list_price_range: PriceRangeSchema.optional(),
+  media: z.array(MediaSchema).optional(),
+  metadata: z.record(z.string(), z.any()).optional(),
+  options: z.array(ProductOptionSchema).optional(),
+  price_range: PriceRangeSchema,
+  rating: RatingSchema.optional(),
+  tags: z.array(z.string()).optional(),
+  title: z.string(),
+  url: z.string().optional(),
+  variants: z.array(VariantSchema).min(1),
 });
 export type SearchResponseProduct = z.infer<typeof SearchResponseProductSchema>;
 
 export const UcpDiscoveryProfileSchema = z.object({
-    "payment": UcpDiscoveryProfilePaymentSchema.optional(),
-    "signing_keys": z.array(SigningKeySchema).optional(),
-    "ucp": UcpSchema,
+  payment: UcpDiscoveryProfilePaymentSchema.optional(),
+  signing_keys: z.array(SigningKeySchema).optional(),
+  ucp: UcpSchema,
 });
 export type UcpDiscoveryProfile = z.infer<typeof UcpDiscoveryProfileSchema>;
 
 export const CheckoutCreateRequestSchema = z.object({
-    "attribution": z.record(z.string(), z.string()).optional(),
-    "buyer": BuyerSchema.optional(),
-    "context": CheckoutCreateRequestContextSchema.optional(),
-    "line_items": z.array(LineItemCreateRequestSchema),
-    "payment": PaymentCreateRequestSchema.optional(),
-    "signals": CheckoutCreateRequestSignalsSchema.optional(),
+  attribution: z.record(z.string(), z.string()).optional(),
+  buyer: BuyerSchema.optional(),
+  context: CheckoutCreateRequestContextSchema.optional(),
+  line_items: z.array(LineItemCreateRequestSchema),
+  payment: PaymentCreateRequestSchema.optional(),
+  signals: CheckoutCreateRequestSignalsSchema.optional(),
 });
 export type CheckoutCreateRequest = z.infer<typeof CheckoutCreateRequestSchema>;
 
 export const OrderSchema = z.object({
-    "adjustments": z.array(AdjustmentSchema).optional(),
-    "attribution": z.record(z.string(), z.string()).optional(),
-    "checkout_id": z.string(),
-    "currency": z.string(),
-    "fulfillment": FulfillmentSchema,
-    "id": z.string(),
-    "label": z.string().optional(),
-    "line_items": z.array(OrderLineItemSchema),
-    "messages": z.array(CheckoutResponseMessageSchema).optional(),
-    "permalink_url": z.string(),
-    "policies": z.array(CheckoutResponsePolicySchema).optional(),
-    "totals": z.array(TotalsResponseSchema),
-    "ucp": UcpResponseSchema,
+  adjustments: z.array(AdjustmentSchema).optional(),
+  attribution: z.record(z.string(), z.string()).optional(),
+  checkout_id: z.string(),
+  currency: z.string(),
+  fulfillment: FulfillmentSchema,
+  id: z.string(),
+  label: z.string().optional(),
+  line_items: z.array(OrderLineItemSchema),
+  messages: z.array(CheckoutResponseMessageSchema).optional(),
+  permalink_url: z.string(),
+  policies: z.array(CheckoutResponsePolicySchema).optional(),
+  totals: z.array(TotalsResponseSchema),
+  ucp: UcpResponseSchema,
 });
 export type Order = z.infer<typeof OrderSchema>;
 
 export const CheckoutWithBuyerConsentCreateRequestSchema = z.object({
-    "attribution": z.record(z.string(), z.string()).optional(),
-    "buyer": BuyerWithConsentCreateRequestSchema.optional(),
-    "context": CheckoutCreateRequestContextSchema.optional(),
-    "line_items": z.array(LineItemCreateRequestSchema),
-    "payment": PaymentCreateRequestSchema.optional(),
-    "signals": CheckoutCreateRequestSignalsSchema.optional(),
+  attribution: z.record(z.string(), z.string()).optional(),
+  buyer: BuyerWithConsentCreateRequestSchema.optional(),
+  context: CheckoutCreateRequestContextSchema.optional(),
+  line_items: z.array(LineItemCreateRequestSchema),
+  payment: PaymentCreateRequestSchema.optional(),
+  signals: CheckoutCreateRequestSignalsSchema.optional(),
 });
-export type CheckoutWithBuyerConsentCreateRequest = z.infer<typeof CheckoutWithBuyerConsentCreateRequestSchema>;
+export type CheckoutWithBuyerConsentCreateRequest = z.infer<
+  typeof CheckoutWithBuyerConsentCreateRequestSchema
+>;
 
 export const CheckoutWithBuyerConsentUpdateRequestSchema = z.object({
-    "attribution": z.record(z.string(), z.string()).optional(),
-    "buyer": BuyerWithConsentUpdateRequestSchema.optional(),
-    "context": CheckoutCreateRequestContextSchema.optional(),
-    "line_items": z.array(LineItemUpdateRequestSchema),
-    "payment": PaymentUpdateRequestSchema.optional(),
-    "signals": CheckoutCreateRequestSignalsSchema.optional(),
+  attribution: z.record(z.string(), z.string()).optional(),
+  buyer: BuyerWithConsentUpdateRequestSchema.optional(),
+  context: CheckoutCreateRequestContextSchema.optional(),
+  line_items: z.array(LineItemUpdateRequestSchema),
+  payment: PaymentUpdateRequestSchema.optional(),
+  signals: CheckoutCreateRequestSignalsSchema.optional(),
 });
-export type CheckoutWithBuyerConsentUpdateRequest = z.infer<typeof CheckoutWithBuyerConsentUpdateRequestSchema>;
+export type CheckoutWithBuyerConsentUpdateRequest = z.infer<
+  typeof CheckoutWithBuyerConsentUpdateRequestSchema
+>;
 
 export const CheckoutWithBuyerConsentResponseSchema = z.object({
-    "actions": z.record(z.string(), z.array(ActionsSchema)).optional(),
-    "attribution": z.record(z.string(), z.string()).optional(),
-    "buyer": BuyerWithConsentResponseSchema.optional(),
-    "context": CheckoutCreateRequestContextSchema.optional(),
-    "continue_url": z.string().optional(),
-    "currency": z.string(),
-    "expires_at": z.coerce.date().optional(),
-    "id": z.string(),
-    "line_items": z.array(LineItemResponseSchema),
-    "links": z.array(CheckoutResponseLinkSchema),
-    "messages": z.array(CheckoutResponseMessageSchema).optional(),
-    "order": OrderConfirmationSchema.optional(),
-    "payment": PaymentResponseSchema.optional(),
-    "policies": z.array(CheckoutResponsePolicySchema).optional(),
-    "signals": CheckoutCreateRequestSignalsSchema.optional(),
-    "status": CheckoutResponseStatusSchema,
-    "totals": z.array(TotalsResponseSchema),
-    "ucp": UcpResponseSchema,
+  actions: z.record(z.string(), z.array(ActionsSchema)).optional(),
+  attribution: z.record(z.string(), z.string()).optional(),
+  buyer: BuyerWithConsentResponseSchema.optional(),
+  context: CheckoutCreateRequestContextSchema.optional(),
+  continue_url: z.string().optional(),
+  currency: z.string(),
+  expires_at: z.coerce.date().optional(),
+  id: z.string(),
+  line_items: z.array(LineItemResponseSchema),
+  links: z.array(CheckoutResponseLinkSchema),
+  messages: z.array(CheckoutResponseMessageSchema).optional(),
+  order: OrderConfirmationSchema.optional(),
+  payment: PaymentResponseSchema.optional(),
+  policies: z.array(CheckoutResponsePolicySchema).optional(),
+  signals: CheckoutCreateRequestSignalsSchema.optional(),
+  status: CheckoutResponseStatusSchema,
+  totals: z.array(TotalsResponseSchema),
+  ucp: UcpResponseSchema,
 });
-export type CheckoutWithBuyerConsentResponse = z.infer<typeof CheckoutWithBuyerConsentResponseSchema>;
+export type CheckoutWithBuyerConsentResponse = z.infer<
+  typeof CheckoutWithBuyerConsentResponseSchema
+>;
 
 export const CheckoutWithDiscountResponseSchema = z.object({
-    "actions": z.record(z.string(), z.array(ActionsSchema)).optional(),
-    "attribution": z.record(z.string(), z.string()).optional(),
-    "buyer": BuyerSchema.optional(),
-    "context": CheckoutCreateRequestContextSchema.optional(),
-    "continue_url": z.string().optional(),
-    "currency": z.string(),
-    "expires_at": z.coerce.date().optional(),
-    "id": z.string(),
-    "line_items": z.array(LineItemResponseSchema),
-    "links": z.array(CheckoutResponseLinkSchema),
-    "messages": z.array(CheckoutResponseMessageSchema).optional(),
-    "order": OrderConfirmationSchema.optional(),
-    "payment": PaymentResponseSchema.optional(),
-    "policies": z.array(CheckoutResponsePolicySchema).optional(),
-    "signals": CheckoutCreateRequestSignalsSchema.optional(),
-    "status": CheckoutResponseStatusSchema,
-    "totals": z.array(TotalsResponseSchema),
-    "ucp": UcpResponseSchema,
-    "discounts": CheckoutWithDiscountResponseDiscountsSchema.optional(),
+  actions: z.record(z.string(), z.array(ActionsSchema)).optional(),
+  attribution: z.record(z.string(), z.string()).optional(),
+  buyer: BuyerSchema.optional(),
+  context: CheckoutCreateRequestContextSchema.optional(),
+  continue_url: z.string().optional(),
+  currency: z.string(),
+  expires_at: z.coerce.date().optional(),
+  id: z.string(),
+  line_items: z.array(LineItemResponseSchema),
+  links: z.array(CheckoutResponseLinkSchema),
+  messages: z.array(CheckoutResponseMessageSchema).optional(),
+  order: OrderConfirmationSchema.optional(),
+  payment: PaymentResponseSchema.optional(),
+  policies: z.array(CheckoutResponsePolicySchema).optional(),
+  signals: CheckoutCreateRequestSignalsSchema.optional(),
+  status: CheckoutResponseStatusSchema,
+  totals: z.array(TotalsResponseSchema),
+  ucp: UcpResponseSchema,
+  discounts: CheckoutWithDiscountResponseDiscountsSchema.optional(),
 });
-export type CheckoutWithDiscountResponse = z.infer<typeof CheckoutWithDiscountResponseSchema>;
+export type CheckoutWithDiscountResponse = z.infer<
+  typeof CheckoutWithDiscountResponseSchema
+>;
 
 export const FulfillmentRequestSchema = z.object({
-    "methods": z.array(FulfillmentMethodCreateRequestSchema).optional(),
+  methods: z.array(FulfillmentMethodCreateRequestSchema).optional(),
 });
 export type FulfillmentRequest = z.infer<typeof FulfillmentRequestSchema>;
 
 export const CheckoutWithFulfillmentUpdateRequestSchema = z.object({
-    "attribution": z.record(z.string(), z.string()).optional(),
-    "buyer": BuyerSchema.optional(),
-    "context": CheckoutCreateRequestContextSchema.optional(),
-    "line_items": z.array(LineItemUpdateRequestSchema),
-    "payment": PaymentUpdateRequestSchema.optional(),
-    "signals": CheckoutCreateRequestSignalsSchema.optional(),
-    "fulfillment": FulfillmentRequestSchema.optional(),
+  attribution: z.record(z.string(), z.string()).optional(),
+  buyer: BuyerSchema.optional(),
+  context: CheckoutCreateRequestContextSchema.optional(),
+  line_items: z.array(LineItemUpdateRequestSchema),
+  payment: PaymentUpdateRequestSchema.optional(),
+  signals: CheckoutCreateRequestSignalsSchema.optional(),
+  fulfillment: FulfillmentRequestSchema.optional(),
 });
-export type CheckoutWithFulfillmentUpdateRequest = z.infer<typeof CheckoutWithFulfillmentUpdateRequestSchema>;
+export type CheckoutWithFulfillmentUpdateRequest = z.infer<
+  typeof CheckoutWithFulfillmentUpdateRequestSchema
+>;
 
 export const CheckoutWithFulfillmentResponseSchema = z.object({
-    "actions": z.record(z.string(), z.array(ActionsSchema)).optional(),
-    "attribution": z.record(z.string(), z.string()).optional(),
-    "buyer": BuyerSchema.optional(),
-    "context": CheckoutCreateRequestContextSchema.optional(),
-    "continue_url": z.string().optional(),
-    "currency": z.string(),
-    "expires_at": z.coerce.date().optional(),
-    "id": z.string(),
-    "line_items": z.array(LineItemResponseSchema),
-    "links": z.array(CheckoutResponseLinkSchema),
-    "messages": z.array(CheckoutResponseMessageSchema).optional(),
-    "order": OrderConfirmationSchema.optional(),
-    "payment": PaymentResponseSchema.optional(),
-    "policies": z.array(CheckoutResponsePolicySchema).optional(),
-    "signals": CheckoutCreateRequestSignalsSchema.optional(),
-    "status": CheckoutResponseStatusSchema,
-    "totals": z.array(TotalsResponseSchema),
-    "ucp": UcpResponseSchema,
-    "fulfillment": FulfillmentResponseSchema.optional(),
+  actions: z.record(z.string(), z.array(ActionsSchema)).optional(),
+  attribution: z.record(z.string(), z.string()).optional(),
+  buyer: BuyerSchema.optional(),
+  context: CheckoutCreateRequestContextSchema.optional(),
+  continue_url: z.string().optional(),
+  currency: z.string(),
+  expires_at: z.coerce.date().optional(),
+  id: z.string(),
+  line_items: z.array(LineItemResponseSchema),
+  links: z.array(CheckoutResponseLinkSchema),
+  messages: z.array(CheckoutResponseMessageSchema).optional(),
+  order: OrderConfirmationSchema.optional(),
+  payment: PaymentResponseSchema.optional(),
+  policies: z.array(CheckoutResponsePolicySchema).optional(),
+  signals: CheckoutCreateRequestSignalsSchema.optional(),
+  status: CheckoutResponseStatusSchema,
+  totals: z.array(TotalsResponseSchema),
+  ucp: UcpResponseSchema,
+  fulfillment: FulfillmentResponseSchema.optional(),
 });
-export type CheckoutWithFulfillmentResponse = z.infer<typeof CheckoutWithFulfillmentResponseSchema>;
+export type CheckoutWithFulfillmentResponse = z.infer<
+  typeof CheckoutWithFulfillmentResponseSchema
+>;
 
 export const LookupResponseProductSchema = z.object({
-    "categories": z.array(CategorySchema).optional(),
-    "description": DescriptionSchema,
-    "handle": z.string().optional(),
-    "id": z.string(),
-    "list_price_range": PriceRangeSchema.optional(),
-    "media": z.array(MediaSchema).optional(),
-    "metadata": z.record(z.string(), z.any()).optional(),
-    "options": z.array(ProductOptionSchema).optional(),
-    "price_range": PriceRangeSchema,
-    "rating": RatingSchema.optional(),
-    "tags": z.array(z.string()).optional(),
-    "title": z.string(),
-    "url": z.string().optional(),
-    "variants": z.array(CatalogLookupSchema).min(1),
+  categories: z.array(CategorySchema).optional(),
+  description: DescriptionSchema,
+  handle: z.string().optional(),
+  id: z.string(),
+  list_price_range: PriceRangeSchema.optional(),
+  media: z.array(MediaSchema).optional(),
+  metadata: z.record(z.string(), z.any()).optional(),
+  options: z.array(ProductOptionSchema).optional(),
+  price_range: PriceRangeSchema,
+  rating: RatingSchema.optional(),
+  tags: z.array(z.string()).optional(),
+  title: z.string(),
+  url: z.string().optional(),
+  variants: z.array(CatalogLookupSchema).min(1),
 });
 export type LookupResponseProduct = z.infer<typeof LookupResponseProductSchema>;
 
 export const ProductSchema = z.object({
-    "options": z.array(ProductOptionSchema).optional(),
-    "selected": z.array(SelectedElementSchema).optional(),
-    "categories": z.array(CategorySchema).optional(),
-    "description": DescriptionSchema,
-    "handle": z.string().optional(),
-    "id": z.string(),
-    "list_price_range": PriceRangeSchema.optional(),
-    "media": z.array(MediaSchema).optional(),
-    "metadata": z.record(z.string(), z.any()).optional(),
-    "price_range": PriceRangeSchema,
-    "rating": RatingSchema.optional(),
-    "tags": z.array(z.string()).optional(),
-    "title": z.string(),
-    "url": z.string().optional(),
-    "variants": z.array(VariantSchema),
+  options: z.array(ProductOptionSchema).optional(),
+  selected: z.array(SelectedElementSchema).optional(),
+  categories: z.array(CategorySchema).optional(),
+  description: DescriptionSchema,
+  handle: z.string().optional(),
+  id: z.string(),
+  list_price_range: PriceRangeSchema.optional(),
+  media: z.array(MediaSchema).optional(),
+  metadata: z.record(z.string(), z.any()).optional(),
+  price_range: PriceRangeSchema,
+  rating: RatingSchema.optional(),
+  tags: z.array(z.string()).optional(),
+  title: z.string(),
+  url: z.string().optional(),
+  variants: z.array(VariantSchema),
 });
 export type Product = z.infer<typeof ProductSchema>;
 
 export const SearchResponseSchema = z.object({
-    "actions": z.record(z.string(), z.array(ActionsSchema)).optional(),
-    "messages": z.array(LookupResponseMessageSchema).optional(),
-    "pagination": SearchResponsePaginationSchema.optional(),
-    "policies": z.array(LookupResponsePolicySchema).optional(),
-    "products": z.array(SearchResponseProductSchema),
-    "ucp": UcpResponseSchema,
+  actions: z.record(z.string(), z.array(ActionsSchema)).optional(),
+  messages: z.array(LookupResponseMessageSchema).optional(),
+  pagination: SearchResponsePaginationSchema.optional(),
+  policies: z.array(LookupResponsePolicySchema).optional(),
+  products: z.array(SearchResponseProductSchema),
+  ucp: UcpResponseSchema,
 });
 export type SearchResponse = z.infer<typeof SearchResponseSchema>;
 
 export const CheckoutWithFulfillmentCreateRequestSchema = z.object({
-    "attribution": z.record(z.string(), z.string()).optional(),
-    "buyer": BuyerSchema.optional(),
-    "context": CheckoutCreateRequestContextSchema.optional(),
-    "line_items": z.array(LineItemCreateRequestSchema),
-    "payment": PaymentCreateRequestSchema.optional(),
-    "signals": CheckoutCreateRequestSignalsSchema.optional(),
-    "fulfillment": FulfillmentRequestSchema.optional(),
+  attribution: z.record(z.string(), z.string()).optional(),
+  buyer: BuyerSchema.optional(),
+  context: CheckoutCreateRequestContextSchema.optional(),
+  line_items: z.array(LineItemCreateRequestSchema),
+  payment: PaymentCreateRequestSchema.optional(),
+  signals: CheckoutCreateRequestSignalsSchema.optional(),
+  fulfillment: FulfillmentRequestSchema.optional(),
 });
-export type CheckoutWithFulfillmentCreateRequest = z.infer<typeof CheckoutWithFulfillmentCreateRequestSchema>;
+export type CheckoutWithFulfillmentCreateRequest = z.infer<
+  typeof CheckoutWithFulfillmentCreateRequestSchema
+>;
 
 export const LookupResponseSchema = z.object({
-    "actions": z.record(z.string(), z.array(ActionsSchema)).optional(),
-    "messages": z.array(LookupResponseMessageSchema).optional(),
-    "policies": z.array(LookupResponsePolicySchema).optional(),
-    "products": z.array(LookupResponseProductSchema),
-    "ucp": UcpResponseSchema,
+  actions: z.record(z.string(), z.array(ActionsSchema)).optional(),
+  messages: z.array(LookupResponseMessageSchema).optional(),
+  policies: z.array(LookupResponsePolicySchema).optional(),
+  products: z.array(LookupResponseProductSchema),
+  ucp: UcpResponseSchema,
 });
 export type LookupResponse = z.infer<typeof LookupResponseSchema>;
 
 export const GetProductResponseSchema = z.object({
-    "actions": z.record(z.string(), z.array(ActionsSchema)).optional(),
-    "messages": z.array(LookupResponseMessageSchema).optional(),
-    "policies": z.array(LookupResponsePolicySchema).optional(),
-    "product": ProductSchema,
-    "ucp": UcpResponseSchema,
+  actions: z.record(z.string(), z.array(ActionsSchema)).optional(),
+  messages: z.array(LookupResponseMessageSchema).optional(),
+  policies: z.array(LookupResponsePolicySchema).optional(),
+  product: ProductSchema,
+  ucp: UcpResponseSchema,
 });
 export type GetProductResponse = z.infer<typeof GetProductResponseSchema>;

--- a/src/spec_generated.ts
+++ b/src/spec_generated.ts
@@ -118,7 +118,9 @@ export const CapabilityDiscoverySchema = z.object({
 export type CapabilityDiscovery = z.infer<typeof CapabilityDiscoverySchema>;
 
 export const A2ASchema = z.object({
-  endpoint: z.string(),
+  endpoint: z
+    .string()
+    .regex(/^https:\/\/[^\/?#\s\\@]+(?:\/[^?#\s\\]*[^\/?#\s\\])?$/),
 });
 export type A2A = z.infer<typeof A2ASchema>;
 
@@ -200,13 +202,13 @@ export type LookupRequestSignals = CheckoutCreateRequestSignals;
 export const ItemResponseSchema = z.object({
   id: z.string(),
   image_url: z.string().optional(),
-  price: z.number(),
+  price: z.number().int().gte(0),
   title: z.string(),
 });
 export type ItemResponse = z.infer<typeof ItemResponseSchema>;
 
 export const TotalResponseSchema = z.object({
-  amount: z.number(),
+  amount: z.number().int(),
   display_text: z.string().optional(),
   type: z.string(),
 });
@@ -244,7 +246,7 @@ export const OrderConfirmationSchema = z.object({
 export type OrderConfirmation = z.infer<typeof OrderConfirmationSchema>;
 
 export const LineSchema = z.object({
-  amount: z.number(),
+  amount: z.number().int(),
   display_text: z.string(),
 });
 export type Line = z.infer<typeof LineSchema>;
@@ -272,9 +274,9 @@ export const ExpectationLineItemSchema = LineItemQuantityRefSchema;
 export type ExpectationLineItem = LineItemQuantityRef;
 
 export const QuantitySchema = z.object({
-  fulfilled: z.number(),
-  original: z.number().optional(),
-  total: z.number(),
+  fulfilled: z.number().int().gte(0),
+  original: z.number().int().gte(0).optional(),
+  total: z.number().int().gte(0),
 });
 export type Quantity = z.infer<typeof QuantitySchema>;
 
@@ -289,15 +291,26 @@ export const PaymentInstrumentSchema = z.object({
 export type PaymentInstrument = z.infer<typeof PaymentInstrumentSchema>;
 
 export const CompleteCheckoutRequestWithAp2Ap2Schema = z.object({
-  checkout_mandate: z.string(),
+  checkout_mandate: z
+    .string()
+    .regex(
+      /^[A-Za-z0-9_-]+\.[A-Za-z0-9_-]*\.[A-Za-z0-9_-]+(~[A-Za-z0-9_-]+)*$/
+    ),
 });
 export type CompleteCheckoutRequestWithAp2Ap2 = z.infer<
   typeof CompleteCheckoutRequestWithAp2Ap2Schema
 >;
 
 export const CheckoutWithAp2MandateAp2Schema = z.object({
-  merchant_authorization: z.string().optional(),
-  checkout_mandate: z.string(),
+  merchant_authorization: z
+    .string()
+    .regex(/^[A-Za-z0-9_-]+\.\.[A-Za-z0-9_-]+$/)
+    .optional(),
+  checkout_mandate: z
+    .string()
+    .regex(
+      /^[A-Za-z0-9_-]+\.[A-Za-z0-9_-]*\.[A-Za-z0-9_-]+(~[A-Za-z0-9_-]+)*$/
+    ),
 });
 export type CheckoutWithAp2MandateAp2 = z.infer<
   typeof CheckoutWithAp2MandateAp2Schema
@@ -329,7 +342,7 @@ export type CheckoutWithDiscountUpdateRequestDiscounts =
   CheckoutWithDiscountCreateRequestDiscounts;
 
 export const AllocationElementSchema = z.object({
-  amount: z.number(),
+  amount: z.number().int().gte(0),
   path: z.string(),
 });
 export type AllocationElement = z.infer<typeof AllocationElementSchema>;
@@ -411,17 +424,17 @@ export const DescriptionSchema = z.object({
 export type Description = z.infer<typeof DescriptionSchema>;
 
 export const PriceSchema = z.object({
-  amount: z.number(),
-  currency: z.string(),
+  amount: z.number().int().gte(0),
+  currency: z.string().regex(/^[A-Z]{3}$/),
 });
 export type Price = z.infer<typeof PriceSchema>;
 
 export const MediaSchema = z.object({
   alt_text: z.string().optional(),
-  height: z.number().optional(),
+  height: z.number().int().gte(1).optional(),
   type: z.string(),
   url: z.string(),
-  width: z.number().optional(),
+  width: z.number().int().gte(1).optional(),
 });
 export type Media = z.infer<typeof MediaSchema>;
 
@@ -432,10 +445,10 @@ export const OptionValueSchema = z.object({
 export type OptionValue = z.infer<typeof OptionValueSchema>;
 
 export const RatingSchema = z.object({
-  count: z.number().optional(),
-  scale_max: z.number(),
-  scale_min: z.number().optional(),
-  value: z.number(),
+  count: z.number().int().gte(0).optional(),
+  scale_max: z.number().gte(1),
+  scale_min: z.number().gte(0).optional(),
+  value: z.number().gte(0),
 });
 export type Rating = z.infer<typeof RatingSchema>;
 
@@ -480,7 +493,7 @@ export type FluffySeller = PurpleSeller;
 
 export const PurpleMeasureSchema = z.object({
   unit: z.string(),
-  value: z.number(),
+  value: z.number().int(),
 });
 export type PurpleMeasure = z.infer<typeof PurpleMeasureSchema>;
 export const FluffyMeasureSchema = PurpleMeasureSchema;
@@ -492,7 +505,7 @@ export type PurpleReference = PurpleMeasure;
 
 export const SearchRequestPaginationSchema = z.object({
   cursor: z.string().optional(),
-  limit: z.number().optional(),
+  limit: z.number().int().gte(1).optional(),
 });
 export type SearchRequestPagination = z.infer<
   typeof SearchRequestPaginationSchema
@@ -501,7 +514,7 @@ export type SearchRequestPagination = z.infer<
 export const SearchResponsePaginationSchema = z.object({
   cursor: z.string().optional(),
   has_next_page: z.boolean(),
-  total_count: z.number().optional(),
+  total_count: z.number().int().gte(0).optional(),
 });
 export type SearchResponsePagination = z.infer<
   typeof SearchResponsePaginationSchema
@@ -566,13 +579,13 @@ export const LineItemResponseSchema = z.object({
   id: z.string(),
   item: ItemResponseSchema,
   parent_id: z.string().optional(),
-  quantity: z.number(),
+  quantity: z.number().int().gte(1),
   totals: z.array(TotalResponseSchema),
 });
 export type LineItemResponse = z.infer<typeof LineItemResponseSchema>;
 
 export const TotalsResponseSchema = z.object({
-  amount: z.number(),
+  amount: z.number().int(),
   display_text: z.string().optional(),
   type: z.string(),
   lines: z.array(LineSchema).optional(),
@@ -695,12 +708,17 @@ export type CheckoutWithDiscountUpdateRequest = z.infer<
 
 export const AppliedElementSchema = z.object({
   allocations: z.array(AllocationElementSchema).optional(),
-  amount: z.number(),
+  amount: z.number().int().gte(0),
   automatic: z.boolean().optional(),
   code: z.string().optional(),
-  eligibility: z.string().optional(),
+  eligibility: z
+    .string()
+    .regex(
+      /^[a-z](?:[a-z0-9-]*[a-z0-9])?(?:\.[a-z0-9](?:[a-z0-9_-]*[a-z0-9_])?)+$/
+    )
+    .optional(),
   method: MethodSchema.optional(),
-  priority: z.number().optional(),
+  priority: z.number().int().gte(1).optional(),
   provisional: z.boolean().optional(),
   title: z.string(),
 });
@@ -813,13 +831,13 @@ export type PriceRange = z.infer<typeof PriceRangeSchema>;
 
 export const ProductOptionSchema = z.object({
   name: z.string(),
-  values: z.array(OptionValueSchema),
+  values: z.array(OptionValueSchema).min(1),
 });
 export type ProductOption = z.infer<typeof ProductOptionSchema>;
 
 export const PurpleUnitPriceSchema = z.object({
-  amount: z.number(),
-  currency: z.string(),
+  amount: z.number().int().gte(0),
+  currency: z.string().regex(/^[A-Z]{3}$/),
   measure: PurpleMeasureSchema,
   reference: PurpleReferenceSchema,
 });
@@ -1015,7 +1033,7 @@ export const CatalogLookupSchema = z.object({
   title: z.string(),
   unit_price: PurpleUnitPriceSchema.optional(),
   url: z.string().optional(),
-  inputs: z.array(InputCorrelationSchema),
+  inputs: z.array(InputCorrelationSchema).min(1),
 });
 export type CatalogLookup = z.infer<typeof CatalogLookupSchema>;
 
@@ -1055,7 +1073,7 @@ export const SearchResponseProductSchema = z.object({
   tags: z.array(z.string()).optional(),
   title: z.string(),
   url: z.string().optional(),
-  variants: z.array(VariantSchema),
+  variants: z.array(VariantSchema).min(1),
 });
 export type SearchResponseProduct = z.infer<typeof SearchResponseProductSchema>;
 
@@ -1170,7 +1188,7 @@ export const LookupResponseProductSchema = z.object({
   tags: z.array(z.string()).optional(),
   title: z.string(),
   url: z.string().optional(),
-  variants: z.array(CatalogLookupSchema),
+  variants: z.array(CatalogLookupSchema).min(1),
 });
 export type LookupResponseProduct = z.infer<typeof LookupResponseProductSchema>;
 

--- a/src/spec_generated.ts
+++ b/src/spec_generated.ts
@@ -1,15 +1,23 @@
 import * as z from "zod";
 
-export const UseSchema = z.enum(["enc", "sig"]);
+
+export const UseSchema = z.enum([
+    "enc",
+    "sig",
+]);
 export type Use = z.infer<typeof UseSchema>;
 
 // Content format, default = plain.
 
-export const ContentTypeSchema = z.enum(["markdown", "plain"]);
+export const ContentTypeSchema = z.enum([
+    "markdown",
+    "plain",
+]);
 export type ContentType = z.infer<typeof ContentTypeSchema>;
 
 // Reflects the resource state and recommended action. 'recoverable': platform can resolve
-// by modifying inputs and retrying via API. 'requires_buyer_input': merchant requires
+// the condition in band, for example by modifying inputs or processing a related Action,
+// and submit a new operation when needed. 'requires_buyer_input': merchant requires
 // information their API doesn't support collecting programmatically (checkout incomplete).
 // 'requires_buyer_review': buyer must authorize before order placement due to policy,
 // regulatory, or entitlement rules. 'unrecoverable': no valid resource exists to act on,
@@ -17,121 +25,125 @@ export type ContentType = z.infer<typeof ContentTypeSchema>;
 // 'status: requires_escalation'.
 
 export const SeveritySchema = z.enum([
-  "recoverable",
-  "requires_buyer_input",
-  "requires_buyer_review",
-  "unrecoverable",
+    "recoverable",
+    "requires_buyer_input",
+    "requires_buyer_review",
+    "unrecoverable",
 ]);
 export type Severity = z.infer<typeof SeveritySchema>;
 
-export const MessageTypeSchema = z.enum(["error", "info", "warning"]);
-export type MessageType = z.infer<typeof MessageTypeSchema>;
 
-// Checkout state indicating the current phase and required action. See Checkout Status
+export const TypeSchema = z.enum([
+    "error",
+    "info",
+    "warning",
+]);
+export type Type = z.infer<typeof TypeSchema>;
+
+// Checkout state indicating the current phase and required processing. See Checkout Status
 // lifecycle documentation for state transition details.
 
 export const CheckoutResponseStatusSchema = z.enum([
-  "canceled",
-  "complete_in_progress",
-  "completed",
-  "incomplete",
-  "ready_for_complete",
-  "requires_escalation",
+    "canceled",
+    "complete_in_progress",
+    "completed",
+    "incomplete",
+    "ready_for_complete",
+    "requires_escalation",
 ]);
-export type CheckoutResponseStatus = z.infer<
-  typeof CheckoutResponseStatusSchema
->;
+export type CheckoutResponseStatus = z.infer<typeof CheckoutResponseStatusSchema>;
 
 // Adjustment status.
 
 export const AdjustmentStatusSchema = z.enum([
-  "completed",
-  "failed",
-  "pending",
+    "completed",
+    "failed",
+    "pending",
 ]);
 export type AdjustmentStatus = z.infer<typeof AdjustmentStatusSchema>;
-
-// Delivery method type (shipping, pickup, digital).
-
-export const MethodTypeEnumSchema = z.enum(["digital", "pickup", "shipping"]);
-export type MethodTypeEnum = z.infer<typeof MethodTypeEnumSchema>;
 
 // Derived status: removed if quantity.total == 0, fulfilled if quantity.total > 0 and
 // quantity.fulfilled == quantity.total, partial if quantity.total > 0 and
 // quantity.fulfilled > 0, otherwise processing.
 
 export const LineItemStatusSchema = z.enum([
-  "fulfilled",
-  "partial",
-  "processing",
-  "removed",
+    "fulfilled",
+    "partial",
+    "processing",
+    "removed",
 ]);
 export type LineItemStatus = z.infer<typeof LineItemStatusSchema>;
+
+// Identifies the party that asserted the current `granted` value for this segment.
+// `business` means the value reflects the business's default policy; `platform` means the
+// value reflects an explicit buyer decision captured by the platform.
+//
+// Identifies the party that asserted the current `granted` value. `business` means the
+// value reflects the business's default policy; `platform` means the value reflects an
+// explicit buyer decision captured by the platform.
+
+export const SourceSchema = z.enum([
+    "business",
+    "platform",
+]);
+export type Source = z.infer<typeof SourceSchema>;
 
 // Allocation method. 'each' = applied independently per item. 'across' = split
 // proportionally by value.
 
-export const MethodSchema = z.enum(["across", "each"]);
+export const MethodSchema = z.enum([
+    "across",
+    "each",
+]);
 export type Method = z.infer<typeof MethodSchema>;
 
-// Fulfillment method type.
-//
-// Fulfillment method type this availability applies to.
-
-export const MethodTypeSchema = z.enum(["pickup", "shipping"]);
-export type MethodType = z.infer<typeof MethodTypeSchema>;
-
 export const PaymentHandlerResponseSchema = z.object({
-  config: z.record(z.string(), z.any()),
-  config_schema: z.string(),
-  id: z.string(),
-  instrument_schemas: z.array(z.string()),
-  name: z.string(),
-  spec: z.string(),
-  version: z.string(),
+    "config": z.record(z.string(), z.any()),
+    "config_schema": z.string(),
+    "id": z.string(),
+    "instrument_schemas": z.array(z.string()),
+    "name": z.string(),
+    "spec": z.string(),
+    "version": z.string(),
 });
-export type PaymentHandlerResponse = z.infer<
-  typeof PaymentHandlerResponseSchema
->;
+export type PaymentHandlerResponse = z.infer<typeof PaymentHandlerResponseSchema>;
 
 export const SigningKeySchema = z.object({
-  alg: z.string().optional(),
-  crv: z.string().optional(),
-  e: z.string().optional(),
-  kid: z.string(),
-  kty: z.string(),
-  n: z.string().optional(),
-  use: UseSchema.optional(),
-  x: z.string().optional(),
-  y: z.string().optional(),
+    "alg": z.string().optional(),
+    "crv": z.string().optional(),
+    "e": z.string().optional(),
+    "kid": z.string(),
+    "kty": z.string(),
+    "n": z.string().optional(),
+    "use": UseSchema.optional(),
+    "x": z.string().optional(),
+    "y": z.string().optional(),
 });
 export type SigningKey = z.infer<typeof SigningKeySchema>;
 
 export const CapabilityDiscoverySchema = z.object({
-  config: z.record(z.string(), z.any()).optional(),
-  extends: z.string().optional(),
-  name: z.string(),
-  schema: z.string(),
-  spec: z.string(),
-  version: z.string(),
+    "config": z.record(z.string(), z.any()).optional(),
+    "extends": z.string().optional(),
+    "name": z.string(),
+    "schema": z.string(),
+    "spec": z.string(),
+    "version": z.string(),
 });
 export type CapabilityDiscovery = z.infer<typeof CapabilityDiscoverySchema>;
 
 export const A2ASchema = z.object({
-  endpoint: z
-    .string()
-    .regex(/^https:\/\/[^\/?#\s\\@]+(?:\/[^?#\s\\]*[^\/?#\s\\])?$/),
+    "endpoint": z.string().regex(/^https:\/\/[^\/?#\s\\@]+(?:\/[^?#\s\\]*[^\/?#\s\\])?$/),
 });
 export type A2A = z.infer<typeof A2ASchema>;
 
 export const EmbeddedSchema = z.object({
-  schema: z.string(),
+    "schema": z.string(),
 });
 export type Embedded = z.infer<typeof EmbeddedSchema>;
 
 export const SchemaEndpointSchema = z.object({
-  endpoint: z.string(),
-  schema: z.string(),
+    "endpoint": z.string(),
+    "schema": z.string(),
 });
 export type SchemaEndpoint = z.infer<typeof SchemaEndpointSchema>;
 export const McpSchema = SchemaEndpointSchema;
@@ -139,31 +151,28 @@ export type Mcp = SchemaEndpoint;
 export const RestSchema = SchemaEndpointSchema;
 export type Rest = SchemaEndpoint;
 
+
+
+
 export const BuyerSchema = z.object({
-  email: z.string().optional(),
-  first_name: z.string().optional(),
-  last_name: z.string().optional(),
-  phone_number: z.string().optional(),
+    "email": z.string().optional(),
+    "first_name": z.string().optional(),
+    "last_name": z.string().optional(),
+    "phone_number": z.string().optional(),
 });
 export type Buyer = z.infer<typeof BuyerSchema>;
 
-export const CheckoutCreateRequestContextSchema = z.object({
-  address_country: z.string().optional(),
-  address_region: z.string().optional(),
-  currency: z.string().optional(),
-  eligibility: z.array(z.string()).optional(),
-  intent: z.string().optional(),
-  language: z.string().optional(),
-  postal_code: z.string().optional(),
+export const PurplePaymentSchema = z.object({
+    "handler": z.string().regex(/^[a-z](?:[a-z0-9-]*[a-z0-9])?(?:\.[a-z0-9](?:[a-z0-9_-]*[a-z0-9_])?)+$/),
+    "types": z.array(z.string()).optional(),
 });
-export type CheckoutCreateRequestContext = z.infer<
-  typeof CheckoutCreateRequestContextSchema
->;
-export const LookupRequestContextSchema = CheckoutCreateRequestContextSchema;
-export type LookupRequestContext = CheckoutCreateRequestContext;
+export type PurplePayment = z.infer<typeof PurplePaymentSchema>;
+export const FluffyPaymentSchema = PurplePaymentSchema;
+export type FluffyPayment = PurplePayment;
+
 
 export const ItemReferenceSchema = z.object({
-  id: z.string(),
+    "id": z.string(),
 });
 export type ItemReference = z.infer<typeof ItemReferenceSchema>;
 export const ItemCreateRequestSchema = ItemReferenceSchema;
@@ -171,99 +180,116 @@ export type ItemCreateRequest = ItemReference;
 export const ItemUpdateRequestSchema = ItemReferenceSchema;
 export type ItemUpdateRequest = ItemReference;
 
+
 export const PostalAddressSchema = z.object({
-  address_country: z.string().optional(),
-  address_locality: z.string().optional(),
-  address_region: z.string().optional(),
-  extended_address: z.string().optional(),
-  first_name: z.string().optional(),
-  last_name: z.string().optional(),
-  phone_number: z.string().optional(),
-  postal_code: z.string().optional(),
-  street_address: z.string().optional(),
+    "address_country": z.string().optional(),
+    "address_locality": z.string().optional(),
+    "address_region": z.string().optional(),
+    "extended_address": z.string().optional(),
+    "first_name": z.string().optional(),
+    "last_name": z.string().optional(),
+    "phone_number": z.string().optional(),
+    "postal_code": z.string().optional(),
+    "street_address": z.string().optional(),
 });
 export type PostalAddress = z.infer<typeof PostalAddressSchema>;
 
 export const PaymentCredentialSchema = z.object({
-  type: z.string(),
+    "type": z.string(),
 });
 export type PaymentCredential = z.infer<typeof PaymentCredentialSchema>;
 
 export const CheckoutCreateRequestSignalsSchema = z.object({
-  "dev.ucp.buyer_ip": z.string().optional(),
-  "dev.ucp.user_agent": z.string().optional(),
+    "dev.ucp.buyer_ip": z.string().optional(),
+    "dev.ucp.user_agent": z.string().optional(),
 });
-export type CheckoutCreateRequestSignals = z.infer<
-  typeof CheckoutCreateRequestSignalsSchema
->;
+export type CheckoutCreateRequestSignals = z.infer<typeof CheckoutCreateRequestSignalsSchema>;
 export const LookupRequestSignalsSchema = CheckoutCreateRequestSignalsSchema;
 export type LookupRequestSignals = CheckoutCreateRequestSignals;
 
+
+
+
+export const ActionsSchema = z.object({
+    "config": z.record(z.string(), z.any()).optional(),
+    "id": z.string().min(1),
+});
+export type Actions = z.infer<typeof ActionsSchema>;
+
 export const ItemResponseSchema = z.object({
-  id: z.string(),
-  image_url: z.string().optional(),
-  price: z.number().int().gte(0),
-  title: z.string(),
+    "id": z.string(),
+    "image_url": z.string().optional(),
+    "price": z.number().int().gte(0),
+    "title": z.string(),
 });
 export type ItemResponse = z.infer<typeof ItemResponseSchema>;
 
 export const TotalResponseSchema = z.object({
-  amount: z.number().int(),
-  display_text: z.string().optional(),
-  type: z.string(),
+    "amount": z.number().int(),
+    "display_text": z.string().optional(),
+    "type": z.string(),
 });
 export type TotalResponse = z.infer<typeof TotalResponseSchema>;
 
-export const LinkSchema = z.object({
-  title: z.string().optional(),
-  type: z.string(),
-  url: z.string(),
+export const CheckoutResponseLinkSchema = z.object({
+    "title": z.string().optional(),
+    "type": z.string(),
+    "url": z.string(),
 });
-export type Link = z.infer<typeof LinkSchema>;
+export type CheckoutResponseLink = z.infer<typeof CheckoutResponseLinkSchema>;
+export const ConsentLinkSchema = CheckoutResponseLinkSchema;
+export type ConsentLink = CheckoutResponseLink;
+
 
 export const CheckoutResponseMessageSchema = z.object({
-  code: z.string().optional(),
-  content: z.string(),
-  content_type: ContentTypeSchema.optional(),
-  path: z.string().optional(),
-  severity: SeveritySchema.optional(),
-  type: MessageTypeSchema,
-  image_url: z.string().optional(),
-  presentation: z.string().optional(),
-  url: z.string().optional(),
+    "code": z.string().optional(),
+    "content": z.string(),
+    "content_type": ContentTypeSchema.optional(),
+    "path": z.string().optional(),
+    "severity": SeveritySchema.optional(),
+    "type": TypeSchema,
+    "image_url": z.string().optional(),
+    "presentation": z.string().optional(),
+    "url": z.string().optional(),
 });
-export type CheckoutResponseMessage = z.infer<
-  typeof CheckoutResponseMessageSchema
->;
+export type CheckoutResponseMessage = z.infer<typeof CheckoutResponseMessageSchema>;
 export const LookupResponseMessageSchema = CheckoutResponseMessageSchema;
 export type LookupResponseMessage = CheckoutResponseMessage;
 
+
 export const OrderConfirmationSchema = z.object({
-  id: z.string(),
-  label: z.string().optional(),
-  permalink_url: z.string(),
+    "id": z.string(),
+    "label": z.string().optional(),
+    "permalink_url": z.string(),
 });
 export type OrderConfirmation = z.infer<typeof OrderConfirmationSchema>;
 
+export const DescriptionSchema = z.object({
+    "html": z.string().optional(),
+    "markdown": z.string().optional(),
+    "plain": z.string().optional(),
+});
+export type Description = z.infer<typeof DescriptionSchema>;
+
 export const LineSchema = z.object({
-  amount: z.number().int(),
-  display_text: z.string(),
+    "amount": z.number().int(),
+    "display_text": z.string(),
 });
 export type Line = z.infer<typeof LineSchema>;
 
 export const CapabilityResponseSchema = z.object({
-  config: z.record(z.string(), z.any()).optional(),
-  extends: z.string().optional(),
-  name: z.string(),
-  schema: z.string().optional(),
-  spec: z.string().optional(),
-  version: z.string(),
+    "config": z.record(z.string(), z.any()).optional(),
+    "extends": z.string().optional(),
+    "name": z.string(),
+    "schema": z.string().optional(),
+    "spec": z.string().optional(),
+    "version": z.string(),
 });
 export type CapabilityResponse = z.infer<typeof CapabilityResponseSchema>;
 
 export const LineItemQuantityRefSchema = z.object({
-  id: z.string(),
-  quantity: z.number(),
+    "id": z.string(),
+    "quantity": z.number(),
 });
 export type LineItemQuantityRef = z.infer<typeof LineItemQuantityRefSchema>;
 export const AdjustmentLineItemSchema = LineItemQuantityRefSchema;
@@ -273,227 +299,228 @@ export type EventLineItem = LineItemQuantityRef;
 export const ExpectationLineItemSchema = LineItemQuantityRefSchema;
 export type ExpectationLineItem = LineItemQuantityRef;
 
+
+
+
+
+
 export const QuantitySchema = z.object({
-  fulfilled: z.number().int().gte(0),
-  original: z.number().int().gte(0).optional(),
-  total: z.number().int().gte(0),
+    "fulfilled": z.number().int().gte(0),
+    "original": z.number().int().gte(0).optional(),
+    "total": z.number().int().gte(0),
 });
 export type Quantity = z.infer<typeof QuantitySchema>;
 
 export const PaymentInstrumentSchema = z.object({
-  billing_address: PostalAddressSchema.optional(),
-  credential: PaymentCredentialSchema.optional(),
-  display: z.record(z.string(), z.any()).optional(),
-  handler_id: z.string(),
-  id: z.string(),
-  type: z.string(),
+    "billing_address": PostalAddressSchema.optional(),
+    "credential": PaymentCredentialSchema.optional(),
+    "display": z.record(z.string(), z.any()).optional(),
+    "handler_id": z.string(),
+    "id": z.string(),
+    "type": z.string(),
 });
 export type PaymentInstrument = z.infer<typeof PaymentInstrumentSchema>;
 
 export const CompleteCheckoutRequestWithAp2Ap2Schema = z.object({
-  checkout_mandate: z
-    .string()
-    .regex(
-      /^[A-Za-z0-9_-]+\.[A-Za-z0-9_-]*\.[A-Za-z0-9_-]+(~[A-Za-z0-9_-]+)*$/
-    ),
+    "checkout_mandate": z.string().regex(/^[A-Za-z0-9_-]+\.[A-Za-z0-9_-]*\.[A-Za-z0-9_-]+(~[A-Za-z0-9_-]+)*$/),
 });
-export type CompleteCheckoutRequestWithAp2Ap2 = z.infer<
-  typeof CompleteCheckoutRequestWithAp2Ap2Schema
->;
+export type CompleteCheckoutRequestWithAp2Ap2 = z.infer<typeof CompleteCheckoutRequestWithAp2Ap2Schema>;
 
 export const CheckoutWithAp2MandateAp2Schema = z.object({
-  merchant_authorization: z
-    .string()
-    .regex(/^[A-Za-z0-9_-]+\.\.[A-Za-z0-9_-]+$/)
-    .optional(),
-  checkout_mandate: z
-    .string()
-    .regex(
-      /^[A-Za-z0-9_-]+\.[A-Za-z0-9_-]*\.[A-Za-z0-9_-]+(~[A-Za-z0-9_-]+)*$/
-    ),
+    "merchant_authorization": z.string().regex(/^[A-Za-z0-9_-]+\.\.[A-Za-z0-9_-]+$/).optional(),
+    "checkout_mandate": z.string().regex(/^[A-Za-z0-9_-]+\.[A-Za-z0-9_-]*\.[A-Za-z0-9_-]+(~[A-Za-z0-9_-]+)*$/),
 });
-export type CheckoutWithAp2MandateAp2 = z.infer<
-  typeof CheckoutWithAp2MandateAp2Schema
->;
+export type CheckoutWithAp2MandateAp2 = z.infer<typeof CheckoutWithAp2MandateAp2Schema>;
 
-export const ConsentSchema = z.object({
-  analytics: z.boolean().optional(),
-  marketing: z.boolean().optional(),
-  preferences: z.boolean().optional(),
-  sale_of_data: z.boolean().optional(),
+export const SegmentValueSchema = z.object({
+    "granted": z.boolean(),
+    "source": SourceSchema,
 });
-export type Consent = z.infer<typeof ConsentSchema>;
-export const FluffyConsentSchema = ConsentSchema;
-export type FluffyConsent = Consent;
-export const PurpleConsentSchema = ConsentSchema;
-export type PurpleConsent = Consent;
-export const TentacledConsentSchema = ConsentSchema;
-export type TentacledConsent = Consent;
+export type SegmentValue = z.infer<typeof SegmentValueSchema>;
+export const SegmentClassSchema = SegmentValueSchema;
+export type SegmentClass = SegmentValue;
+
+
+
+
+
+
+export const ConsentSegmentSchema = z.object({
+    "description": z.string(),
+    "granted": z.boolean(),
+    "links": z.array(ConsentLinkSchema).optional(),
+    "source": SourceSchema,
+});
+export type ConsentSegment = z.infer<typeof ConsentSegmentSchema>;
 
 export const CheckoutWithDiscountCreateRequestDiscountsSchema = z.object({
-  codes: z.array(z.string()).optional(),
+    "codes": z.array(z.string()).optional(),
 });
-export type CheckoutWithDiscountCreateRequestDiscounts = z.infer<
-  typeof CheckoutWithDiscountCreateRequestDiscountsSchema
->;
-export const CheckoutWithDiscountUpdateRequestDiscountsSchema =
-  CheckoutWithDiscountCreateRequestDiscountsSchema;
-export type CheckoutWithDiscountUpdateRequestDiscounts =
-  CheckoutWithDiscountCreateRequestDiscounts;
+export type CheckoutWithDiscountCreateRequestDiscounts = z.infer<typeof CheckoutWithDiscountCreateRequestDiscountsSchema>;
+export const CheckoutWithDiscountUpdateRequestDiscountsSchema = CheckoutWithDiscountCreateRequestDiscountsSchema;
+export type CheckoutWithDiscountUpdateRequestDiscounts = CheckoutWithDiscountCreateRequestDiscounts;
+
+
+
 
 export const AllocationElementSchema = z.object({
-  amount: z.number().int().gte(0),
-  path: z.string(),
+    "amount": z.number().int().gte(0),
+    "path": z.string(),
 });
 export type AllocationElement = z.infer<typeof AllocationElementSchema>;
 
 export const FulfillmentDestinationRequestSchema = z.object({
-  address_country: z.string().optional(),
-  address_locality: z.string().optional(),
-  address_region: z.string().optional(),
-  extended_address: z.string().optional(),
-  first_name: z.string().optional(),
-  last_name: z.string().optional(),
-  phone_number: z.string().optional(),
-  postal_code: z.string().optional(),
-  street_address: z.string().optional(),
-  id: z.string().optional(),
-  address: PostalAddressSchema.optional(),
-  name: z.string().optional(),
+    "address_country": z.string().optional(),
+    "address_locality": z.string().optional(),
+    "address_region": z.string().optional(),
+    "extended_address": z.string().optional(),
+    "first_name": z.string().optional(),
+    "last_name": z.string().optional(),
+    "phone_number": z.string().optional(),
+    "postal_code": z.string().optional(),
+    "street_address": z.string().optional(),
+    "id": z.string().optional(),
+    "address": PostalAddressSchema.optional(),
+    "name": z.string().optional(),
 });
-export type FulfillmentDestinationRequest = z.infer<
-  typeof FulfillmentDestinationRequestSchema
->;
+export type FulfillmentDestinationRequest = z.infer<typeof FulfillmentDestinationRequestSchema>;
 
 export const FulfillmentOptionSchema = z.object({
-  carrier: z.string().optional(),
-  description: z.string().optional(),
-  earliest_fulfillment_time: z.coerce.date().optional(),
-  id: z.string(),
-  latest_fulfillment_time: z.coerce.date().optional(),
-  title: z.string(),
-  totals: z.array(TotalResponseSchema),
+    "description": DescriptionSchema.optional(),
+    "id": z.string(),
+    "title": z.string(),
+    "carrier": z.string().optional(),
+    "earliest_fulfillment_time": z.coerce.date().optional(),
+    "latest_fulfillment_time": z.coerce.date().optional(),
+    "totals": z.array(TotalResponseSchema),
 });
 export type FulfillmentOption = z.infer<typeof FulfillmentOptionSchema>;
 
 export const FulfillmentAvailableMethodSchema = z.object({
-  description: z.string().optional(),
-  fulfillable_on: z.union([z.null(), z.string()]).optional(),
-  line_item_ids: z.array(z.string()),
-  type: MethodTypeSchema,
+    "description": z.string().optional(),
+    "fulfillable_on": z.union([z.null(), z.string()]).optional(),
+    "line_item_ids": z.array(z.string()),
+    "type": z.string(),
 });
-export type FulfillmentAvailableMethod = z.infer<
-  typeof FulfillmentAvailableMethodSchema
->;
+export type FulfillmentAvailableMethod = z.infer<typeof FulfillmentAvailableMethodSchema>;
 
 export const FulfillmentDestinationResponseSchema = z.object({
-  address_country: z.string().optional(),
-  address_locality: z.string().optional(),
-  address_region: z.string().optional(),
-  extended_address: z.string().optional(),
-  first_name: z.string().optional(),
-  last_name: z.string().optional(),
-  phone_number: z.string().optional(),
-  postal_code: z.string().optional(),
-  street_address: z.string().optional(),
-  id: z.string(),
-  address: PostalAddressSchema.optional(),
-  name: z.string().optional(),
+    "address_country": z.string().optional(),
+    "address_locality": z.string().optional(),
+    "address_region": z.string().optional(),
+    "extended_address": z.string().optional(),
+    "first_name": z.string().optional(),
+    "last_name": z.string().optional(),
+    "phone_number": z.string().optional(),
+    "postal_code": z.string().optional(),
+    "street_address": z.string().optional(),
+    "id": z.string(),
+    "address": PostalAddressSchema.optional(),
+    "name": z.string().optional(),
 });
-export type FulfillmentDestinationResponse = z.infer<
-  typeof FulfillmentDestinationResponseSchema
->;
+export type FulfillmentDestinationResponse = z.infer<typeof FulfillmentDestinationResponseSchema>;
+
+
 
 export const PriceFilterSchema = z.object({
-  max: z.number().optional(),
-  min: z.number().optional(),
+    "max": z.number().optional(),
+    "min": z.number().optional(),
 });
 export type PriceFilter = z.infer<typeof PriceFilterSchema>;
 
+
+
+
+
+export const LookupResponsePolicySchema = z.object({
+    "applies_to": z.array(z.string()).optional(),
+    "description": DescriptionSchema,
+    "type": z.string().regex(/^[a-z](?:[a-z0-9-]*[a-z0-9])?(?:\.[a-z0-9](?:[a-z0-9_-]*[a-z0-9_])?)+$/),
+    "url": z.string().optional(),
+});
+export type LookupResponsePolicy = z.infer<typeof LookupResponsePolicySchema>;
+export const CheckoutResponsePolicySchema = LookupResponsePolicySchema;
+export type CheckoutResponsePolicy = LookupResponsePolicy;
+
+
 export const CategorySchema = z.object({
-  taxonomy: z.string().optional(),
-  value: z.string(),
+    "taxonomy": z.string().optional(),
+    "value": z.string(),
 });
 export type Category = z.infer<typeof CategorySchema>;
 
-export const DescriptionSchema = z.object({
-  html: z.string().optional(),
-  markdown: z.string().optional(),
-  plain: z.string().optional(),
-});
-export type Description = z.infer<typeof DescriptionSchema>;
-
 export const PriceSchema = z.object({
-  amount: z.number().int().gte(0),
-  currency: z.string().regex(/^[A-Z]{3}$/),
+    "amount": z.number().int().gte(0),
+    "currency": z.string().regex(/^[A-Z]{3}$/),
 });
 export type Price = z.infer<typeof PriceSchema>;
 
 export const MediaSchema = z.object({
-  alt_text: z.string().optional(),
-  height: z.number().int().gte(1).optional(),
-  type: z.string(),
-  url: z.string(),
-  width: z.number().int().gte(1).optional(),
+    "alt_text": z.string().optional(),
+    "height": z.number().int().gte(1).optional(),
+    "type": z.string(),
+    "url": z.string(),
+    "width": z.number().int().gte(1).optional(),
 });
 export type Media = z.infer<typeof MediaSchema>;
 
 export const OptionValueSchema = z.object({
-  id: z.string().optional(),
-  label: z.string(),
+    "id": z.string().optional(),
+    "label": z.string(),
 });
 export type OptionValue = z.infer<typeof OptionValueSchema>;
 
 export const RatingSchema = z.object({
-  count: z.number().int().gte(0).optional(),
-  scale_max: z.number().gte(1),
-  scale_min: z.number().gte(0).optional(),
-  value: z.number().gte(0),
+    "count": z.number().int().gte(0).optional(),
+    "scale_max": z.number().gte(1),
+    "scale_min": z.number().gte(0).optional(),
+    "value": z.number().gte(0),
 });
 export type Rating = z.infer<typeof RatingSchema>;
 
-export const PurpleAvailabilitySchema = z.object({
-  available: z.boolean().optional(),
-  status: z.string().optional(),
+export const AvailabilitySchema = z.object({
+    "available": z.boolean().optional(),
+    "status": z.string().optional(),
 });
-export type PurpleAvailability = z.infer<typeof PurpleAvailabilitySchema>;
-export const FluffyAvailabilitySchema = PurpleAvailabilitySchema;
-export type FluffyAvailability = PurpleAvailability;
+export type Availability = z.infer<typeof AvailabilitySchema>;
 
 export const PurpleBarcodeSchema = z.object({
-  type: z.string(),
-  value: z.string(),
+    "type": z.string(),
+    "value": z.string(),
 });
 export type PurpleBarcode = z.infer<typeof PurpleBarcodeSchema>;
 export const FluffyBarcodeSchema = PurpleBarcodeSchema;
 export type FluffyBarcode = PurpleBarcode;
 
+
 export const InputCorrelationSchema = z.object({
-  id: z.string(),
-  match: z.string().optional(),
+    "id": z.string(),
+    "match": z.string().optional(),
 });
 export type InputCorrelation = z.infer<typeof InputCorrelationSchema>;
 
 export const OptionElementSchema = z.object({
-  id: z.string().optional(),
-  label: z.string(),
-  name: z.string(),
+    "id": z.string().optional(),
+    "label": z.string(),
+    "name": z.string(),
 });
 export type OptionElement = z.infer<typeof OptionElementSchema>;
 export const SelectedElementSchema = OptionElementSchema;
 export type SelectedElement = OptionElement;
 
+
 export const PurpleSellerSchema = z.object({
-  links: z.array(LinkSchema).optional(),
-  name: z.string().optional(),
+    "links": z.array(CheckoutResponseLinkSchema).optional(),
+    "name": z.string().optional(),
 });
 export type PurpleSeller = z.infer<typeof PurpleSellerSchema>;
 export const FluffySellerSchema = PurpleSellerSchema;
 export type FluffySeller = PurpleSeller;
 
+
 export const PurpleMeasureSchema = z.object({
-  unit: z.string(),
-  value: z.number().int(),
+    "unit": z.string(),
+    "value": z.number().int(),
 });
 export type PurpleMeasure = z.infer<typeof PurpleMeasureSchema>;
 export const FluffyMeasureSchema = PurpleMeasureSchema;
@@ -503,67 +530,89 @@ export type FluffyReference = PurpleMeasure;
 export const PurpleReferenceSchema = PurpleMeasureSchema;
 export type PurpleReference = PurpleMeasure;
 
+
+
+
+
+
+
+
+
+
+
+
+
+
 export const SearchRequestPaginationSchema = z.object({
-  cursor: z.string().optional(),
-  limit: z.number().int().gte(1).optional(),
+    "cursor": z.string().optional(),
+    "limit": z.number().int().gte(1).optional(),
 });
-export type SearchRequestPagination = z.infer<
-  typeof SearchRequestPaginationSchema
->;
+export type SearchRequestPagination = z.infer<typeof SearchRequestPaginationSchema>;
 
 export const SearchResponsePaginationSchema = z.object({
-  cursor: z.string().optional(),
-  has_next_page: z.boolean(),
-  total_count: z.number().int().gte(0).optional(),
+    "cursor": z.string().optional(),
+    "has_next_page": z.boolean(),
+    "total_count": z.number().int().gte(0).optional(),
 });
-export type SearchResponsePagination = z.infer<
-  typeof SearchResponsePaginationSchema
->;
+export type SearchResponsePagination = z.infer<typeof SearchResponsePaginationSchema>;
 
-export const PaymentSchema = z.object({
-  handlers: z.array(PaymentHandlerResponseSchema).optional(),
+export const UcpDiscoveryProfilePaymentSchema = z.object({
+    "handlers": z.array(PaymentHandlerResponseSchema).optional(),
 });
-export type Payment = z.infer<typeof PaymentSchema>;
+export type UcpDiscoveryProfilePayment = z.infer<typeof UcpDiscoveryProfilePaymentSchema>;
 
 export const UcpServiceSchema = z.object({
-  a2a: A2ASchema.optional(),
-  embedded: EmbeddedSchema.optional(),
-  mcp: McpSchema.optional(),
-  rest: RestSchema.optional(),
-  spec: z.string(),
-  version: z.string(),
+    "a2a": A2ASchema.optional(),
+    "embedded": EmbeddedSchema.optional(),
+    "mcp": McpSchema.optional(),
+    "rest": RestSchema.optional(),
+    "spec": z.string(),
+    "version": z.string(),
 });
 export type UcpService = z.infer<typeof UcpServiceSchema>;
 
+export const CheckoutCreateRequestContextSchema = z.object({
+    "address_country": z.string().optional(),
+    "address_region": z.string().optional(),
+    "postal_code": z.string().optional(),
+    "currency": z.string().optional(),
+    "eligibility": z.array(z.string()).optional(),
+    "intent": z.string().optional(),
+    "language": z.string().optional(),
+    "payment": z.array(PurplePaymentSchema).optional(),
+});
+export type CheckoutCreateRequestContext = z.infer<typeof CheckoutCreateRequestContextSchema>;
+export const LookupRequestContextSchema = CheckoutCreateRequestContextSchema;
+export type LookupRequestContext = CheckoutCreateRequestContext;
+
+
 export const LineItemCreateRequestSchema = z.object({
-  item: ItemCreateRequestSchema,
-  quantity: z.number(),
+    "item": ItemCreateRequestSchema,
+    "quantity": z.number(),
 });
 export type LineItemCreateRequest = z.infer<typeof LineItemCreateRequestSchema>;
 
 export const SelectedPaymentInstrumentSchema = z.object({
-  billing_address: PostalAddressSchema.optional(),
-  credential: PaymentCredentialSchema.optional(),
-  display: z.record(z.string(), z.any()).optional(),
-  handler_id: z.string(),
-  id: z.string(),
-  type: z.string(),
-  selected: z.boolean().optional(),
+    "billing_address": PostalAddressSchema.optional(),
+    "credential": PaymentCredentialSchema.optional(),
+    "display": z.record(z.string(), z.any()).optional(),
+    "handler_id": z.string(),
+    "id": z.string(),
+    "type": z.string(),
+    "selected": z.boolean().optional(),
 });
-export type SelectedPaymentInstrument = z.infer<
-  typeof SelectedPaymentInstrumentSchema
->;
+export type SelectedPaymentInstrument = z.infer<typeof SelectedPaymentInstrumentSchema>;
 
 export const LineItemUpdateRequestSchema = z.object({
-  id: z.string().optional(),
-  item: ItemUpdateRequestSchema,
-  parent_id: z.string().optional(),
-  quantity: z.number(),
+    "id": z.string().optional(),
+    "item": ItemUpdateRequestSchema,
+    "parent_id": z.string().optional(),
+    "quantity": z.number(),
 });
 export type LineItemUpdateRequest = z.infer<typeof LineItemUpdateRequestSchema>;
 
 export const PaymentSelectionSchema = z.object({
-  instruments: z.array(SelectedPaymentInstrumentSchema).optional(),
+    "instruments": z.array(SelectedPaymentInstrumentSchema).optional(),
 });
 export type PaymentSelection = z.infer<typeof PaymentSelectionSchema>;
 export const PaymentCompleteRequestSchema = PaymentSelectionSchema;
@@ -575,673 +624,701 @@ export type PaymentResponse = PaymentSelection;
 export const PaymentUpdateRequestSchema = PaymentSelectionSchema;
 export type PaymentUpdateRequest = PaymentSelection;
 
+
+
+
 export const LineItemResponseSchema = z.object({
-  id: z.string(),
-  item: ItemResponseSchema,
-  parent_id: z.string().optional(),
-  quantity: z.number().int().gte(1),
-  totals: z.array(TotalResponseSchema),
+    "id": z.string(),
+    "item": ItemResponseSchema,
+    "parent_id": z.string().optional(),
+    "quantity": z.number().int().gte(1),
+    "totals": z.array(TotalResponseSchema),
 });
 export type LineItemResponse = z.infer<typeof LineItemResponseSchema>;
 
+
+
+
+
 export const TotalsResponseSchema = z.object({
-  amount: z.number().int(),
-  display_text: z.string().optional(),
-  type: z.string(),
-  lines: z.array(LineSchema).optional(),
+    "amount": z.number().int(),
+    "display_text": z.string().optional(),
+    "type": z.string(),
+    "lines": z.array(LineSchema).optional(),
 });
 export type TotalsResponse = z.infer<typeof TotalsResponseSchema>;
 
 export const UcpResponseSchema = z.object({
-  capabilities: z.record(z.string(), z.array(CapabilityResponseSchema)),
-  version: z.string(),
+    "capabilities": z.record(z.string(), z.array(CapabilityResponseSchema)),
+    "version": z.string(),
 });
 export type UcpResponse = z.infer<typeof UcpResponseSchema>;
 
 export const AdjustmentSchema = z.object({
-  description: z.string().optional(),
-  id: z.string(),
-  line_items: z.array(AdjustmentLineItemSchema).optional(),
-  occurred_at: z.coerce.date(),
-  status: AdjustmentStatusSchema,
-  totals: z.array(TotalResponseSchema).optional(),
-  type: z.string(),
+    "description": z.string().optional(),
+    "id": z.string(),
+    "line_items": z.array(AdjustmentLineItemSchema).optional(),
+    "occurred_at": z.coerce.date(),
+    "status": AdjustmentStatusSchema,
+    "totals": z.array(TotalResponseSchema).optional(),
+    "type": z.string(),
 });
 export type Adjustment = z.infer<typeof AdjustmentSchema>;
 
 export const FulfillmentEventSchema = z.object({
-  carrier: z.string().optional(),
-  description: z.string().optional(),
-  id: z.string(),
-  line_items: z.array(EventLineItemSchema),
-  occurred_at: z.coerce.date(),
-  tracking_number: z.string().optional(),
-  tracking_url: z.string().optional(),
-  type: z.string(),
+    "carrier": z.string().optional(),
+    "description": z.string().optional(),
+    "id": z.string(),
+    "line_items": z.array(EventLineItemSchema),
+    "occurred_at": z.coerce.date(),
+    "tracking_number": z.string().optional(),
+    "tracking_url": z.string().optional(),
+    "type": z.string(),
 });
 export type FulfillmentEvent = z.infer<typeof FulfillmentEventSchema>;
 
 export const ExpectationSchema = z.object({
-  description: z.string().optional(),
-  destination: PostalAddressSchema,
-  fulfillable_on: z.string().optional(),
-  id: z.string(),
-  line_items: z.array(ExpectationLineItemSchema),
-  method_type: MethodTypeEnumSchema,
+    "description": z.string().optional(),
+    "destination": PostalAddressSchema,
+    "fulfillable_on": z.string().optional(),
+    "id": z.string(),
+    "line_items": z.array(ExpectationLineItemSchema),
+    "method_type": z.string(),
 });
 export type Expectation = z.infer<typeof ExpectationSchema>;
 
 export const OrderLineItemSchema = z.object({
-  id: z.string(),
-  item: ItemResponseSchema,
-  parent_id: z.string().optional(),
-  quantity: QuantitySchema,
-  status: LineItemStatusSchema,
-  totals: z.array(TotalResponseSchema),
+    "id": z.string(),
+    "item": ItemResponseSchema,
+    "parent_id": z.string().optional(),
+    "quantity": QuantitySchema,
+    "status": LineItemStatusSchema,
+    "totals": z.array(TotalResponseSchema),
 });
 export type OrderLineItem = z.infer<typeof OrderLineItemSchema>;
 
 export const PaymentDataSchema = z.object({
-  payment_data: PaymentInstrumentSchema,
+    "payment_data": PaymentInstrumentSchema,
 });
 export type PaymentData = z.infer<typeof PaymentDataSchema>;
 
 export const CompleteCheckoutRequestWithAp2Schema = z.object({
-  ap2: CompleteCheckoutRequestWithAp2Ap2Schema.optional(),
+    "ap2": CompleteCheckoutRequestWithAp2Ap2Schema.optional(),
 });
-export type CompleteCheckoutRequestWithAp2 = z.infer<
-  typeof CompleteCheckoutRequestWithAp2Schema
->;
+export type CompleteCheckoutRequestWithAp2 = z.infer<typeof CompleteCheckoutRequestWithAp2Schema>;
 
 export const CheckoutWithAp2MandateSchema = z.object({
-  attribution: z.record(z.string(), z.string()).optional(),
-  buyer: BuyerSchema.optional(),
-  context: CheckoutCreateRequestContextSchema.optional(),
-  continue_url: z.string().optional(),
-  currency: z.string(),
-  expires_at: z.coerce.date().optional(),
-  id: z.string(),
-  line_items: z.array(LineItemResponseSchema),
-  links: z.array(LinkSchema),
-  messages: z.array(CheckoutResponseMessageSchema).optional(),
-  order: OrderConfirmationSchema.optional(),
-  payment: PaymentResponseSchema.optional(),
-  signals: CheckoutCreateRequestSignalsSchema.optional(),
-  status: CheckoutResponseStatusSchema,
-  totals: z.array(TotalsResponseSchema),
-  ucp: UcpResponseSchema,
-  ap2: CheckoutWithAp2MandateAp2Schema.optional(),
+    "actions": z.record(z.string(), z.array(ActionsSchema)).optional(),
+    "attribution": z.record(z.string(), z.string()).optional(),
+    "buyer": BuyerSchema.optional(),
+    "context": CheckoutCreateRequestContextSchema.optional(),
+    "continue_url": z.string().optional(),
+    "currency": z.string(),
+    "expires_at": z.coerce.date().optional(),
+    "id": z.string(),
+    "line_items": z.array(LineItemResponseSchema),
+    "links": z.array(CheckoutResponseLinkSchema),
+    "messages": z.array(CheckoutResponseMessageSchema).optional(),
+    "order": OrderConfirmationSchema.optional(),
+    "payment": PaymentResponseSchema.optional(),
+    "policies": z.array(CheckoutResponsePolicySchema).optional(),
+    "signals": CheckoutCreateRequestSignalsSchema.optional(),
+    "status": CheckoutResponseStatusSchema,
+    "totals": z.array(TotalsResponseSchema),
+    "ucp": UcpResponseSchema,
+    "ap2": CheckoutWithAp2MandateAp2Schema.optional(),
 });
-export type CheckoutWithAp2Mandate = z.infer<
-  typeof CheckoutWithAp2MandateSchema
->;
+export type CheckoutWithAp2Mandate = z.infer<typeof CheckoutWithAp2MandateSchema>;
 
-export const BuyerWithConsentCreateRequestSchema = z.object({
-  email: z.string().optional(),
-  first_name: z.string().optional(),
-  last_name: z.string().optional(),
-  phone_number: z.string().optional(),
-  consent: PurpleConsentSchema.optional(),
+export const ConsentValueSchema = z.object({
+    "granted": z.boolean(),
+    "segments": z.record(z.string(), SegmentValueSchema).optional(),
+    "source": SourceSchema,
 });
-export type BuyerWithConsentCreateRequest = z.infer<
-  typeof BuyerWithConsentCreateRequestSchema
->;
-export const BuyerWithConsentResponseSchema =
-  BuyerWithConsentCreateRequestSchema;
-export type BuyerWithConsentResponse = BuyerWithConsentCreateRequest;
-export const BuyerWithConsentUpdateRequestSchema =
-  BuyerWithConsentCreateRequestSchema;
-export type BuyerWithConsentUpdateRequest = BuyerWithConsentCreateRequest;
+export type ConsentValue = z.infer<typeof ConsentValueSchema>;
+export const ConsentClassSchema = ConsentValueSchema;
+export type ConsentClass = ConsentValue;
+
+
+
+
+export const BuyerConsentSchema = z.object({
+    "description": z.string(),
+    "granted": z.boolean(),
+    "links": z.array(ConsentLinkSchema).optional(),
+    "segments": z.record(z.string(), ConsentSegmentSchema).optional(),
+    "source": SourceSchema,
+});
+export type BuyerConsent = z.infer<typeof BuyerConsentSchema>;
 
 export const CheckoutWithDiscountUpdateRequestSchema = z.object({
-  attribution: z.record(z.string(), z.string()).optional(),
-  buyer: BuyerSchema.optional(),
-  context: CheckoutCreateRequestContextSchema.optional(),
-  line_items: z.array(LineItemUpdateRequestSchema),
-  payment: PaymentUpdateRequestSchema.optional(),
-  signals: CheckoutCreateRequestSignalsSchema.optional(),
-  discounts: CheckoutWithDiscountUpdateRequestDiscountsSchema.optional(),
+    "attribution": z.record(z.string(), z.string()).optional(),
+    "buyer": BuyerSchema.optional(),
+    "context": CheckoutCreateRequestContextSchema.optional(),
+    "line_items": z.array(LineItemUpdateRequestSchema),
+    "payment": PaymentUpdateRequestSchema.optional(),
+    "signals": CheckoutCreateRequestSignalsSchema.optional(),
+    "discounts": CheckoutWithDiscountUpdateRequestDiscountsSchema.optional(),
 });
-export type CheckoutWithDiscountUpdateRequest = z.infer<
-  typeof CheckoutWithDiscountUpdateRequestSchema
->;
+export type CheckoutWithDiscountUpdateRequest = z.infer<typeof CheckoutWithDiscountUpdateRequestSchema>;
 
 export const AppliedElementSchema = z.object({
-  allocations: z.array(AllocationElementSchema).optional(),
-  amount: z.number().int().gte(0),
-  automatic: z.boolean().optional(),
-  code: z.string().optional(),
-  eligibility: z
-    .string()
-    .regex(
-      /^[a-z](?:[a-z0-9-]*[a-z0-9])?(?:\.[a-z0-9](?:[a-z0-9_-]*[a-z0-9_])?)+$/
-    )
-    .optional(),
-  method: MethodSchema.optional(),
-  priority: z.number().int().gte(1).optional(),
-  provisional: z.boolean().optional(),
-  title: z.string(),
+    "allocations": z.array(AllocationElementSchema).optional(),
+    "amount": z.number().int().gte(0),
+    "automatic": z.boolean().optional(),
+    "code": z.string().optional(),
+    "eligibility": z.string().regex(/^[a-z](?:[a-z0-9-]*[a-z0-9])?(?:\.[a-z0-9](?:[a-z0-9_-]*[a-z0-9_])?)+$/).optional(),
+    "method": MethodSchema.optional(),
+    "priority": z.number().int().gte(1).optional(),
+    "provisional": z.boolean().optional(),
+    "title": z.string(),
 });
 export type AppliedElement = z.infer<typeof AppliedElementSchema>;
 
 export const FulfillmentGroupSchema = z.object({
-  id: z.string(),
-  line_item_ids: z.array(z.string()),
-  options: z.array(FulfillmentOptionSchema).optional(),
-  selected_option_id: z.union([z.null(), z.string()]).optional(),
+    "id": z.string(),
+    "line_item_ids": z.array(z.string()),
+    "options": z.array(FulfillmentOptionSchema).optional(),
+    "selected_option_id": z.union([z.null(), z.string()]).optional(),
 });
 export type FulfillmentGroup = z.infer<typeof FulfillmentGroupSchema>;
 
 export const FulfillmentMethodResponseSchema = z.object({
-  destinations: z.array(FulfillmentDestinationResponseSchema).optional(),
-  groups: z.array(FulfillmentGroupSchema).optional(),
-  id: z.string(),
-  line_item_ids: z.array(z.string()),
-  selected_destination_id: z.union([z.null(), z.string()]).optional(),
-  type: MethodTypeSchema,
+    "destinations": z.array(FulfillmentDestinationResponseSchema).optional(),
+    "groups": z.array(FulfillmentGroupSchema).optional(),
+    "id": z.string(),
+    "line_item_ids": z.array(z.string()),
+    "selected_destination_id": z.union([z.null(), z.string()]).optional(),
+    "type": z.string(),
 });
-export type FulfillmentMethodResponse = z.infer<
-  typeof FulfillmentMethodResponseSchema
->;
+export type FulfillmentMethodResponse = z.infer<typeof FulfillmentMethodResponseSchema>;
 
 export const CartCreateRequestSchema = z.object({
-  attribution: z.record(z.string(), z.string()).optional(),
-  buyer: BuyerSchema.optional(),
-  context: CheckoutCreateRequestContextSchema.optional(),
-  line_items: z.array(LineItemCreateRequestSchema),
-  signals: CheckoutCreateRequestSignalsSchema.optional(),
+    "attribution": z.record(z.string(), z.string()).optional(),
+    "buyer": BuyerSchema.optional(),
+    "context": CheckoutCreateRequestContextSchema.optional(),
+    "line_items": z.array(LineItemCreateRequestSchema),
+    "signals": CheckoutCreateRequestSignalsSchema.optional(),
 });
 export type CartCreateRequest = z.infer<typeof CartCreateRequestSchema>;
 
 export const CartUpdateRequestSchema = z.object({
-  attribution: z.record(z.string(), z.string()).optional(),
-  buyer: BuyerSchema.optional(),
-  context: CheckoutCreateRequestContextSchema.optional(),
-  id: z.string(),
-  line_items: z.array(LineItemUpdateRequestSchema),
-  signals: CheckoutCreateRequestSignalsSchema.optional(),
+    "attribution": z.record(z.string(), z.string()).optional(),
+    "buyer": BuyerSchema.optional(),
+    "context": CheckoutCreateRequestContextSchema.optional(),
+    "id": z.string(),
+    "line_items": z.array(LineItemUpdateRequestSchema),
+    "signals": CheckoutCreateRequestSignalsSchema.optional(),
 });
 export type CartUpdateRequest = z.infer<typeof CartUpdateRequestSchema>;
 
 export const CartResponseSchema = z.object({
-  attribution: z.record(z.string(), z.string()).optional(),
-  buyer: BuyerSchema.optional(),
-  context: CheckoutCreateRequestContextSchema.optional(),
-  continue_url: z.string().optional(),
-  currency: z.string(),
-  expires_at: z.coerce.date().optional(),
-  id: z.string(),
-  line_items: z.array(LineItemResponseSchema),
-  links: z.array(LinkSchema).optional(),
-  messages: z.array(CheckoutResponseMessageSchema).optional(),
-  signals: CheckoutCreateRequestSignalsSchema.optional(),
-  totals: z.array(TotalsResponseSchema),
-  ucp: UcpResponseSchema,
+    "actions": z.record(z.string(), z.array(ActionsSchema)).optional(),
+    "attribution": z.record(z.string(), z.string()).optional(),
+    "buyer": BuyerSchema.optional(),
+    "context": CheckoutCreateRequestContextSchema.optional(),
+    "continue_url": z.string().optional(),
+    "currency": z.string(),
+    "expires_at": z.coerce.date().optional(),
+    "id": z.string(),
+    "line_items": z.array(LineItemResponseSchema),
+    "links": z.array(CheckoutResponseLinkSchema).optional(),
+    "messages": z.array(CheckoutResponseMessageSchema).optional(),
+    "policies": z.array(CheckoutResponsePolicySchema).optional(),
+    "signals": CheckoutCreateRequestSignalsSchema.optional(),
+    "totals": z.array(TotalsResponseSchema),
+    "ucp": UcpResponseSchema,
 });
 export type CartResponse = z.infer<typeof CartResponseSchema>;
 
 export const CheckoutWithCartUpdateRequestSchema = z.object({
-  attribution: z.record(z.string(), z.string()).optional(),
-  buyer: BuyerSchema.optional(),
-  context: CheckoutCreateRequestContextSchema.optional(),
-  line_items: z.array(LineItemUpdateRequestSchema),
-  payment: PaymentUpdateRequestSchema.optional(),
-  signals: CheckoutCreateRequestSignalsSchema.optional(),
+    "attribution": z.record(z.string(), z.string()).optional(),
+    "buyer": BuyerSchema.optional(),
+    "context": CheckoutCreateRequestContextSchema.optional(),
+    "line_items": z.array(LineItemUpdateRequestSchema),
+    "payment": PaymentUpdateRequestSchema.optional(),
+    "signals": CheckoutCreateRequestSignalsSchema.optional(),
 });
-export type CheckoutWithCartUpdateRequest = z.infer<
-  typeof CheckoutWithCartUpdateRequestSchema
->;
+export type CheckoutWithCartUpdateRequest = z.infer<typeof CheckoutWithCartUpdateRequestSchema>;
 export const CheckoutUpdateRequestSchema = CheckoutWithCartUpdateRequestSchema;
 export type CheckoutUpdateRequest = CheckoutWithCartUpdateRequest;
 
+
 export const CheckoutWithCartResponseSchema = z.object({
-  attribution: z.record(z.string(), z.string()).optional(),
-  buyer: BuyerSchema.optional(),
-  context: CheckoutCreateRequestContextSchema.optional(),
-  continue_url: z.string().optional(),
-  currency: z.string(),
-  expires_at: z.coerce.date().optional(),
-  id: z.string(),
-  line_items: z.array(LineItemResponseSchema),
-  links: z.array(LinkSchema),
-  messages: z.array(CheckoutResponseMessageSchema).optional(),
-  order: OrderConfirmationSchema.optional(),
-  payment: PaymentResponseSchema.optional(),
-  signals: CheckoutCreateRequestSignalsSchema.optional(),
-  status: CheckoutResponseStatusSchema,
-  totals: z.array(TotalsResponseSchema),
-  ucp: UcpResponseSchema,
-  cart_id: z.string().optional(),
+    "actions": z.record(z.string(), z.array(ActionsSchema)).optional(),
+    "attribution": z.record(z.string(), z.string()).optional(),
+    "buyer": BuyerSchema.optional(),
+    "context": CheckoutCreateRequestContextSchema.optional(),
+    "continue_url": z.string().optional(),
+    "currency": z.string(),
+    "expires_at": z.coerce.date().optional(),
+    "id": z.string(),
+    "line_items": z.array(LineItemResponseSchema),
+    "links": z.array(CheckoutResponseLinkSchema),
+    "messages": z.array(CheckoutResponseMessageSchema).optional(),
+    "order": OrderConfirmationSchema.optional(),
+    "payment": PaymentResponseSchema.optional(),
+    "policies": z.array(CheckoutResponsePolicySchema).optional(),
+    "signals": CheckoutCreateRequestSignalsSchema.optional(),
+    "status": CheckoutResponseStatusSchema,
+    "totals": z.array(TotalsResponseSchema),
+    "ucp": UcpResponseSchema,
+    "cart_id": z.string().optional(),
 });
-export type CheckoutWithCartResponse = z.infer<
-  typeof CheckoutWithCartResponseSchema
->;
+export type CheckoutWithCartResponse = z.infer<typeof CheckoutWithCartResponseSchema>;
+
+
 
 export const SearchFiltersSchema = z.object({
-  categories: z.array(z.string()).optional(),
-  price: PriceFilterSchema.optional(),
+    "categories": z.array(z.string()).optional(),
+    "price": PriceFilterSchema.optional(),
 });
 export type SearchFilters = z.infer<typeof SearchFiltersSchema>;
 
 export const PriceRangeSchema = z.object({
-  max: PriceSchema,
-  min: PriceSchema,
+    "max": PriceSchema,
+    "min": PriceSchema,
 });
 export type PriceRange = z.infer<typeof PriceRangeSchema>;
 
 export const ProductOptionSchema = z.object({
-  name: z.string(),
-  values: z.array(OptionValueSchema).min(1),
+    "name": z.string(),
+    "values": z.array(OptionValueSchema).min(1),
 });
 export type ProductOption = z.infer<typeof ProductOptionSchema>;
 
 export const PurpleUnitPriceSchema = z.object({
-  amount: z.number().int().gte(0),
-  currency: z.string().regex(/^[A-Z]{3}$/),
-  measure: PurpleMeasureSchema,
-  reference: PurpleReferenceSchema,
+    "amount": z.number().int().gte(0),
+    "currency": z.string().regex(/^[A-Z]{3}$/),
+    "measure": PurpleMeasureSchema,
+    "reference": PurpleReferenceSchema,
 });
 export type PurpleUnitPrice = z.infer<typeof PurpleUnitPriceSchema>;
 export const FluffyUnitPriceSchema = PurpleUnitPriceSchema;
 export type FluffyUnitPrice = PurpleUnitPrice;
 
+
 export const GetProductRequestSchema = z.object({
-  attribution: z.record(z.string(), z.string()).optional(),
-  context: LookupRequestContextSchema.optional(),
-  filters: SearchFiltersSchema.optional(),
-  id: z.string(),
-  preferences: z.array(z.string()).optional(),
-  selected: z.array(SelectedElementSchema).optional(),
-  signals: LookupRequestSignalsSchema.optional(),
+    "attribution": z.record(z.string(), z.string()).optional(),
+    "context": LookupRequestContextSchema.optional(),
+    "filters": SearchFiltersSchema.optional(),
+    "id": z.string(),
+    "preferences": z.array(z.string()).optional(),
+    "selected": z.array(SelectedElementSchema).optional(),
+    "signals": LookupRequestSignalsSchema.optional(),
 });
 export type GetProductRequest = z.infer<typeof GetProductRequestSchema>;
 
+
+
 export const SearchRequestSchema = z.object({
-  attribution: z.record(z.string(), z.string()).optional(),
-  context: LookupRequestContextSchema.optional(),
-  filters: SearchFiltersSchema.optional(),
-  pagination: SearchRequestPaginationSchema.optional(),
-  query: z.string().optional(),
-  signals: LookupRequestSignalsSchema.optional(),
+    "attribution": z.record(z.string(), z.string()).optional(),
+    "context": LookupRequestContextSchema.optional(),
+    "filters": SearchFiltersSchema.optional(),
+    "pagination": SearchRequestPaginationSchema.optional(),
+    "query": z.string().optional(),
+    "signals": LookupRequestSignalsSchema.optional(),
 });
 export type SearchRequest = z.infer<typeof SearchRequestSchema>;
 
 export const UcpSchema = z.object({
-  capabilities: z.array(CapabilityDiscoverySchema),
-  services: z.record(z.string(), UcpServiceSchema),
-  version: z.string(),
+    "capabilities": z.array(CapabilityDiscoverySchema),
+    "services": z.record(z.string(), UcpServiceSchema),
+    "version": z.string(),
 });
 export type Ucp = z.infer<typeof UcpSchema>;
 
+
+
+
+
 export const CheckoutCompleteRequestSchema = z.object({
-  attribution: z.record(z.string(), z.string()).optional(),
-  payment: PaymentCompleteRequestSchema,
-  signals: CheckoutCreateRequestSignalsSchema.optional(),
+    "attribution": z.record(z.string(), z.string()).optional(),
+    "payment": PaymentCompleteRequestSchema,
+    "signals": CheckoutCreateRequestSignalsSchema.optional(),
 });
-export type CheckoutCompleteRequest = z.infer<
-  typeof CheckoutCompleteRequestSchema
->;
+export type CheckoutCompleteRequest = z.infer<typeof CheckoutCompleteRequestSchema>;
 
 export const CheckoutResponseSchema = z.object({
-  attribution: z.record(z.string(), z.string()).optional(),
-  buyer: BuyerSchema.optional(),
-  context: CheckoutCreateRequestContextSchema.optional(),
-  continue_url: z.string().optional(),
-  currency: z.string(),
-  expires_at: z.coerce.date().optional(),
-  id: z.string(),
-  line_items: z.array(LineItemResponseSchema),
-  links: z.array(LinkSchema),
-  messages: z.array(CheckoutResponseMessageSchema).optional(),
-  order: OrderConfirmationSchema.optional(),
-  payment: PaymentResponseSchema.optional(),
-  signals: CheckoutCreateRequestSignalsSchema.optional(),
-  status: CheckoutResponseStatusSchema,
-  totals: z.array(TotalsResponseSchema),
-  ucp: UcpResponseSchema,
+    "actions": z.record(z.string(), z.array(ActionsSchema)).optional(),
+    "attribution": z.record(z.string(), z.string()).optional(),
+    "buyer": BuyerSchema.optional(),
+    "context": CheckoutCreateRequestContextSchema.optional(),
+    "continue_url": z.string().optional(),
+    "currency": z.string(),
+    "expires_at": z.coerce.date().optional(),
+    "id": z.string(),
+    "line_items": z.array(LineItemResponseSchema),
+    "links": z.array(CheckoutResponseLinkSchema),
+    "messages": z.array(CheckoutResponseMessageSchema).optional(),
+    "order": OrderConfirmationSchema.optional(),
+    "payment": PaymentResponseSchema.optional(),
+    "policies": z.array(CheckoutResponsePolicySchema).optional(),
+    "signals": CheckoutCreateRequestSignalsSchema.optional(),
+    "status": CheckoutResponseStatusSchema,
+    "totals": z.array(TotalsResponseSchema),
+    "ucp": UcpResponseSchema,
 });
 export type CheckoutResponse = z.infer<typeof CheckoutResponseSchema>;
 
 export const FulfillmentSchema = z.object({
-  events: z.array(FulfillmentEventSchema).optional(),
-  expectations: z.array(ExpectationSchema).optional(),
+    "events": z.array(FulfillmentEventSchema).optional(),
+    "expectations": z.array(ExpectationSchema).optional(),
 });
 export type Fulfillment = z.infer<typeof FulfillmentSchema>;
 
-export const CheckoutWithBuyerConsentCreateRequestSchema = z.object({
-  attribution: z.record(z.string(), z.string()).optional(),
-  buyer: BuyerWithConsentCreateRequestSchema.optional(),
-  context: CheckoutCreateRequestContextSchema.optional(),
-  line_items: z.array(LineItemCreateRequestSchema),
-  payment: PaymentCreateRequestSchema.optional(),
-  signals: CheckoutCreateRequestSignalsSchema.optional(),
+export const BuyerWithConsentCreateRequestSchema = z.object({
+    "email": z.string().optional(),
+    "first_name": z.string().optional(),
+    "last_name": z.string().optional(),
+    "phone_number": z.string().optional(),
+    "consent": z.record(z.string(), ConsentValueSchema).optional(),
 });
-export type CheckoutWithBuyerConsentCreateRequest = z.infer<
-  typeof CheckoutWithBuyerConsentCreateRequestSchema
->;
+export type BuyerWithConsentCreateRequest = z.infer<typeof BuyerWithConsentCreateRequestSchema>;
 
-export const CheckoutWithBuyerConsentUpdateRequestSchema = z.object({
-  attribution: z.record(z.string(), z.string()).optional(),
-  buyer: BuyerWithConsentUpdateRequestSchema.optional(),
-  context: CheckoutCreateRequestContextSchema.optional(),
-  line_items: z.array(LineItemUpdateRequestSchema),
-  payment: PaymentUpdateRequestSchema.optional(),
-  signals: CheckoutCreateRequestSignalsSchema.optional(),
+export const BuyerWithConsentUpdateRequestSchema = z.object({
+    "email": z.string().optional(),
+    "first_name": z.string().optional(),
+    "last_name": z.string().optional(),
+    "phone_number": z.string().optional(),
+    "consent": z.record(z.string(), ConsentClassSchema).optional(),
 });
-export type CheckoutWithBuyerConsentUpdateRequest = z.infer<
-  typeof CheckoutWithBuyerConsentUpdateRequestSchema
->;
+export type BuyerWithConsentUpdateRequest = z.infer<typeof BuyerWithConsentUpdateRequestSchema>;
 
-export const CheckoutWithBuyerConsentResponseSchema = z.object({
-  attribution: z.record(z.string(), z.string()).optional(),
-  buyer: BuyerWithConsentResponseSchema.optional(),
-  context: CheckoutCreateRequestContextSchema.optional(),
-  continue_url: z.string().optional(),
-  currency: z.string(),
-  expires_at: z.coerce.date().optional(),
-  id: z.string(),
-  line_items: z.array(LineItemResponseSchema),
-  links: z.array(LinkSchema),
-  messages: z.array(CheckoutResponseMessageSchema).optional(),
-  order: OrderConfirmationSchema.optional(),
-  payment: PaymentResponseSchema.optional(),
-  signals: CheckoutCreateRequestSignalsSchema.optional(),
-  status: CheckoutResponseStatusSchema,
-  totals: z.array(TotalsResponseSchema),
-  ucp: UcpResponseSchema,
+export const BuyerWithConsentResponseSchema = z.object({
+    "email": z.string().optional(),
+    "first_name": z.string().optional(),
+    "last_name": z.string().optional(),
+    "phone_number": z.string().optional(),
+    "consent": z.record(z.string(), BuyerConsentSchema).optional(),
 });
-export type CheckoutWithBuyerConsentResponse = z.infer<
-  typeof CheckoutWithBuyerConsentResponseSchema
->;
+export type BuyerWithConsentResponse = z.infer<typeof BuyerWithConsentResponseSchema>;
 
 export const CheckoutWithDiscountCreateRequestSchema = z.object({
-  attribution: z.record(z.string(), z.string()).optional(),
-  buyer: BuyerSchema.optional(),
-  context: CheckoutCreateRequestContextSchema.optional(),
-  line_items: z.array(LineItemCreateRequestSchema),
-  payment: PaymentCreateRequestSchema.optional(),
-  signals: CheckoutCreateRequestSignalsSchema.optional(),
-  discounts: CheckoutWithDiscountCreateRequestDiscountsSchema.optional(),
+    "attribution": z.record(z.string(), z.string()).optional(),
+    "buyer": BuyerSchema.optional(),
+    "context": CheckoutCreateRequestContextSchema.optional(),
+    "line_items": z.array(LineItemCreateRequestSchema),
+    "payment": PaymentCreateRequestSchema.optional(),
+    "signals": CheckoutCreateRequestSignalsSchema.optional(),
+    "discounts": CheckoutWithDiscountCreateRequestDiscountsSchema.optional(),
 });
-export type CheckoutWithDiscountCreateRequest = z.infer<
-  typeof CheckoutWithDiscountCreateRequestSchema
->;
+export type CheckoutWithDiscountCreateRequest = z.infer<typeof CheckoutWithDiscountCreateRequestSchema>;
 
 export const CheckoutWithDiscountResponseDiscountsSchema = z.object({
-  applied: z.array(AppliedElementSchema).optional(),
-  codes: z.array(z.string()).optional(),
+    "applied": z.array(AppliedElementSchema).optional(),
+    "codes": z.array(z.string()).optional(),
 });
-export type CheckoutWithDiscountResponseDiscounts = z.infer<
-  typeof CheckoutWithDiscountResponseDiscountsSchema
->;
+export type CheckoutWithDiscountResponseDiscounts = z.infer<typeof CheckoutWithDiscountResponseDiscountsSchema>;
 
 export const FulfillmentMethodCreateRequestSchema = z.object({
-  destinations: z.array(FulfillmentDestinationRequestSchema).optional(),
-  groups: z.array(FulfillmentGroupSchema).optional(),
-  line_item_ids: z.array(z.string()).optional(),
-  selected_destination_id: z.union([z.null(), z.string()]).optional(),
-  type: MethodTypeSchema,
+    "destinations": z.array(FulfillmentDestinationRequestSchema).optional(),
+    "groups": z.array(FulfillmentGroupSchema).optional(),
+    "line_item_ids": z.array(z.string()).optional(),
+    "selected_destination_id": z.union([z.null(), z.string()]).optional(),
+    "type": z.string(),
 });
-export type FulfillmentMethodCreateRequest = z.infer<
-  typeof FulfillmentMethodCreateRequestSchema
->;
+export type FulfillmentMethodCreateRequest = z.infer<typeof FulfillmentMethodCreateRequestSchema>;
 
 export const FulfillmentResponseSchema = z.object({
-  available_methods: z.array(FulfillmentAvailableMethodSchema).optional(),
-  methods: z.array(FulfillmentMethodResponseSchema).optional(),
+    "available_methods": z.array(FulfillmentAvailableMethodSchema).optional(),
+    "methods": z.array(FulfillmentMethodResponseSchema).optional(),
 });
 export type FulfillmentResponse = z.infer<typeof FulfillmentResponseSchema>;
 
 export const CheckoutWithCartCreateRequestSchema = z.object({
-  attribution: z.record(z.string(), z.string()).optional(),
-  buyer: BuyerSchema.optional(),
-  context: CheckoutCreateRequestContextSchema.optional(),
-  line_items: z.array(LineItemCreateRequestSchema),
-  payment: PaymentCreateRequestSchema.optional(),
-  signals: CheckoutCreateRequestSignalsSchema.optional(),
-  cart_id: z.string().optional(),
+    "attribution": z.record(z.string(), z.string()).optional(),
+    "buyer": BuyerSchema.optional(),
+    "context": CheckoutCreateRequestContextSchema.optional(),
+    "line_items": z.array(LineItemCreateRequestSchema),
+    "payment": PaymentCreateRequestSchema.optional(),
+    "signals": CheckoutCreateRequestSignalsSchema.optional(),
+    "cart_id": z.string().optional(),
 });
-export type CheckoutWithCartCreateRequest = z.infer<
-  typeof CheckoutWithCartCreateRequestSchema
->;
+export type CheckoutWithCartCreateRequest = z.infer<typeof CheckoutWithCartCreateRequestSchema>;
 
 export const LookupRequestSchema = z.object({
-  attribution: z.record(z.string(), z.string()).optional(),
-  context: LookupRequestContextSchema.optional(),
-  filters: SearchFiltersSchema.optional(),
-  ids: z.array(z.string()),
-  signals: LookupRequestSignalsSchema.optional(),
+    "attribution": z.record(z.string(), z.string()).optional(),
+    "context": LookupRequestContextSchema.optional(),
+    "filters": SearchFiltersSchema.optional(),
+    "ids": z.array(z.string()),
+    "signals": LookupRequestSignalsSchema.optional(),
 });
 export type LookupRequest = z.infer<typeof LookupRequestSchema>;
 
 export const CatalogLookupSchema = z.object({
-  availability: PurpleAvailabilitySchema.optional(),
-  barcodes: z.array(PurpleBarcodeSchema).optional(),
-  categories: z.array(CategorySchema).optional(),
-  description: DescriptionSchema,
-  handle: z.string().optional(),
-  id: z.string(),
-  list_price: PriceSchema.optional(),
-  media: z.array(MediaSchema).optional(),
-  metadata: z.record(z.string(), z.any()).optional(),
-  options: z.array(OptionElementSchema).optional(),
-  price: PriceSchema,
-  rating: RatingSchema.optional(),
-  seller: PurpleSellerSchema.optional(),
-  sku: z.string().optional(),
-  tags: z.array(z.string()).optional(),
-  title: z.string(),
-  unit_price: PurpleUnitPriceSchema.optional(),
-  url: z.string().optional(),
-  inputs: z.array(InputCorrelationSchema).min(1),
+    "availability": AvailabilitySchema.optional(),
+    "barcodes": z.array(PurpleBarcodeSchema).optional(),
+    "categories": z.array(CategorySchema).optional(),
+    "description": DescriptionSchema,
+    "handle": z.string().optional(),
+    "id": z.string(),
+    "list_price": PriceSchema.optional(),
+    "media": z.array(MediaSchema).optional(),
+    "metadata": z.record(z.string(), z.any()).optional(),
+    "options": z.array(OptionElementSchema).optional(),
+    "price": PriceSchema,
+    "rating": RatingSchema.optional(),
+    "seller": PurpleSellerSchema.optional(),
+    "sku": z.string().optional(),
+    "tags": z.array(z.string()).optional(),
+    "title": z.string(),
+    "unit_price": PurpleUnitPriceSchema.optional(),
+    "url": z.string().optional(),
+    "inputs": z.array(InputCorrelationSchema).min(1),
 });
 export type CatalogLookup = z.infer<typeof CatalogLookupSchema>;
 
 export const VariantSchema = z.object({
-  availability: FluffyAvailabilitySchema.optional(),
-  barcodes: z.array(FluffyBarcodeSchema).optional(),
-  categories: z.array(CategorySchema).optional(),
-  description: DescriptionSchema,
-  handle: z.string().optional(),
-  id: z.string(),
-  list_price: PriceSchema.optional(),
-  media: z.array(MediaSchema).optional(),
-  metadata: z.record(z.string(), z.any()).optional(),
-  options: z.array(OptionElementSchema).optional(),
-  price: PriceSchema,
-  rating: RatingSchema.optional(),
-  seller: FluffySellerSchema.optional(),
-  sku: z.string().optional(),
-  tags: z.array(z.string()).optional(),
-  title: z.string(),
-  unit_price: FluffyUnitPriceSchema.optional(),
-  url: z.string().optional(),
+    "availability": AvailabilitySchema.optional(),
+    "barcodes": z.array(FluffyBarcodeSchema).optional(),
+    "categories": z.array(CategorySchema).optional(),
+    "description": DescriptionSchema,
+    "handle": z.string().optional(),
+    "id": z.string(),
+    "list_price": PriceSchema.optional(),
+    "media": z.array(MediaSchema).optional(),
+    "metadata": z.record(z.string(), z.any()).optional(),
+    "options": z.array(OptionElementSchema).optional(),
+    "price": PriceSchema,
+    "rating": RatingSchema.optional(),
+    "seller": FluffySellerSchema.optional(),
+    "sku": z.string().optional(),
+    "tags": z.array(z.string()).optional(),
+    "title": z.string(),
+    "unit_price": FluffyUnitPriceSchema.optional(),
+    "url": z.string().optional(),
 });
 export type Variant = z.infer<typeof VariantSchema>;
 
 export const SearchResponseProductSchema = z.object({
-  categories: z.array(CategorySchema).optional(),
-  description: DescriptionSchema,
-  handle: z.string().optional(),
-  id: z.string(),
-  list_price_range: PriceRangeSchema.optional(),
-  media: z.array(MediaSchema).optional(),
-  metadata: z.record(z.string(), z.any()).optional(),
-  options: z.array(ProductOptionSchema).optional(),
-  price_range: PriceRangeSchema,
-  rating: RatingSchema.optional(),
-  tags: z.array(z.string()).optional(),
-  title: z.string(),
-  url: z.string().optional(),
-  variants: z.array(VariantSchema).min(1),
+    "categories": z.array(CategorySchema).optional(),
+    "description": DescriptionSchema,
+    "handle": z.string().optional(),
+    "id": z.string(),
+    "list_price_range": PriceRangeSchema.optional(),
+    "media": z.array(MediaSchema).optional(),
+    "metadata": z.record(z.string(), z.any()).optional(),
+    "options": z.array(ProductOptionSchema).optional(),
+    "price_range": PriceRangeSchema,
+    "rating": RatingSchema.optional(),
+    "tags": z.array(z.string()).optional(),
+    "title": z.string(),
+    "url": z.string().optional(),
+    "variants": z.array(VariantSchema).min(1),
 });
 export type SearchResponseProduct = z.infer<typeof SearchResponseProductSchema>;
 
 export const UcpDiscoveryProfileSchema = z.object({
-  payment: PaymentSchema.optional(),
-  signing_keys: z.array(SigningKeySchema).optional(),
-  ucp: UcpSchema,
+    "payment": UcpDiscoveryProfilePaymentSchema.optional(),
+    "signing_keys": z.array(SigningKeySchema).optional(),
+    "ucp": UcpSchema,
 });
 export type UcpDiscoveryProfile = z.infer<typeof UcpDiscoveryProfileSchema>;
 
 export const CheckoutCreateRequestSchema = z.object({
-  attribution: z.record(z.string(), z.string()).optional(),
-  buyer: BuyerSchema.optional(),
-  context: CheckoutCreateRequestContextSchema.optional(),
-  line_items: z.array(LineItemCreateRequestSchema),
-  payment: PaymentCreateRequestSchema.optional(),
-  signals: CheckoutCreateRequestSignalsSchema.optional(),
+    "attribution": z.record(z.string(), z.string()).optional(),
+    "buyer": BuyerSchema.optional(),
+    "context": CheckoutCreateRequestContextSchema.optional(),
+    "line_items": z.array(LineItemCreateRequestSchema),
+    "payment": PaymentCreateRequestSchema.optional(),
+    "signals": CheckoutCreateRequestSignalsSchema.optional(),
 });
 export type CheckoutCreateRequest = z.infer<typeof CheckoutCreateRequestSchema>;
 
 export const OrderSchema = z.object({
-  adjustments: z.array(AdjustmentSchema).optional(),
-  attribution: z.record(z.string(), z.string()).optional(),
-  checkout_id: z.string(),
-  currency: z.string(),
-  fulfillment: FulfillmentSchema,
-  id: z.string(),
-  label: z.string().optional(),
-  line_items: z.array(OrderLineItemSchema),
-  messages: z.array(CheckoutResponseMessageSchema).optional(),
-  permalink_url: z.string(),
-  totals: z.array(TotalsResponseSchema),
-  ucp: UcpResponseSchema,
+    "adjustments": z.array(AdjustmentSchema).optional(),
+    "attribution": z.record(z.string(), z.string()).optional(),
+    "checkout_id": z.string(),
+    "currency": z.string(),
+    "fulfillment": FulfillmentSchema,
+    "id": z.string(),
+    "label": z.string().optional(),
+    "line_items": z.array(OrderLineItemSchema),
+    "messages": z.array(CheckoutResponseMessageSchema).optional(),
+    "permalink_url": z.string(),
+    "policies": z.array(CheckoutResponsePolicySchema).optional(),
+    "totals": z.array(TotalsResponseSchema),
+    "ucp": UcpResponseSchema,
 });
 export type Order = z.infer<typeof OrderSchema>;
 
-export const CheckoutWithDiscountResponseSchema = z.object({
-  attribution: z.record(z.string(), z.string()).optional(),
-  buyer: BuyerSchema.optional(),
-  context: CheckoutCreateRequestContextSchema.optional(),
-  continue_url: z.string().optional(),
-  currency: z.string(),
-  expires_at: z.coerce.date().optional(),
-  id: z.string(),
-  line_items: z.array(LineItemResponseSchema),
-  links: z.array(LinkSchema),
-  messages: z.array(CheckoutResponseMessageSchema).optional(),
-  order: OrderConfirmationSchema.optional(),
-  payment: PaymentResponseSchema.optional(),
-  signals: CheckoutCreateRequestSignalsSchema.optional(),
-  status: CheckoutResponseStatusSchema,
-  totals: z.array(TotalsResponseSchema),
-  ucp: UcpResponseSchema,
-  discounts: CheckoutWithDiscountResponseDiscountsSchema.optional(),
+export const CheckoutWithBuyerConsentCreateRequestSchema = z.object({
+    "attribution": z.record(z.string(), z.string()).optional(),
+    "buyer": BuyerWithConsentCreateRequestSchema.optional(),
+    "context": CheckoutCreateRequestContextSchema.optional(),
+    "line_items": z.array(LineItemCreateRequestSchema),
+    "payment": PaymentCreateRequestSchema.optional(),
+    "signals": CheckoutCreateRequestSignalsSchema.optional(),
 });
-export type CheckoutWithDiscountResponse = z.infer<
-  typeof CheckoutWithDiscountResponseSchema
->;
+export type CheckoutWithBuyerConsentCreateRequest = z.infer<typeof CheckoutWithBuyerConsentCreateRequestSchema>;
+
+export const CheckoutWithBuyerConsentUpdateRequestSchema = z.object({
+    "attribution": z.record(z.string(), z.string()).optional(),
+    "buyer": BuyerWithConsentUpdateRequestSchema.optional(),
+    "context": CheckoutCreateRequestContextSchema.optional(),
+    "line_items": z.array(LineItemUpdateRequestSchema),
+    "payment": PaymentUpdateRequestSchema.optional(),
+    "signals": CheckoutCreateRequestSignalsSchema.optional(),
+});
+export type CheckoutWithBuyerConsentUpdateRequest = z.infer<typeof CheckoutWithBuyerConsentUpdateRequestSchema>;
+
+export const CheckoutWithBuyerConsentResponseSchema = z.object({
+    "actions": z.record(z.string(), z.array(ActionsSchema)).optional(),
+    "attribution": z.record(z.string(), z.string()).optional(),
+    "buyer": BuyerWithConsentResponseSchema.optional(),
+    "context": CheckoutCreateRequestContextSchema.optional(),
+    "continue_url": z.string().optional(),
+    "currency": z.string(),
+    "expires_at": z.coerce.date().optional(),
+    "id": z.string(),
+    "line_items": z.array(LineItemResponseSchema),
+    "links": z.array(CheckoutResponseLinkSchema),
+    "messages": z.array(CheckoutResponseMessageSchema).optional(),
+    "order": OrderConfirmationSchema.optional(),
+    "payment": PaymentResponseSchema.optional(),
+    "policies": z.array(CheckoutResponsePolicySchema).optional(),
+    "signals": CheckoutCreateRequestSignalsSchema.optional(),
+    "status": CheckoutResponseStatusSchema,
+    "totals": z.array(TotalsResponseSchema),
+    "ucp": UcpResponseSchema,
+});
+export type CheckoutWithBuyerConsentResponse = z.infer<typeof CheckoutWithBuyerConsentResponseSchema>;
+
+export const CheckoutWithDiscountResponseSchema = z.object({
+    "actions": z.record(z.string(), z.array(ActionsSchema)).optional(),
+    "attribution": z.record(z.string(), z.string()).optional(),
+    "buyer": BuyerSchema.optional(),
+    "context": CheckoutCreateRequestContextSchema.optional(),
+    "continue_url": z.string().optional(),
+    "currency": z.string(),
+    "expires_at": z.coerce.date().optional(),
+    "id": z.string(),
+    "line_items": z.array(LineItemResponseSchema),
+    "links": z.array(CheckoutResponseLinkSchema),
+    "messages": z.array(CheckoutResponseMessageSchema).optional(),
+    "order": OrderConfirmationSchema.optional(),
+    "payment": PaymentResponseSchema.optional(),
+    "policies": z.array(CheckoutResponsePolicySchema).optional(),
+    "signals": CheckoutCreateRequestSignalsSchema.optional(),
+    "status": CheckoutResponseStatusSchema,
+    "totals": z.array(TotalsResponseSchema),
+    "ucp": UcpResponseSchema,
+    "discounts": CheckoutWithDiscountResponseDiscountsSchema.optional(),
+});
+export type CheckoutWithDiscountResponse = z.infer<typeof CheckoutWithDiscountResponseSchema>;
 
 export const FulfillmentRequestSchema = z.object({
-  methods: z.array(FulfillmentMethodCreateRequestSchema).optional(),
+    "methods": z.array(FulfillmentMethodCreateRequestSchema).optional(),
 });
 export type FulfillmentRequest = z.infer<typeof FulfillmentRequestSchema>;
 
 export const CheckoutWithFulfillmentUpdateRequestSchema = z.object({
-  attribution: z.record(z.string(), z.string()).optional(),
-  buyer: BuyerSchema.optional(),
-  context: CheckoutCreateRequestContextSchema.optional(),
-  line_items: z.array(LineItemUpdateRequestSchema),
-  payment: PaymentUpdateRequestSchema.optional(),
-  signals: CheckoutCreateRequestSignalsSchema.optional(),
-  fulfillment: FulfillmentRequestSchema.optional(),
+    "attribution": z.record(z.string(), z.string()).optional(),
+    "buyer": BuyerSchema.optional(),
+    "context": CheckoutCreateRequestContextSchema.optional(),
+    "line_items": z.array(LineItemUpdateRequestSchema),
+    "payment": PaymentUpdateRequestSchema.optional(),
+    "signals": CheckoutCreateRequestSignalsSchema.optional(),
+    "fulfillment": FulfillmentRequestSchema.optional(),
 });
-export type CheckoutWithFulfillmentUpdateRequest = z.infer<
-  typeof CheckoutWithFulfillmentUpdateRequestSchema
->;
+export type CheckoutWithFulfillmentUpdateRequest = z.infer<typeof CheckoutWithFulfillmentUpdateRequestSchema>;
 
 export const CheckoutWithFulfillmentResponseSchema = z.object({
-  attribution: z.record(z.string(), z.string()).optional(),
-  buyer: BuyerSchema.optional(),
-  context: CheckoutCreateRequestContextSchema.optional(),
-  continue_url: z.string().optional(),
-  currency: z.string(),
-  expires_at: z.coerce.date().optional(),
-  id: z.string(),
-  line_items: z.array(LineItemResponseSchema),
-  links: z.array(LinkSchema),
-  messages: z.array(CheckoutResponseMessageSchema).optional(),
-  order: OrderConfirmationSchema.optional(),
-  payment: PaymentResponseSchema.optional(),
-  signals: CheckoutCreateRequestSignalsSchema.optional(),
-  status: CheckoutResponseStatusSchema,
-  totals: z.array(TotalsResponseSchema),
-  ucp: UcpResponseSchema,
-  fulfillment: FulfillmentResponseSchema.optional(),
+    "actions": z.record(z.string(), z.array(ActionsSchema)).optional(),
+    "attribution": z.record(z.string(), z.string()).optional(),
+    "buyer": BuyerSchema.optional(),
+    "context": CheckoutCreateRequestContextSchema.optional(),
+    "continue_url": z.string().optional(),
+    "currency": z.string(),
+    "expires_at": z.coerce.date().optional(),
+    "id": z.string(),
+    "line_items": z.array(LineItemResponseSchema),
+    "links": z.array(CheckoutResponseLinkSchema),
+    "messages": z.array(CheckoutResponseMessageSchema).optional(),
+    "order": OrderConfirmationSchema.optional(),
+    "payment": PaymentResponseSchema.optional(),
+    "policies": z.array(CheckoutResponsePolicySchema).optional(),
+    "signals": CheckoutCreateRequestSignalsSchema.optional(),
+    "status": CheckoutResponseStatusSchema,
+    "totals": z.array(TotalsResponseSchema),
+    "ucp": UcpResponseSchema,
+    "fulfillment": FulfillmentResponseSchema.optional(),
 });
-export type CheckoutWithFulfillmentResponse = z.infer<
-  typeof CheckoutWithFulfillmentResponseSchema
->;
+export type CheckoutWithFulfillmentResponse = z.infer<typeof CheckoutWithFulfillmentResponseSchema>;
 
 export const LookupResponseProductSchema = z.object({
-  categories: z.array(CategorySchema).optional(),
-  description: DescriptionSchema,
-  handle: z.string().optional(),
-  id: z.string(),
-  list_price_range: PriceRangeSchema.optional(),
-  media: z.array(MediaSchema).optional(),
-  metadata: z.record(z.string(), z.any()).optional(),
-  options: z.array(ProductOptionSchema).optional(),
-  price_range: PriceRangeSchema,
-  rating: RatingSchema.optional(),
-  tags: z.array(z.string()).optional(),
-  title: z.string(),
-  url: z.string().optional(),
-  variants: z.array(CatalogLookupSchema).min(1),
+    "categories": z.array(CategorySchema).optional(),
+    "description": DescriptionSchema,
+    "handle": z.string().optional(),
+    "id": z.string(),
+    "list_price_range": PriceRangeSchema.optional(),
+    "media": z.array(MediaSchema).optional(),
+    "metadata": z.record(z.string(), z.any()).optional(),
+    "options": z.array(ProductOptionSchema).optional(),
+    "price_range": PriceRangeSchema,
+    "rating": RatingSchema.optional(),
+    "tags": z.array(z.string()).optional(),
+    "title": z.string(),
+    "url": z.string().optional(),
+    "variants": z.array(CatalogLookupSchema).min(1),
 });
 export type LookupResponseProduct = z.infer<typeof LookupResponseProductSchema>;
 
 export const ProductSchema = z.object({
-  options: z.array(ProductOptionSchema).optional(),
-  selected: z.array(SelectedElementSchema).optional(),
-  categories: z.array(CategorySchema).optional(),
-  description: DescriptionSchema,
-  handle: z.string().optional(),
-  id: z.string(),
-  list_price_range: PriceRangeSchema.optional(),
-  media: z.array(MediaSchema).optional(),
-  metadata: z.record(z.string(), z.any()).optional(),
-  price_range: PriceRangeSchema,
-  rating: RatingSchema.optional(),
-  tags: z.array(z.string()).optional(),
-  title: z.string(),
-  url: z.string().optional(),
-  variants: z.array(VariantSchema),
+    "options": z.array(ProductOptionSchema).optional(),
+    "selected": z.array(SelectedElementSchema).optional(),
+    "categories": z.array(CategorySchema).optional(),
+    "description": DescriptionSchema,
+    "handle": z.string().optional(),
+    "id": z.string(),
+    "list_price_range": PriceRangeSchema.optional(),
+    "media": z.array(MediaSchema).optional(),
+    "metadata": z.record(z.string(), z.any()).optional(),
+    "price_range": PriceRangeSchema,
+    "rating": RatingSchema.optional(),
+    "tags": z.array(z.string()).optional(),
+    "title": z.string(),
+    "url": z.string().optional(),
+    "variants": z.array(VariantSchema),
 });
 export type Product = z.infer<typeof ProductSchema>;
 
 export const SearchResponseSchema = z.object({
-  messages: z.array(LookupResponseMessageSchema).optional(),
-  pagination: SearchResponsePaginationSchema.optional(),
-  products: z.array(SearchResponseProductSchema),
-  ucp: UcpResponseSchema,
+    "actions": z.record(z.string(), z.array(ActionsSchema)).optional(),
+    "messages": z.array(LookupResponseMessageSchema).optional(),
+    "pagination": SearchResponsePaginationSchema.optional(),
+    "policies": z.array(LookupResponsePolicySchema).optional(),
+    "products": z.array(SearchResponseProductSchema),
+    "ucp": UcpResponseSchema,
 });
 export type SearchResponse = z.infer<typeof SearchResponseSchema>;
 
 export const CheckoutWithFulfillmentCreateRequestSchema = z.object({
-  attribution: z.record(z.string(), z.string()).optional(),
-  buyer: BuyerSchema.optional(),
-  context: CheckoutCreateRequestContextSchema.optional(),
-  line_items: z.array(LineItemCreateRequestSchema),
-  payment: PaymentCreateRequestSchema.optional(),
-  signals: CheckoutCreateRequestSignalsSchema.optional(),
-  fulfillment: FulfillmentRequestSchema.optional(),
+    "attribution": z.record(z.string(), z.string()).optional(),
+    "buyer": BuyerSchema.optional(),
+    "context": CheckoutCreateRequestContextSchema.optional(),
+    "line_items": z.array(LineItemCreateRequestSchema),
+    "payment": PaymentCreateRequestSchema.optional(),
+    "signals": CheckoutCreateRequestSignalsSchema.optional(),
+    "fulfillment": FulfillmentRequestSchema.optional(),
 });
-export type CheckoutWithFulfillmentCreateRequest = z.infer<
-  typeof CheckoutWithFulfillmentCreateRequestSchema
->;
+export type CheckoutWithFulfillmentCreateRequest = z.infer<typeof CheckoutWithFulfillmentCreateRequestSchema>;
 
 export const LookupResponseSchema = z.object({
-  messages: z.array(LookupResponseMessageSchema).optional(),
-  products: z.array(LookupResponseProductSchema),
-  ucp: UcpResponseSchema,
+    "actions": z.record(z.string(), z.array(ActionsSchema)).optional(),
+    "messages": z.array(LookupResponseMessageSchema).optional(),
+    "policies": z.array(LookupResponsePolicySchema).optional(),
+    "products": z.array(LookupResponseProductSchema),
+    "ucp": UcpResponseSchema,
 });
 export type LookupResponse = z.infer<typeof LookupResponseSchema>;
 
 export const GetProductResponseSchema = z.object({
-  messages: z.array(LookupResponseMessageSchema).optional(),
-  product: ProductSchema,
-  ucp: UcpResponseSchema,
+    "actions": z.record(z.string(), z.array(ActionsSchema)).optional(),
+    "messages": z.array(LookupResponseMessageSchema).optional(),
+    "policies": z.array(LookupResponsePolicySchema).optional(),
+    "product": ProductSchema,
+    "ucp": UcpResponseSchema,
 });
 export type GetProductResponse = z.infer<typeof GetProductResponseSchema>;

--- a/tests/spec-constraints.test.js
+++ b/tests/spec-constraints.test.js
@@ -1,0 +1,97 @@
+// Regression tests for js-sdk#33: the generated zod schemas must enforce the
+// value constraints declared in the UCP JSON Schemas, not just object shape.
+//
+// The schemas are compiled from src/spec_generated.ts by the "pretest" step so
+// the test exercises the generated zod schemas directly.
+
+const { test } = require("node:test");
+const assert = require("node:assert/strict");
+
+const {
+  PriceSchema,
+  TotalResponseSchema,
+  MediaSchema,
+  ProductOptionSchema,
+} = require("./.dist/spec_generated.js");
+
+const accepts = (schema, value) => schema.safeParse(value).success === true;
+const rejects = (schema, value) => schema.safeParse(value).success === false;
+
+// --- PriceSchema: the headline of issue #33 --------------------------------
+// amount is { type: integer, minimum: 0 }; currency is ^[A-Z]{3}$.
+
+test("PriceSchema rejects a negative amount (minimum: 0)", () => {
+  assert.ok(rejects(PriceSchema, { amount: -50, currency: "USD" }));
+});
+
+test("PriceSchema rejects a non-integer amount (type: integer)", () => {
+  assert.ok(rejects(PriceSchema, { amount: 9.99, currency: "USD" }));
+});
+
+test("PriceSchema rejects a lowercase currency (pattern ^[A-Z]{3}$)", () => {
+  assert.ok(rejects(PriceSchema, { amount: 5, currency: "usd" }));
+});
+
+test("PriceSchema accepts a spec-valid price", () => {
+  assert.ok(accepts(PriceSchema, { amount: 5, currency: "USD" }));
+  assert.ok(accepts(PriceSchema, { amount: 0, currency: "EUR" })); // 0 = free
+});
+
+test("PriceSchema: the exact invalid payloads from issue #33 are rejected", () => {
+  // Each of these `.parse()` calls succeeded before the fix.
+  assert.ok(rejects(PriceSchema, { amount: -50 }));
+  assert.ok(rejects(PriceSchema, { amount: 9.99 }));
+  assert.ok(rejects(PriceSchema, { currency: "usd" }));
+});
+
+// --- TotalResponseSchema: object-scoped correctness ------------------------
+// A signed total amount is { type: integer } WITHOUT `minimum`. The fix must
+// enforce `.int()` here but must NOT wrongly add `.gte(0)` -- a discount total
+// is legitimately negative.
+
+test("TotalResponseSchema accepts a negative integer amount", () => {
+  assert.ok(accepts(TotalResponseSchema, { amount: -100, type: "discount" }));
+});
+
+test("TotalResponseSchema still rejects a non-integer amount", () => {
+  assert.ok(rejects(TotalResponseSchema, { amount: 1.5, type: "discount" }));
+});
+
+// --- MediaSchema: integer + minimum on dimensions --------------------------
+// height / width are { type: integer, minimum: 1 }.
+
+test("MediaSchema rejects a zero dimension (minimum: 1)", () => {
+  assert.ok(
+    rejects(MediaSchema, { type: "image", url: "https://x/y.png", height: 0 })
+  );
+});
+
+test("MediaSchema rejects a fractional dimension (type: integer)", () => {
+  assert.ok(
+    rejects(MediaSchema, { type: "image", url: "https://x/y.png", width: 1.5 })
+  );
+});
+
+test("MediaSchema accepts positive integer dimensions", () => {
+  assert.ok(
+    accepts(MediaSchema, {
+      type: "image",
+      url: "https://x/y.png",
+      height: 1,
+      width: 640,
+    })
+  );
+});
+
+// --- ProductOptionSchema: array minItems -----------------------------------
+// values is an array with minItems: 1.
+
+test("ProductOptionSchema rejects an empty values array (minItems: 1)", () => {
+  assert.ok(rejects(ProductOptionSchema, { name: "size", values: [] }));
+});
+
+test("ProductOptionSchema accepts a non-empty values array", () => {
+  assert.ok(
+    accepts(ProductOptionSchema, { name: "size", values: [{ label: "S" }] })
+  );
+});

--- a/tests/spec-constraints.test.js
+++ b/tests/spec-constraints.test.js
@@ -1,3 +1,17 @@
+// Copyright 2026 UCP Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // Regression tests for js-sdk#33: the generated zod schemas must enforce the
 // value constraints declared in the UCP JSON Schemas, not just object shape.
 //


### PR DESCRIPTION
## Summary
The generated zod schemas in `src/spec_generated.ts` enforce object shape and enums but drop **every value/type constraint** the JSON Schemas define, because quicktype's `typescript-zod` target emits shape + `z.enum` only. So `.parse()` accepts spec-invalid instances. Closes #33.

For example, before this change all three of these validate:
```ts
PriceSchema.safeParse({ amount: 9.99, currency: "USD" }).success // schema: integer
PriceSchema.safeParse({ amount: -50,  currency: "USD" }).success // schema: minimum 0
PriceSchema.safeParse({ amount: 5,    currency: "usd" }).success // schema: ^[A-Z]{3}$
```

## Approach
A new post-generation step, `scripts/inject-schema-constraints.mjs`, re-attaches the dropped constraints, wired into `generate_models.sh` right after the existing normalize step. This mirrors the Python SDK's `postprocess_models.py`, which patches constraints its generator drops.

Constraints covered: `type: integer` → `.int()`, `minimum`/`maximum` → `.gte()`/`.lte()`, `exclusiveMinimum`/`exclusiveMaximum` → `.gt()`/`.lt()`, `pattern` → `.regex()`, `minLength`/`maxLength` → `.min()`/`.max()` (`.length()` when equal), and `minItems`/`maxItems` on arrays.

### Object-scoped to avoid false positives
The key correctness concern: matching by property **name** alone is unsound. `amount` is `integer, minimum: 0` in `Price` but a **signed** `integer` (no minimum) in discount/adjustment totals — same name, different schema. Blanket-applying `.gte(0)` would wrongly reject legitimately-negative amounts.

So the injector indexes each object schema by its full **property-name set**, and splices constraints onto a generated field only when (a) the property-set matches exactly and (b) the generated field's base type agrees. Result:
```ts
PriceSchema:   amount: z.number().int().gte(0),  currency: z.string().regex(/^[A-Z]{3}$/)
// signed total (discount/adjustment):
               amount: z.number().int()          // correctly NO .gte(0)
```
Property-sets whose constraints are ambiguous are skipped and reported (only 3 across the whole spec).

## Tests
`tests/spec-constraints.test.js` (node:test, no new deps) — the exact #33 payloads reject, valid input passes, plus the object-scoping proof that a signed total still accepts a negative amount but rejects a fractional one. On the pre-fix file **5 pass / 7 fail**; after the fix **12/12 pass**. Adds `pretest`/`test` scripts (the repo had none) that compile `src/spec_generated.ts` to CJS and run the suite version-agnostically.

## Verification
- `npm run build` (all tsc configs): exit 0
- `npm test`: 12/12
- `pre-commit run --all-files`: prettier, codespell, and the rest pass (shellcheck validated separately; the hook is Docker-gated)
- Idempotent: re-running the injector reports `0 injected, N already constrained`, byte-identical output.

## Scope
Deferred (documented, no false enforcement): `uniqueItems`, `const`, `minContains`/`maxContains` — these need `.refine()`/`z.literal` and are cleanly extensible in the same script. The committed `src/spec_generated.ts` diff is constraint-injection only; a maintainer regen via the wired step picks up any current-schema drift.