### PR TITLE
fix: enforce propertyNames key pattern on the generated Signals schema

### DIFF
--- a/scripts/inject-schema-constraints.mjs
+++ b/scripts/inject-schema-constraints.mjs
@@ -200,6 +200,34 @@ function resolveObject(node, file, seen = new Set(), depth = 0) {
 }
 
 /**
+ * Resolve a `propertyNames` subschema to its literal regex `pattern`, following
+ * a `$ref` (e.g. `signals.json` inlines the pattern; `ucp.json` maps `$ref`
+ * `reverse_domain_name.json`). Returns the pattern string exactly as authored in
+ * the source schema (never a hand-copied literal), or null when the constraint
+ * is not a plain string pattern we can express as a zod key check.
+ */
+function resolvePropertyNamesPattern(node, file, seen = new Set(), depth = 0) {
+  if (!node || typeof node !== "object" || depth > 32) {
+    return null;
+  }
+  if (typeof node.$ref === "string") {
+    const key = `${file}|${node.$ref}`;
+    if (seen.has(key)) {
+      return null;
+    }
+    seen.add(key);
+    const resolved = resolveRef(node.$ref, file);
+    return resolvePropertyNamesPattern(
+      resolved.node,
+      resolved.file,
+      seen,
+      depth + 1
+    );
+  }
+  return typeof node.pattern === "string" ? node.pattern : null;
+}
+
+/**
  * A single `contains` cardinality clause: the array MUST hold between `min`
  * and `max` items whose `property` equals `value`. We only recover the
  * common, unambiguous shape `{ contains: { properties: { <p>: { const: <v> }
@@ -289,6 +317,16 @@ function describeConstraint(propertyNode, file) {
 // setKey -> Map(propertyName -> Map(signature -> descriptor))
 const constraintIndex = new Map();
 
+// Object-level `propertyNames` (a key-name constraint, not a per-field one) for
+// objects that declare it alongside named `properties` -- the extra-allow +
+// named-field shape (`signals.json`: reverse-domain key pattern + named
+// dev.ucp.* fields + `additionalProperties: true`) that quicktype renders as a
+// plain `z.object`, dropping both the key pattern and the extra-key retention.
+// Pure dict-map `propertyNames` (no named `properties`, e.g. ucp.json's
+// registries) render as `z.record` and are intentionally not handled here; they
+// need a distinct record-key mechanism. setKey -> Map(signature -> descriptor).
+const propertyNamesIndex = new Map();
+
 function recordObject(properties, file) {
   const setKey = Object.keys(properties).sort().join(",");
   if (!constraintIndex.has(setKey)) {
@@ -305,6 +343,45 @@ function recordObject(properties, file) {
     }
     byProperty.get(name).set(described.signature, described.descriptor);
   }
+}
+
+/**
+ * Record an object-level `propertyNames` key constraint, keyed like the scalar
+ * index by the object's sorted named-property set. Only the extra-allow +
+ * named-field shape is recorded: named `properties` are present (so the
+ * generated schema is a `z.object`, not a `z.record`), `additionalProperties` is
+ * `true` (extras allowed, so they must be retained AND key-checked), and the
+ * key constraint resolves to a literal pattern. `propertyNames` on an `allOf`
+ * branch is followed like the scalar merge (first branch wins).
+ */
+function recordPropertyNames(node, properties, file) {
+  let propertyNames = node.propertyNames;
+  let additionalProperties = node.additionalProperties;
+  if (propertyNames === undefined && Array.isArray(node.allOf)) {
+    for (const sub of node.allOf) {
+      if (sub && typeof sub === "object" && sub.propertyNames !== undefined) {
+        propertyNames = sub.propertyNames;
+        if (additionalProperties === undefined) {
+          additionalProperties = sub.additionalProperties;
+        }
+        break;
+      }
+    }
+  }
+  if (propertyNames === undefined || additionalProperties !== true) {
+    return;
+  }
+  const pattern = resolvePropertyNamesPattern(propertyNames, file);
+  if (pattern === null) {
+    return;
+  }
+  const setKey = Object.keys(properties).sort().join(",");
+  const descriptor = { pattern };
+  const signature = JSON.stringify(descriptor);
+  if (!propertyNamesIndex.has(setKey)) {
+    propertyNamesIndex.set(setKey, new Map());
+  }
+  propertyNamesIndex.get(setKey).set(signature, descriptor);
 }
 
 function walkSchema(node, file, seen = new Set(), depth = 0) {
@@ -324,6 +401,7 @@ function walkSchema(node, file, seen = new Set(), depth = 0) {
   const resolvedObject = resolveObject(node, file);
   if (resolvedObject) {
     recordObject(resolvedObject.properties, resolvedObject.file);
+    recordPropertyNames(node, resolvedObject.properties, file);
   }
   if (node.properties && typeof node.properties === "object") {
     for (const child of Object.values(node.properties)) {
@@ -388,6 +466,19 @@ for (const [setKey, byProperty] of constraintIndex) {
   }
 }
 
+// Resolve the object-level propertyNames index to one descriptor per set,
+// dropping any set that carried conflicting patterns (mirrors the scalar
+// ambiguity guard so a coincidental property-set clash never over-restricts).
+// setKey -> descriptor
+const resolvedPropertyNames = new Map();
+for (const [setKey, bySignature] of propertyNamesIndex) {
+  if (bySignature.size === 1) {
+    resolvedPropertyNames.set(setKey, [...bySignature.values()][0]);
+  } else {
+    ambiguous.push({ setKey, name: "<propertyNames>", count: bySignature.size });
+  }
+}
+
 // --- Zod method rendering --------------------------------------------------
 
 function toRegexLiteral(pattern) {
@@ -442,6 +533,40 @@ function renderContainsRefine(groups) {
     `ctx.addIssue({ code: z.ZodIssueCode.custom, message: ` +
     "`Array must contain at most ${rule.max} item(s) where " +
     "${rule.property} = ${JSON.stringify(rule.value)} (maxContains)` });" +
+    `}}})`
+  );
+}
+
+/**
+ * Object-level `propertyNames` enforcement for an extra-allow object.
+ *
+ * `.catchall(z.any())` retains extra keys (a bare `z.object` strips them, which
+ * would silently drop the `additionalProperties: true` reverse-domain extras the
+ * schema means to keep), and the `.superRefine` matches every property name --
+ * named fields and retained extras alike -- against the source key pattern.
+ *
+ * `RegExp.test` is used deliberately: it implements JSON Schema's unanchored
+ * `pattern` semantics, and for the source's `^...$`-anchored pattern it matches
+ * only end-of-input in ECMA-262 (no `m` flag), so a trailing-newline key is
+ * rejected -- the JS analogue of python-sdk#66's `re.fullmatch` fix (Python's
+ * `re.match` admits `"...\n"`). See scripts test for the pinned newline case.
+ *
+ * Out of scope for this per-object key check: zod-core strips an own `__proto__`
+ * key from every `z.object` (a prototype-pollution safeguard) before `.catchall`
+ * / `.superRefine` run, so such a key is silently dropped (safe direction: not
+ * preserved, no pollution) rather than surfaced as a rejection. That is an
+ * SDK-wide zod trait, not a per-schema property, and it is pinned by a test.
+ */
+function renderPropertyNamesRefine(pattern) {
+  const regex = toRegexLiteral(pattern);
+  return (
+    `.catchall(z.any())` +
+    `.superRefine((value, ctx) => {` +
+    `for (const key of Object.keys(value)) {` +
+    `if (!${regex}.test(key)) {` +
+    `ctx.addIssue({ code: z.ZodIssueCode.custom, path: [key], message: ` +
+    "`Property name ${JSON.stringify(key)} does not match the required " +
+    "pattern (propertyNames)` });" +
     `}}})`
   );
 }
@@ -579,6 +704,22 @@ function alreadyConstrained(baseCall) {
   return false;
 }
 
+/**
+ * Idempotency for the object-level propertyNames splice: is the whole
+ * `z.object({...})` call already wrapped by a key-check method chain
+ * (`.catchall(...)` / `.superRefine(...)`)?
+ */
+function objectAlreadyConstrained(objectCall) {
+  const parent = objectCall.parent;
+  if (parent && ts.isPropertyAccessExpression(parent)) {
+    const method = parent.name.text;
+    if (method === "catchall" || method === "superRefine") {
+      return true;
+    }
+  }
+  return false;
+}
+
 // --- Parse the generated file and compute edits ----------------------------
 
 const sourceText = fs.readFileSync(targetPath, "utf8");
@@ -594,6 +735,7 @@ const edits = []; // { pos, text }
 const report = {
   objectsMatched: 0,
   fieldsInjected: 0,
+  propertyNamesInjected: 0,
   fieldsSkippedType: 0,
   fieldsAlreadyDone: 0,
   injections: [],
@@ -620,12 +762,13 @@ function handleObjectLiteral(objectLiteral) {
   }
   const setKey = [...names].sort().join(",");
   const resolvedProperties = resolvedIndex.get(setKey);
-  if (!resolvedProperties) {
+  const propertyNamesDescriptor = resolvedPropertyNames.get(setKey);
+  if (!resolvedProperties && !propertyNamesDescriptor) {
     return;
   }
   let matchedAny = false;
   for (const prop of objectLiteral.properties) {
-    if (!ts.isPropertyAssignment(prop)) {
+    if (!resolvedProperties || !ts.isPropertyAssignment(prop)) {
       continue;
     }
     const name =
@@ -658,6 +801,25 @@ function handleObjectLiteral(objectLiteral) {
     report.fieldsInjected += 1;
     report.injections.push(`${setKey} :: ${name} ${methods.join("")}`);
     matchedAny = true;
+  }
+  // Object-level propertyNames: splice a key-pattern check onto the whole
+  // `z.object({...})` call (the property-set here is the constrained object).
+  if (propertyNamesDescriptor) {
+    const objectCall = objectLiteral.parent;
+    if (
+      objectCall &&
+      ts.isCallExpression(objectCall) &&
+      !objectAlreadyConstrained(objectCall)
+    ) {
+      const text = renderPropertyNamesRefine(propertyNamesDescriptor.pattern);
+      edits.push({ pos: objectCall.getEnd(), text });
+      report.propertyNamesInjected += 1;
+      report.injections.push(`${setKey} :: <propertyNames> ${text}`);
+      matchedAny = true;
+    } else if (objectCall && objectAlreadyConstrained(objectCall)) {
+      report.fieldsAlreadyDone += 1;
+      matchedAny = true;
+    }
   }
   if (matchedAny) {
     report.objectsMatched += 1;
@@ -695,6 +857,7 @@ fs.writeFileSync(targetPath, output);
 process.stdout.write(
   `inject-schema-constraints: ${report.fieldsInjected} field(s) constrained ` +
     `across ${report.objectsMatched} object schema(s); ` +
+    `${report.propertyNamesInjected} propertyNames key-check(s); ` +
     `${report.fieldsAlreadyDone} already constrained; ` +
     `${report.fieldsSkippedType} skipped (base-type mismatch).\n`
 );

--- a/src/spec_generated.ts
+++ b/src/spec_generated.ts
@@ -196,10 +196,23 @@ export const PaymentCredentialSchema = z.object({
 });
 export type PaymentCredential = z.infer<typeof PaymentCredentialSchema>;
 
-export const CheckoutCreateRequestSignalsSchema = z.object({
-  "dev.ucp.buyer_ip": z.string().optional(),
-  "dev.ucp.user_agent": z.string().optional(),
-});
+export const CheckoutCreateRequestSignalsSchema = z
+  .object({
+    "dev.ucp.buyer_ip": z.string().optional(),
+    "dev.ucp.user_agent": z.string().optional(),
+  })
+  .catchall(z.any())
+  .superRefine((value, ctx) => {
+    for (const key of Object.keys(value)) {
+      if (!/^[a-z][a-z0-9]*(?:\.[a-z][a-z0-9_]*)+$/.test(key)) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: [key],
+          message: `Property name ${JSON.stringify(key)} does not match the required pattern (propertyNames)`,
+        });
+      }
+    }
+  });
 export type CheckoutCreateRequestSignals = z.infer<
   typeof CheckoutCreateRequestSignalsSchema
 >;

--- a/tests/signals-property-names.test.js
+++ b/tests/signals-property-names.test.js
@@ -1,0 +1,128 @@
+// Copyright 2026 UCP Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// propertyNames enforcement for the Signals object.
+//
+// signals.json declares named `properties` (dev.ucp.buyer_ip, dev.ucp.user_agent)
+// alongside `propertyNames.pattern` (reverse-domain) and
+// `additionalProperties: true`. quicktype's typescript-zod target emits only the
+// object shape, dropping both `propertyNames` (so a malformed key is not
+// rejected) and `additionalProperties: true` (so a well-formed reverse-domain
+// extra is silently stripped rather than preserved). This is the js-sdk sibling
+// of python-sdk#66; the enforcement is re-attached in
+// scripts/inject-schema-constraints.mjs.
+//
+// The schemas are compiled from src/spec_generated.ts by the "pretest" step so
+// the test exercises the generated zod schemas directly.
+
+const { test } = require("node:test");
+const assert = require("node:assert/strict");
+
+const {
+  CheckoutCreateRequestSignalsSchema,
+  LookupRequestSignalsSchema,
+} = require("./.dist/spec_generated.js");
+
+const accepts = (schema, value) => schema.safeParse(value).success === true;
+const rejects = (schema, value) => schema.safeParse(value).success === false;
+
+// The reverse-domain key pattern signals.json/propertyNames requires, identical
+// to shopping/types/reverse_domain_name.json.
+const PATTERN = /^[a-z][a-z0-9]*(?:\.[a-z][a-z0-9_]*)+$/;
+
+test("Signals rejects a malformed (non reverse-domain) property name", () => {
+  assert.ok(
+    rejects(CheckoutCreateRequestSignalsSchema, {
+      "dev.ucp.buyer_ip": "1.2.3.4",
+      "bogus KEY!": "x",
+    }),
+    "a key that violates propertyNames.pattern must be rejected"
+  );
+});
+
+test("Signals accepts and preserves a well-formed reverse-domain extra key", () => {
+  const result = CheckoutCreateRequestSignalsSchema.safeParse({
+    "dev.ucp.buyer_ip": "1.2.3.4",
+    "com.example.device_id": "abc123",
+  });
+  assert.ok(result.success, "a reverse-domain extra key must be accepted");
+  assert.equal(
+    result.data["com.example.device_id"],
+    "abc123",
+    "additionalProperties: true means the reverse-domain extra must be preserved"
+  );
+});
+
+test("Signals still populates its named fields", () => {
+  const result = CheckoutCreateRequestSignalsSchema.safeParse({
+    "dev.ucp.buyer_ip": "1.2.3.4",
+    "dev.ucp.user_agent": "curl/8",
+  });
+  assert.ok(result.success);
+  assert.equal(result.data["dev.ucp.buyer_ip"], "1.2.3.4");
+  assert.equal(result.data["dev.ucp.user_agent"], "curl/8");
+});
+
+// python-sdk#66 anchor lesson, pinned for the JS/ECMA-262 dialect. Python's
+// re.match admits a trailing newline against a `$`-anchored pattern; in
+// JavaScript `$` (no `m` flag) matches only end-of-input, so RegExp.test — the
+// operator that matches JSON Schema's unanchored `pattern` semantics — already
+// rejects "com.example.k\n". This test pins that behavior so a future
+// refactor cannot silently regress to a newline-admitting check.
+test("Signals rejects a reverse-domain key with a trailing newline", () => {
+  assert.equal(
+    PATTERN.test("com.example.k\n"),
+    false,
+    "sanity: pattern rejects trailing newline"
+  );
+  assert.ok(
+    rejects(CheckoutCreateRequestSignalsSchema, {
+      "com.example.k\n": "x",
+    }),
+    "a trailing-newline key must be rejected (anchor safety)"
+  );
+});
+
+test("LookupRequestSignalsSchema enforces the same propertyNames rule", () => {
+  assert.ok(
+    rejects(LookupRequestSignalsSchema, { "bogus KEY!": "x" }),
+    "the aliased Signals schema must enforce propertyNames too"
+  );
+  assert.ok(accepts(LookupRequestSignalsSchema, { "com.example.ok": "y" }));
+});
+
+// Known boundary, pinned. zod-core drops an own `__proto__` key from every
+// z.object (a prototype-pollution safeguard) BEFORE .catchall/.superRefine run,
+// so the key never reaches this per-object propertyNames check. The direction is
+// safe -- the key is dropped, not preserved, and the prototype is not polluted --
+// but it is silently dropped rather than rejected. This is an SDK-wide zod trait,
+// not specific to Signals, so it is documented here rather than special-cased.
+// Every OTHER pattern-violating own key, including "constructor" and "prototype",
+// is rejected as normal.
+test("Signals: an own __proto__ key is dropped by zod-core (not preserved, no pollution)", () => {
+  const result = CheckoutCreateRequestSignalsSchema.safeParse(
+    JSON.parse('{"__proto__":{"polluted":true},"dev.ucp.buyer_ip":"1.2.3.4"}')
+  );
+  assert.ok(result.success, "zod-core strips own __proto__ before validation");
+  assert.ok(
+    !Object.prototype.hasOwnProperty.call(result.data, "__proto__"),
+    "the __proto__ key must not survive into the parsed output"
+  );
+  assert.equal({}.polluted, undefined, "Object.prototype must not be polluted");
+});
+
+test("Signals rejects own constructor / prototype keys (only literal __proto__ is dropped)", () => {
+  assert.ok(rejects(CheckoutCreateRequestSignalsSchema, { constructor: "x" }));
+  assert.ok(rejects(CheckoutCreateRequestSignalsSchema, { prototype: "x" }));
+});


### PR DESCRIPTION
# Description

`propertyNames` is not enforced on the one generated schema where it maps to an
extra-permitting object with named fields. quicktype's `typescript-zod` target
emits only the object shape, so both the key pattern (`propertyNames`) and the
extra-key retention (`additionalProperties: true`) are dropped.

**Observed** (on current `main`, committed models, `src/spec_generated.ts`):

```js
const { CheckoutCreateRequestSignalsSchema } = require("./src/spec_generated");

CheckoutCreateRequestSignalsSchema.parse({
  "dev.ucp.buyer_ip": "1.2.3.4",
  "bogus KEY!": "x",
});
// succeeds; the malformed key is silently STRIPPED (z.object drops unknowns)

CheckoutCreateRequestSignalsSchema.parse({ "com.example.device_id": "abc" });
// succeeds but returns {}; the well-formed reverse-domain extra is LOST
```

**Expected**: the malformed key is rejected, and the well-formed reverse-domain
extra is preserved. `signals.json` requires every property name to match the
reverse-domain pattern `^[a-z][a-z0-9]*(?:\.[a-z][a-z0-9_]*)+$`
(`shopping/types/signals.json` `propertyNames.pattern`, the same pattern as
`shopping/types/reverse_domain_name.json`), and it sets
`additionalProperties: true`, so a well-formed extra such as
`com.example.device_id` must be kept.

## Why it happens / why CI did not catch it

`signals.json` declares `propertyNames` alongside named `properties`
(`dev.ucp.buyer_ip`, `dev.ucp.user_agent`) and `additionalProperties: true`.
quicktype emits it as a bare `z.object({...})` with the two named fields.
`z.object` strips unknown keys by default, so extra keys are neither retained nor
checked against the key pattern. No test asserted key-pattern rejection, so the
dropped constraint shipped green.

## Fix (source-driven, in the generation pipeline)

`scripts/inject-schema-constraints.mjs` already re-attaches the value constraints
quicktype drops (#34/#37). This extends it to the object-level `propertyNames`
key constraint: it scans the source schemas for objects that declare
`propertyNames` **and** carry named `properties`, reads the key pattern from the
source (inline `pattern`, or a `$ref` to e.g. `reverse_domain_name.json` — never
duplicated in code), and splices onto the matching `z.object` call:

```js
.catchall(z.any())            // retain extras (additionalProperties: true)
.superRefine((value, ctx) => {
  for (const key of Object.keys(value)) {
    if (!/^[a-z][a-z0-9]*(?:\.[a-z][a-z0-9_]*)+$/.test(key)) {
      ctx.addIssue({ code: z.ZodIssueCode.custom, path: [key], message: ... });
    }
  }
})
```

`.catchall(z.any())` keeps the reverse-domain extras a bare `z.object` would drop;
the `.superRefine` matches every property name (named fields and retained extras
alike) against the source pattern. The injected regex is byte-identical to
`signals.json` `propertyNames.pattern`.

`RegExp.test` is used deliberately. It implements JSON Schema's unanchored
`pattern` semantics, and for the source's `^...$`-anchored pattern it matches
only end-of-input in ECMA-262 (no `m` flag), so a trailing-newline key
(`"com.example.k\n"`) is rejected. This is the JS analogue of the python-sdk#66
sibling fix, where Python's `re.match` had to become `re.fullmatch` because
`re.match` admits a trailing newline against a `$`-anchored pattern; JavaScript's
`$` does not, and a pinned test asserts it.

## Scope — `propertyNames` sites in the 2026-04-08 spec

The change deliberately handles only the `propertyNames` + named-`properties`
(extra-permitting object) shape. Every `propertyNames` site in the spec is
accounted for:

| Source site | Named props | Generated shape | Decision |
| --- | --- | --- | --- |
| `shopping/types/signals.json` (root) | yes (`dev.ucp.buyer_ip`, `dev.ucp.user_agent`); `additionalProperties: true` | `z.object` — `CheckoutCreateRequestSignalsSchema` (aliased `LookupRequestSignalsSchema`) | **Converted** |
| `ucp.json` `#/$defs/base` `services` / `capabilities` / `payment_handlers` | no (pure map) | `z.record(z.string(), V)` in `UcpResponseSchema`; `services` also in `UcpSchema` | Out of scope — see below |
| `ucp.json` `#/$defs/requires` `capabilities` | no (pure map) | not emitted (not reachable from the generation roots) | Out of scope — not generated |
| `ucp.json` business `supported_versions` | no (pure map) | not emitted | Out of scope — not generated |
| `common/identity_linking.json` `config.scopes` | no (pure map) | not emitted (capability config resolves to a generic record) | Out of scope — not generated |

`Signals` is the only `propertyNames` + named-`properties` object in the spec, so
the enforcement lands on it and its alias.

### Note on the `z.record` registries (honest residual, not "already safe")

The pure dict-map registries that *do* project — `UcpResponseSchema`
`capabilities` / `payment_handlers` / `services`, and `UcpSchema` `services` —
render as `z.record(z.string(), V)`, whose `z.string()` key schema does **not**
enforce the reverse-domain pattern:

```js
z.record(z.string(), z.any()).safeParse({ "bad KEY!": 1 }).success; // true
```

So in js-sdk these keys are currently unvalidated. This differs from python-sdk#66,
where the equivalent maps became `dict[ReverseDomainName, V]` and pydantic already
validates the keys — that reasoning does **not** carry over to zod. Enforcing
these needs a distinct mechanism (rewriting the `z.record` key schema to
`z.record(z.string().regex(<pattern>), V)`), not the object-scoped named-property
injector this PR extends. It is left as a scoped follow-up rather than folded in,
to keep this change focused; flagged here so it is not mistaken for already-safe.

`minProperties` (source: `shopping/types/description.json`,
`shopping/types/available_payment_instrument.json`) is a separate constraint
class with no `propertyNames` and is likewise left as a clean follow-up.

### Known boundary

zod-core silently drops an own `__proto__` key from every `z.object` (a
prototype-pollution safeguard) before `.catchall` / `.superRefine` run, so a
`{"__proto__": ...}` payload parses successfully with the key absent from the
output — dropped rather than rejected. The direction is safe: the key is not
preserved and the prototype is not polluted. This is an SDK-wide zod trait
(`.passthrough()` and `.catchall()` drop it identically), not specific to
Signals, so this PR pins the behavior with a test rather than special-casing one
schema with a raw-input wrapper. Every other pattern-violating own key —
including `constructor` and `prototype` — is rejected as normal; only the literal
`__proto__` is affected.

## Verification

- Failing test first, on the committed models: malformed extra key accepted
  (stripped), reverse-domain extra lost. Green after regeneration. Kill-test:
  neutralizing the injector's `propertyNames` path turns the new semantic tests
  red (4 of 5), the named-field test stays green.
- Rejects the malformed key; rejects the trailing-newline key (`"com.example.k\n"`,
  anchor safety); preserves the well-formed reverse-domain extra; the named
  fields still populate; the alias enforces the same.
- `npm test`: all green (48 tests).
- Regenerated from the pinned spec (`./generate_models.sh <ucp @ release/2026-04-08>`)
  and normalized with the repo's pinned prettier hook; the diff is limited to the
  `Signals` schema, and a second regeneration is byte-identical, so the
  model-drift job stays green.
- `npm run build` (cjs/esm/types) clean; full `pre-commit` on the changed files
  clean (prettier, codespell, whitespace, shebang/executable checks).

This is the js-sdk sibling of python-sdk#66 (the other SDK; prior art, not a
duplicate).
