### PR TITLE
chore: regenerate specs based on ucp release/2026-04-08

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@ucp-js/sdk",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@ucp-js/sdk",
-      "version": "0.4.2",
+      "version": "0.4.3",
       "license": "Apache-2.0",
       "dependencies": {
         "zod": "^3.23.8"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ucp-js/sdk",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "description": "UCP SDK for JavaScript",
   "license": "Apache-2.0",
   "main": "./dist/cjs/index.js",

--- a/src/spec_generated.ts
+++ b/src/spec_generated.ts
@@ -9,8 +9,7 @@ export const ContentTypeSchema = z.enum(["markdown", "plain"]);
 export type ContentType = z.infer<typeof ContentTypeSchema>;
 
 // Reflects the resource state and recommended action. 'recoverable': platform can resolve
-// the condition in band, for example by modifying inputs or processing a related Action,
-// and submit a new operation when needed. 'requires_buyer_input': merchant requires
+// by modifying inputs and retrying via API. 'requires_buyer_input': merchant requires
 // information their API doesn't support collecting programmatically (checkout incomplete).
 // 'requires_buyer_review': buyer must authorize before order placement due to policy,
 // regulatory, or entitlement rules. 'unrecoverable': no valid resource exists to act on,
@@ -25,10 +24,10 @@ export const SeveritySchema = z.enum([
 ]);
 export type Severity = z.infer<typeof SeveritySchema>;
 
-export const TypeSchema = z.enum(["error", "info", "warning"]);
-export type Type = z.infer<typeof TypeSchema>;
+export const MessageTypeSchema = z.enum(["error", "info", "warning"]);
+export type MessageType = z.infer<typeof MessageTypeSchema>;
 
-// Checkout state indicating the current phase and required processing. See Checkout Status
+// Checkout state indicating the current phase and required action. See Checkout Status
 // lifecycle documentation for state transition details.
 
 export const CheckoutResponseStatusSchema = z.enum([
@@ -52,6 +51,11 @@ export const AdjustmentStatusSchema = z.enum([
 ]);
 export type AdjustmentStatus = z.infer<typeof AdjustmentStatusSchema>;
 
+// Delivery method type (shipping, pickup, digital).
+
+export const MethodTypeEnumSchema = z.enum(["digital", "pickup", "shipping"]);
+export type MethodTypeEnum = z.infer<typeof MethodTypeEnumSchema>;
+
 // Derived status: removed if quantity.total == 0, fulfilled if quantity.total > 0 and
 // quantity.fulfilled == quantity.total, partial if quantity.total > 0 and
 // quantity.fulfilled > 0, otherwise processing.
@@ -64,22 +68,18 @@ export const LineItemStatusSchema = z.enum([
 ]);
 export type LineItemStatus = z.infer<typeof LineItemStatusSchema>;
 
-// Identifies the party that asserted the current `granted` value for this segment.
-// `business` means the value reflects the business's default policy; `platform` means the
-// value reflects an explicit buyer decision captured by the platform.
-//
-// Identifies the party that asserted the current `granted` value. `business` means the
-// value reflects the business's default policy; `platform` means the value reflects an
-// explicit buyer decision captured by the platform.
-
-export const SourceSchema = z.enum(["business", "platform"]);
-export type Source = z.infer<typeof SourceSchema>;
-
 // Allocation method. 'each' = applied independently per item. 'across' = split
 // proportionally by value.
 
 export const MethodSchema = z.enum(["across", "each"]);
 export type Method = z.infer<typeof MethodSchema>;
+
+// Fulfillment method type.
+//
+// Fulfillment method type this availability applies to.
+
+export const MethodTypeSchema = z.enum(["pickup", "shipping"]);
+export type MethodType = z.infer<typeof MethodTypeSchema>;
 
 export const PaymentHandlerResponseSchema = z.object({
   config: z.record(z.string(), z.any()),
@@ -118,9 +118,7 @@ export const CapabilityDiscoverySchema = z.object({
 export type CapabilityDiscovery = z.infer<typeof CapabilityDiscoverySchema>;
 
 export const A2ASchema = z.object({
-  endpoint: z
-    .string()
-    .regex(/^https:\/\/[^\/?#\s\\@]+(?:\/[^?#\s\\]*[^\/?#\s\\])?$/),
+  endpoint: z.string(),
 });
 export type A2A = z.infer<typeof A2ASchema>;
 
@@ -147,17 +145,20 @@ export const BuyerSchema = z.object({
 });
 export type Buyer = z.infer<typeof BuyerSchema>;
 
-export const PurplePaymentSchema = z.object({
-  handler: z
-    .string()
-    .regex(
-      /^[a-z](?:[a-z0-9-]*[a-z0-9])?(?:\.[a-z0-9](?:[a-z0-9_-]*[a-z0-9_])?)+$/
-    ),
-  types: z.array(z.string()).optional(),
+export const CheckoutCreateRequestContextSchema = z.object({
+  address_country: z.string().optional(),
+  address_region: z.string().optional(),
+  currency: z.string().optional(),
+  eligibility: z.array(z.string()).optional(),
+  intent: z.string().optional(),
+  language: z.string().optional(),
+  postal_code: z.string().optional(),
 });
-export type PurplePayment = z.infer<typeof PurplePaymentSchema>;
-export const FluffyPaymentSchema = PurplePaymentSchema;
-export type FluffyPayment = PurplePayment;
+export type CheckoutCreateRequestContext = z.infer<
+  typeof CheckoutCreateRequestContextSchema
+>;
+export const LookupRequestContextSchema = CheckoutCreateRequestContextSchema;
+export type LookupRequestContext = CheckoutCreateRequestContext;
 
 export const ItemReferenceSchema = z.object({
   id: z.string(),
@@ -196,12 +197,6 @@ export type CheckoutCreateRequestSignals = z.infer<
 export const LookupRequestSignalsSchema = CheckoutCreateRequestSignalsSchema;
 export type LookupRequestSignals = CheckoutCreateRequestSignals;
 
-export const ActionsSchema = z.object({
-  config: z.record(z.string(), z.any()).optional(),
-  id: z.string().min(1),
-});
-export type Actions = z.infer<typeof ActionsSchema>;
-
 export const ItemResponseSchema = z.object({
   id: z.string(),
   image_url: z.string().optional(),
@@ -217,14 +212,12 @@ export const TotalResponseSchema = z.object({
 });
 export type TotalResponse = z.infer<typeof TotalResponseSchema>;
 
-export const CheckoutResponseLinkSchema = z.object({
+export const LinkSchema = z.object({
   title: z.string().optional(),
   type: z.string(),
   url: z.string(),
 });
-export type CheckoutResponseLink = z.infer<typeof CheckoutResponseLinkSchema>;
-export const ConsentLinkSchema = CheckoutResponseLinkSchema;
-export type ConsentLink = CheckoutResponseLink;
+export type Link = z.infer<typeof LinkSchema>;
 
 export const CheckoutResponseMessageSchema = z.object({
   code: z.string().optional(),
@@ -232,7 +225,7 @@ export const CheckoutResponseMessageSchema = z.object({
   content_type: ContentTypeSchema.optional(),
   path: z.string().optional(),
   severity: SeveritySchema.optional(),
-  type: TypeSchema,
+  type: MessageTypeSchema,
   image_url: z.string().optional(),
   presentation: z.string().optional(),
   url: z.string().optional(),
@@ -249,13 +242,6 @@ export const OrderConfirmationSchema = z.object({
   permalink_url: z.string(),
 });
 export type OrderConfirmation = z.infer<typeof OrderConfirmationSchema>;
-
-export const DescriptionSchema = z.object({
-  html: z.string().optional(),
-  markdown: z.string().optional(),
-  plain: z.string().optional(),
-});
-export type Description = z.infer<typeof DescriptionSchema>;
 
 export const LineSchema = z.object({
   amount: z.number().int(),
@@ -328,21 +314,19 @@ export type CheckoutWithAp2MandateAp2 = z.infer<
   typeof CheckoutWithAp2MandateAp2Schema
 >;
 
-export const SegmentValueSchema = z.object({
-  granted: z.boolean(),
-  source: SourceSchema,
+export const ConsentSchema = z.object({
+  analytics: z.boolean().optional(),
+  marketing: z.boolean().optional(),
+  preferences: z.boolean().optional(),
+  sale_of_data: z.boolean().optional(),
 });
-export type SegmentValue = z.infer<typeof SegmentValueSchema>;
-export const SegmentClassSchema = SegmentValueSchema;
-export type SegmentClass = SegmentValue;
-
-export const ConsentSegmentSchema = z.object({
-  description: z.string(),
-  granted: z.boolean(),
-  links: z.array(ConsentLinkSchema).optional(),
-  source: SourceSchema,
-});
-export type ConsentSegment = z.infer<typeof ConsentSegmentSchema>;
+export type Consent = z.infer<typeof ConsentSchema>;
+export const FluffyConsentSchema = ConsentSchema;
+export type FluffyConsent = Consent;
+export const PurpleConsentSchema = ConsentSchema;
+export type PurpleConsent = Consent;
+export const TentacledConsentSchema = ConsentSchema;
+export type TentacledConsent = Consent;
 
 export const CheckoutWithDiscountCreateRequestDiscountsSchema = z.object({
   codes: z.array(z.string()).optional(),
@@ -380,12 +364,12 @@ export type FulfillmentDestinationRequest = z.infer<
 >;
 
 export const FulfillmentOptionSchema = z.object({
-  description: DescriptionSchema.optional(),
-  id: z.string(),
-  title: z.string(),
   carrier: z.string().optional(),
+  description: z.string().optional(),
   earliest_fulfillment_time: z.coerce.date().optional(),
+  id: z.string(),
   latest_fulfillment_time: z.coerce.date().optional(),
+  title: z.string(),
   totals: z.array(TotalResponseSchema),
 });
 export type FulfillmentOption = z.infer<typeof FulfillmentOptionSchema>;
@@ -394,7 +378,7 @@ export const FulfillmentAvailableMethodSchema = z.object({
   description: z.string().optional(),
   fulfillable_on: z.union([z.null(), z.string()]).optional(),
   line_item_ids: z.array(z.string()),
-  type: z.string(),
+  type: MethodTypeSchema,
 });
 export type FulfillmentAvailableMethod = z.infer<
   typeof FulfillmentAvailableMethodSchema
@@ -424,25 +408,18 @@ export const PriceFilterSchema = z.object({
 });
 export type PriceFilter = z.infer<typeof PriceFilterSchema>;
 
-export const LookupResponsePolicySchema = z.object({
-  applies_to: z.array(z.string()).optional(),
-  description: DescriptionSchema,
-  type: z
-    .string()
-    .regex(
-      /^[a-z](?:[a-z0-9-]*[a-z0-9])?(?:\.[a-z0-9](?:[a-z0-9_-]*[a-z0-9_])?)+$/
-    ),
-  url: z.string().optional(),
-});
-export type LookupResponsePolicy = z.infer<typeof LookupResponsePolicySchema>;
-export const CheckoutResponsePolicySchema = LookupResponsePolicySchema;
-export type CheckoutResponsePolicy = LookupResponsePolicy;
-
 export const CategorySchema = z.object({
   taxonomy: z.string().optional(),
   value: z.string(),
 });
 export type Category = z.infer<typeof CategorySchema>;
+
+export const DescriptionSchema = z.object({
+  html: z.string().optional(),
+  markdown: z.string().optional(),
+  plain: z.string().optional(),
+});
+export type Description = z.infer<typeof DescriptionSchema>;
 
 export const PriceSchema = z.object({
   amount: z.number().int().gte(0),
@@ -473,11 +450,13 @@ export const RatingSchema = z.object({
 });
 export type Rating = z.infer<typeof RatingSchema>;
 
-export const AvailabilitySchema = z.object({
+export const PurpleAvailabilitySchema = z.object({
   available: z.boolean().optional(),
   status: z.string().optional(),
 });
-export type Availability = z.infer<typeof AvailabilitySchema>;
+export type PurpleAvailability = z.infer<typeof PurpleAvailabilitySchema>;
+export const FluffyAvailabilitySchema = PurpleAvailabilitySchema;
+export type FluffyAvailability = PurpleAvailability;
 
 export const PurpleBarcodeSchema = z.object({
   type: z.string(),
@@ -503,7 +482,7 @@ export const SelectedElementSchema = OptionElementSchema;
 export type SelectedElement = OptionElement;
 
 export const PurpleSellerSchema = z.object({
-  links: z.array(CheckoutResponseLinkSchema).optional(),
+  links: z.array(LinkSchema).optional(),
   name: z.string().optional(),
 });
 export type PurpleSeller = z.infer<typeof PurpleSellerSchema>;
@@ -539,12 +518,10 @@ export type SearchResponsePagination = z.infer<
   typeof SearchResponsePaginationSchema
 >;
 
-export const UcpDiscoveryProfilePaymentSchema = z.object({
+export const PaymentSchema = z.object({
   handlers: z.array(PaymentHandlerResponseSchema).optional(),
 });
-export type UcpDiscoveryProfilePayment = z.infer<
-  typeof UcpDiscoveryProfilePaymentSchema
->;
+export type Payment = z.infer<typeof PaymentSchema>;
 
 export const UcpServiceSchema = z.object({
   a2a: A2ASchema.optional(),
@@ -555,22 +532,6 @@ export const UcpServiceSchema = z.object({
   version: z.string(),
 });
 export type UcpService = z.infer<typeof UcpServiceSchema>;
-
-export const CheckoutCreateRequestContextSchema = z.object({
-  address_country: z.string().optional(),
-  address_region: z.string().optional(),
-  postal_code: z.string().optional(),
-  currency: z.string().optional(),
-  eligibility: z.array(z.string()).optional(),
-  intent: z.string().optional(),
-  language: z.string().optional(),
-  payment: z.array(PurplePaymentSchema).optional(),
-});
-export type CheckoutCreateRequestContext = z.infer<
-  typeof CheckoutCreateRequestContextSchema
->;
-export const LookupRequestContextSchema = CheckoutCreateRequestContextSchema;
-export type LookupRequestContext = CheckoutCreateRequestContext;
 
 export const LineItemCreateRequestSchema = z.object({
   item: ItemCreateRequestSchema,
@@ -664,7 +625,7 @@ export const ExpectationSchema = z.object({
   fulfillable_on: z.string().optional(),
   id: z.string(),
   line_items: z.array(ExpectationLineItemSchema),
-  method_type: z.string(),
+  method_type: MethodTypeEnumSchema,
 });
 export type Expectation = z.infer<typeof ExpectationSchema>;
 
@@ -691,7 +652,6 @@ export type CompleteCheckoutRequestWithAp2 = z.infer<
 >;
 
 export const CheckoutWithAp2MandateSchema = z.object({
-  actions: z.record(z.string(), z.array(ActionsSchema)).optional(),
   attribution: z.record(z.string(), z.string()).optional(),
   buyer: BuyerSchema.optional(),
   context: CheckoutCreateRequestContextSchema.optional(),
@@ -700,11 +660,10 @@ export const CheckoutWithAp2MandateSchema = z.object({
   expires_at: z.coerce.date().optional(),
   id: z.string(),
   line_items: z.array(LineItemResponseSchema),
-  links: z.array(CheckoutResponseLinkSchema),
+  links: z.array(LinkSchema),
   messages: z.array(CheckoutResponseMessageSchema).optional(),
   order: OrderConfirmationSchema.optional(),
   payment: PaymentResponseSchema.optional(),
-  policies: z.array(CheckoutResponsePolicySchema).optional(),
   signals: CheckoutCreateRequestSignalsSchema.optional(),
   status: CheckoutResponseStatusSchema,
   totals: z.array(TotalsResponseSchema),
@@ -715,23 +674,22 @@ export type CheckoutWithAp2Mandate = z.infer<
   typeof CheckoutWithAp2MandateSchema
 >;
 
-export const ConsentValueSchema = z.object({
-  granted: z.boolean(),
-  segments: z.record(z.string(), SegmentValueSchema).optional(),
-  source: SourceSchema,
+export const BuyerWithConsentCreateRequestSchema = z.object({
+  email: z.string().optional(),
+  first_name: z.string().optional(),
+  last_name: z.string().optional(),
+  phone_number: z.string().optional(),
+  consent: PurpleConsentSchema.optional(),
 });
-export type ConsentValue = z.infer<typeof ConsentValueSchema>;
-export const ConsentClassSchema = ConsentValueSchema;
-export type ConsentClass = ConsentValue;
-
-export const BuyerConsentSchema = z.object({
-  description: z.string(),
-  granted: z.boolean(),
-  links: z.array(ConsentLinkSchema).optional(),
-  segments: z.record(z.string(), ConsentSegmentSchema).optional(),
-  source: SourceSchema,
-});
-export type BuyerConsent = z.infer<typeof BuyerConsentSchema>;
+export type BuyerWithConsentCreateRequest = z.infer<
+  typeof BuyerWithConsentCreateRequestSchema
+>;
+export const BuyerWithConsentResponseSchema =
+  BuyerWithConsentCreateRequestSchema;
+export type BuyerWithConsentResponse = BuyerWithConsentCreateRequest;
+export const BuyerWithConsentUpdateRequestSchema =
+  BuyerWithConsentCreateRequestSchema;
+export type BuyerWithConsentUpdateRequest = BuyerWithConsentCreateRequest;
 
 export const CheckoutWithDiscountUpdateRequestSchema = z.object({
   attribution: z.record(z.string(), z.string()).optional(),
@@ -753,9 +711,7 @@ export const AppliedElementSchema = z.object({
   code: z.string().optional(),
   eligibility: z
     .string()
-    .regex(
-      /^[a-z](?:[a-z0-9-]*[a-z0-9])?(?:\.[a-z0-9](?:[a-z0-9_-]*[a-z0-9_])?)+$/
-    )
+    .regex(/^[a-z][a-z0-9]*(?:\.[a-z][a-z0-9_]*)+$/)
     .optional(),
   method: MethodSchema.optional(),
   priority: z.number().int().gte(1).optional(),
@@ -778,7 +734,7 @@ export const FulfillmentMethodResponseSchema = z.object({
   id: z.string(),
   line_item_ids: z.array(z.string()),
   selected_destination_id: z.union([z.null(), z.string()]).optional(),
-  type: z.string(),
+  type: MethodTypeSchema,
 });
 export type FulfillmentMethodResponse = z.infer<
   typeof FulfillmentMethodResponseSchema
@@ -804,7 +760,6 @@ export const CartUpdateRequestSchema = z.object({
 export type CartUpdateRequest = z.infer<typeof CartUpdateRequestSchema>;
 
 export const CartResponseSchema = z.object({
-  actions: z.record(z.string(), z.array(ActionsSchema)).optional(),
   attribution: z.record(z.string(), z.string()).optional(),
   buyer: BuyerSchema.optional(),
   context: CheckoutCreateRequestContextSchema.optional(),
@@ -813,9 +768,8 @@ export const CartResponseSchema = z.object({
   expires_at: z.coerce.date().optional(),
   id: z.string(),
   line_items: z.array(LineItemResponseSchema),
-  links: z.array(CheckoutResponseLinkSchema).optional(),
+  links: z.array(LinkSchema).optional(),
   messages: z.array(CheckoutResponseMessageSchema).optional(),
-  policies: z.array(CheckoutResponsePolicySchema).optional(),
   signals: CheckoutCreateRequestSignalsSchema.optional(),
   totals: z.array(TotalsResponseSchema),
   ucp: UcpResponseSchema,
@@ -837,7 +791,6 @@ export const CheckoutUpdateRequestSchema = CheckoutWithCartUpdateRequestSchema;
 export type CheckoutUpdateRequest = CheckoutWithCartUpdateRequest;
 
 export const CheckoutWithCartResponseSchema = z.object({
-  actions: z.record(z.string(), z.array(ActionsSchema)).optional(),
   attribution: z.record(z.string(), z.string()).optional(),
   buyer: BuyerSchema.optional(),
   context: CheckoutCreateRequestContextSchema.optional(),
@@ -846,11 +799,10 @@ export const CheckoutWithCartResponseSchema = z.object({
   expires_at: z.coerce.date().optional(),
   id: z.string(),
   line_items: z.array(LineItemResponseSchema),
-  links: z.array(CheckoutResponseLinkSchema),
+  links: z.array(LinkSchema),
   messages: z.array(CheckoutResponseMessageSchema).optional(),
   order: OrderConfirmationSchema.optional(),
   payment: PaymentResponseSchema.optional(),
-  policies: z.array(CheckoutResponsePolicySchema).optional(),
   signals: CheckoutCreateRequestSignalsSchema.optional(),
   status: CheckoutResponseStatusSchema,
   totals: z.array(TotalsResponseSchema),
@@ -927,7 +879,6 @@ export type CheckoutCompleteRequest = z.infer<
 >;
 
 export const CheckoutResponseSchema = z.object({
-  actions: z.record(z.string(), z.array(ActionsSchema)).optional(),
   attribution: z.record(z.string(), z.string()).optional(),
   buyer: BuyerSchema.optional(),
   context: CheckoutCreateRequestContextSchema.optional(),
@@ -936,11 +887,10 @@ export const CheckoutResponseSchema = z.object({
   expires_at: z.coerce.date().optional(),
   id: z.string(),
   line_items: z.array(LineItemResponseSchema),
-  links: z.array(CheckoutResponseLinkSchema),
+  links: z.array(LinkSchema),
   messages: z.array(CheckoutResponseMessageSchema).optional(),
   order: OrderConfirmationSchema.optional(),
   payment: PaymentResponseSchema.optional(),
-  policies: z.array(CheckoutResponsePolicySchema).optional(),
   signals: CheckoutCreateRequestSignalsSchema.optional(),
   status: CheckoutResponseStatusSchema,
   totals: z.array(TotalsResponseSchema),
@@ -954,37 +904,50 @@ export const FulfillmentSchema = z.object({
 });
 export type Fulfillment = z.infer<typeof FulfillmentSchema>;
 
-export const BuyerWithConsentCreateRequestSchema = z.object({
-  email: z.string().optional(),
-  first_name: z.string().optional(),
-  last_name: z.string().optional(),
-  phone_number: z.string().optional(),
-  consent: z.record(z.string(), ConsentValueSchema).optional(),
+export const CheckoutWithBuyerConsentCreateRequestSchema = z.object({
+  attribution: z.record(z.string(), z.string()).optional(),
+  buyer: BuyerWithConsentCreateRequestSchema.optional(),
+  context: CheckoutCreateRequestContextSchema.optional(),
+  line_items: z.array(LineItemCreateRequestSchema),
+  payment: PaymentCreateRequestSchema.optional(),
+  signals: CheckoutCreateRequestSignalsSchema.optional(),
 });
-export type BuyerWithConsentCreateRequest = z.infer<
-  typeof BuyerWithConsentCreateRequestSchema
+export type CheckoutWithBuyerConsentCreateRequest = z.infer<
+  typeof CheckoutWithBuyerConsentCreateRequestSchema
 >;
 
-export const BuyerWithConsentUpdateRequestSchema = z.object({
-  email: z.string().optional(),
-  first_name: z.string().optional(),
-  last_name: z.string().optional(),
-  phone_number: z.string().optional(),
-  consent: z.record(z.string(), ConsentClassSchema).optional(),
+export const CheckoutWithBuyerConsentUpdateRequestSchema = z.object({
+  attribution: z.record(z.string(), z.string()).optional(),
+  buyer: BuyerWithConsentUpdateRequestSchema.optional(),
+  context: CheckoutCreateRequestContextSchema.optional(),
+  line_items: z.array(LineItemUpdateRequestSchema),
+  payment: PaymentUpdateRequestSchema.optional(),
+  signals: CheckoutCreateRequestSignalsSchema.optional(),
 });
-export type BuyerWithConsentUpdateRequest = z.infer<
-  typeof BuyerWithConsentUpdateRequestSchema
+export type CheckoutWithBuyerConsentUpdateRequest = z.infer<
+  typeof CheckoutWithBuyerConsentUpdateRequestSchema
 >;
 
-export const BuyerWithConsentResponseSchema = z.object({
-  email: z.string().optional(),
-  first_name: z.string().optional(),
-  last_name: z.string().optional(),
-  phone_number: z.string().optional(),
-  consent: z.record(z.string(), BuyerConsentSchema).optional(),
+export const CheckoutWithBuyerConsentResponseSchema = z.object({
+  attribution: z.record(z.string(), z.string()).optional(),
+  buyer: BuyerWithConsentResponseSchema.optional(),
+  context: CheckoutCreateRequestContextSchema.optional(),
+  continue_url: z.string().optional(),
+  currency: z.string(),
+  expires_at: z.coerce.date().optional(),
+  id: z.string(),
+  line_items: z.array(LineItemResponseSchema),
+  links: z.array(LinkSchema),
+  messages: z.array(CheckoutResponseMessageSchema).optional(),
+  order: OrderConfirmationSchema.optional(),
+  payment: PaymentResponseSchema.optional(),
+  signals: CheckoutCreateRequestSignalsSchema.optional(),
+  status: CheckoutResponseStatusSchema,
+  totals: z.array(TotalsResponseSchema),
+  ucp: UcpResponseSchema,
 });
-export type BuyerWithConsentResponse = z.infer<
-  typeof BuyerWithConsentResponseSchema
+export type CheckoutWithBuyerConsentResponse = z.infer<
+  typeof CheckoutWithBuyerConsentResponseSchema
 >;
 
 export const CheckoutWithDiscountCreateRequestSchema = z.object({
@@ -1013,7 +976,7 @@ export const FulfillmentMethodCreateRequestSchema = z.object({
   groups: z.array(FulfillmentGroupSchema).optional(),
   line_item_ids: z.array(z.string()).optional(),
   selected_destination_id: z.union([z.null(), z.string()]).optional(),
-  type: z.string(),
+  type: MethodTypeSchema,
 });
 export type FulfillmentMethodCreateRequest = z.infer<
   typeof FulfillmentMethodCreateRequestSchema
@@ -1048,7 +1011,7 @@ export const LookupRequestSchema = z.object({
 export type LookupRequest = z.infer<typeof LookupRequestSchema>;
 
 export const CatalogLookupSchema = z.object({
-  availability: AvailabilitySchema.optional(),
+  availability: PurpleAvailabilitySchema.optional(),
   barcodes: z.array(PurpleBarcodeSchema).optional(),
   categories: z.array(CategorySchema).optional(),
   description: DescriptionSchema,
@@ -1071,7 +1034,7 @@ export const CatalogLookupSchema = z.object({
 export type CatalogLookup = z.infer<typeof CatalogLookupSchema>;
 
 export const VariantSchema = z.object({
-  availability: AvailabilitySchema.optional(),
+  availability: FluffyAvailabilitySchema.optional(),
   barcodes: z.array(FluffyBarcodeSchema).optional(),
   categories: z.array(CategorySchema).optional(),
   description: DescriptionSchema,
@@ -1111,7 +1074,7 @@ export const SearchResponseProductSchema = z.object({
 export type SearchResponseProduct = z.infer<typeof SearchResponseProductSchema>;
 
 export const UcpDiscoveryProfileSchema = z.object({
-  payment: UcpDiscoveryProfilePaymentSchema.optional(),
+  payment: PaymentSchema.optional(),
   signing_keys: z.array(SigningKeySchema).optional(),
   ucp: UcpSchema,
 });
@@ -1138,62 +1101,12 @@ export const OrderSchema = z.object({
   line_items: z.array(OrderLineItemSchema),
   messages: z.array(CheckoutResponseMessageSchema).optional(),
   permalink_url: z.string(),
-  policies: z.array(CheckoutResponsePolicySchema).optional(),
   totals: z.array(TotalsResponseSchema),
   ucp: UcpResponseSchema,
 });
 export type Order = z.infer<typeof OrderSchema>;
 
-export const CheckoutWithBuyerConsentCreateRequestSchema = z.object({
-  attribution: z.record(z.string(), z.string()).optional(),
-  buyer: BuyerWithConsentCreateRequestSchema.optional(),
-  context: CheckoutCreateRequestContextSchema.optional(),
-  line_items: z.array(LineItemCreateRequestSchema),
-  payment: PaymentCreateRequestSchema.optional(),
-  signals: CheckoutCreateRequestSignalsSchema.optional(),
-});
-export type CheckoutWithBuyerConsentCreateRequest = z.infer<
-  typeof CheckoutWithBuyerConsentCreateRequestSchema
->;
-
-export const CheckoutWithBuyerConsentUpdateRequestSchema = z.object({
-  attribution: z.record(z.string(), z.string()).optional(),
-  buyer: BuyerWithConsentUpdateRequestSchema.optional(),
-  context: CheckoutCreateRequestContextSchema.optional(),
-  line_items: z.array(LineItemUpdateRequestSchema),
-  payment: PaymentUpdateRequestSchema.optional(),
-  signals: CheckoutCreateRequestSignalsSchema.optional(),
-});
-export type CheckoutWithBuyerConsentUpdateRequest = z.infer<
-  typeof CheckoutWithBuyerConsentUpdateRequestSchema
->;
-
-export const CheckoutWithBuyerConsentResponseSchema = z.object({
-  actions: z.record(z.string(), z.array(ActionsSchema)).optional(),
-  attribution: z.record(z.string(), z.string()).optional(),
-  buyer: BuyerWithConsentResponseSchema.optional(),
-  context: CheckoutCreateRequestContextSchema.optional(),
-  continue_url: z.string().optional(),
-  currency: z.string(),
-  expires_at: z.coerce.date().optional(),
-  id: z.string(),
-  line_items: z.array(LineItemResponseSchema),
-  links: z.array(CheckoutResponseLinkSchema),
-  messages: z.array(CheckoutResponseMessageSchema).optional(),
-  order: OrderConfirmationSchema.optional(),
-  payment: PaymentResponseSchema.optional(),
-  policies: z.array(CheckoutResponsePolicySchema).optional(),
-  signals: CheckoutCreateRequestSignalsSchema.optional(),
-  status: CheckoutResponseStatusSchema,
-  totals: z.array(TotalsResponseSchema),
-  ucp: UcpResponseSchema,
-});
-export type CheckoutWithBuyerConsentResponse = z.infer<
-  typeof CheckoutWithBuyerConsentResponseSchema
->;
-
 export const CheckoutWithDiscountResponseSchema = z.object({
-  actions: z.record(z.string(), z.array(ActionsSchema)).optional(),
   attribution: z.record(z.string(), z.string()).optional(),
   buyer: BuyerSchema.optional(),
   context: CheckoutCreateRequestContextSchema.optional(),
@@ -1202,11 +1115,10 @@ export const CheckoutWithDiscountResponseSchema = z.object({
   expires_at: z.coerce.date().optional(),
   id: z.string(),
   line_items: z.array(LineItemResponseSchema),
-  links: z.array(CheckoutResponseLinkSchema),
+  links: z.array(LinkSchema),
   messages: z.array(CheckoutResponseMessageSchema).optional(),
   order: OrderConfirmationSchema.optional(),
   payment: PaymentResponseSchema.optional(),
-  policies: z.array(CheckoutResponsePolicySchema).optional(),
   signals: CheckoutCreateRequestSignalsSchema.optional(),
   status: CheckoutResponseStatusSchema,
   totals: z.array(TotalsResponseSchema),
@@ -1236,7 +1148,6 @@ export type CheckoutWithFulfillmentUpdateRequest = z.infer<
 >;
 
 export const CheckoutWithFulfillmentResponseSchema = z.object({
-  actions: z.record(z.string(), z.array(ActionsSchema)).optional(),
   attribution: z.record(z.string(), z.string()).optional(),
   buyer: BuyerSchema.optional(),
   context: CheckoutCreateRequestContextSchema.optional(),
@@ -1245,11 +1156,10 @@ export const CheckoutWithFulfillmentResponseSchema = z.object({
   expires_at: z.coerce.date().optional(),
   id: z.string(),
   line_items: z.array(LineItemResponseSchema),
-  links: z.array(CheckoutResponseLinkSchema),
+  links: z.array(LinkSchema),
   messages: z.array(CheckoutResponseMessageSchema).optional(),
   order: OrderConfirmationSchema.optional(),
   payment: PaymentResponseSchema.optional(),
-  policies: z.array(CheckoutResponsePolicySchema).optional(),
   signals: CheckoutCreateRequestSignalsSchema.optional(),
   status: CheckoutResponseStatusSchema,
   totals: z.array(TotalsResponseSchema),
@@ -1298,10 +1208,8 @@ export const ProductSchema = z.object({
 export type Product = z.infer<typeof ProductSchema>;
 
 export const SearchResponseSchema = z.object({
-  actions: z.record(z.string(), z.array(ActionsSchema)).optional(),
   messages: z.array(LookupResponseMessageSchema).optional(),
   pagination: SearchResponsePaginationSchema.optional(),
-  policies: z.array(LookupResponsePolicySchema).optional(),
   products: z.array(SearchResponseProductSchema),
   ucp: UcpResponseSchema,
 });
@@ -1321,18 +1229,14 @@ export type CheckoutWithFulfillmentCreateRequest = z.infer<
 >;
 
 export const LookupResponseSchema = z.object({
-  actions: z.record(z.string(), z.array(ActionsSchema)).optional(),
   messages: z.array(LookupResponseMessageSchema).optional(),
-  policies: z.array(LookupResponsePolicySchema).optional(),
   products: z.array(LookupResponseProductSchema),
   ucp: UcpResponseSchema,
 });
 export type LookupResponse = z.infer<typeof LookupResponseSchema>;
 
 export const GetProductResponseSchema = z.object({
-  actions: z.record(z.string(), z.array(ActionsSchema)).optional(),
   messages: z.array(LookupResponseMessageSchema).optional(),
-  policies: z.array(LookupResponsePolicySchema).optional(),
   product: ProductSchema,
   ucp: UcpResponseSchema,
 });


### PR DESCRIPTION
# Description

Regenerated the JS SDK specifications (`src/spec_generated.ts`) based on the `release/2026-04-08` branch of the `ucp` repository.

## Category (Required)

- [ ] **Core Protocol**
- [ ] **Governance/Contributing**
- [ ] **Capability**
- [ ] **Documentation**
- [ ] **Infrastructure**
- [ ] **Maintenance**
- [x] **SDK**
- [ ] **Samples / Conformance**
- [ ] **UCP Schema**
- [ ] **Community Health (.github)**

## Related Issues

None.

## Checklist

- [x] I have followed the [Contributing Guide](https://github.com/Universal-Commerce-Protocol/.github/blob/main/CONTRIBUTING.md) (including Conventional Commits title requirements and `!` for breaking changes).
- [ ] I have updated the documentation (if applicable).
- [x] My changes pass all local linting and formatting checks.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] (For Core/Capability) I have included/updated the relevant JSON schemas.
- [ ] I have regenerated Python Pydantic models by running generate_models.sh under python_sdk.

