### PR TITLE
fix: enforce minProperties in generated schemas

### DIFF
--- a/scripts/inject-schema-constraints.mjs
+++ b/scripts/inject-schema-constraints.mjs
@@ -394,13 +394,26 @@ function recordPropertyNames(node, properties, file) {
 }
 
 function recordMinProperties(node, properties) {
-  if (node.minProperties === undefined) {
+  let minProperties = node.minProperties;
+  let additionalProperties = node.additionalProperties;
+  if (minProperties === undefined && Array.isArray(node.allOf)) {
+    for (const sub of node.allOf) {
+      if (sub && typeof sub === "object" && sub.minProperties !== undefined) {
+        minProperties = sub.minProperties;
+        if (additionalProperties === undefined) {
+          additionalProperties = sub.additionalProperties;
+        }
+        break;
+      }
+    }
+  }
+  if (minProperties === undefined) {
     return;
   }
   const setKey = Object.keys(properties).sort().join(",");
   const descriptor = {
-    minimum: node.minProperties,
-    retainAdditionalProperties: node.additionalProperties !== false,
+    minimum: minProperties,
+    retainAdditionalProperties: additionalProperties !== false,
   };
   const signature = JSON.stringify(descriptor);
   if (!minPropertiesIndex.has(setKey)) {
@@ -764,7 +777,11 @@ function objectAlreadyConstrained(objectCall) {
   const parent = objectCall.parent;
   if (parent && ts.isPropertyAccessExpression(parent)) {
     const method = parent.name.text;
-    if (method === "catchall" || method === "superRefine") {
+    if (
+      method === "catchall" ||
+      method === "superRefine" ||
+      method === "refine"
+    ) {
       return true;
     }
   }

--- a/scripts/inject-schema-constraints.mjs
+++ b/scripts/inject-schema-constraints.mjs
@@ -123,6 +123,7 @@ const CONSTRAINT_KEYS = [
   "minItems",
   "maxItems",
   "uniqueItems",
+  "minProperties",
 ];
 
 /** Effective value constraints for a schema node, following $ref + allOf. */
@@ -306,6 +307,8 @@ function describeConstraint(propertyNode, file) {
   if (eff.minItems !== undefined) descriptor.minItems = eff.minItems;
   if (eff.maxItems !== undefined) descriptor.maxItems = eff.maxItems;
   if (eff.uniqueItems === true) descriptor.uniqueItems = true;
+  if (eff.minProperties !== undefined)
+    descriptor.minProperties = eff.minProperties;
   const containsGroups = collectContainsGroups(propertyNode, file);
   if (containsGroups.length) descriptor.containsGroups = containsGroups;
   const signature = JSON.stringify(descriptor);
@@ -326,6 +329,12 @@ const constraintIndex = new Map();
 // registries) render as `z.record` and are intentionally not handled here; they
 // need a distinct record-key mechanism. setKey -> Map(signature -> descriptor).
 const propertyNamesIndex = new Map();
+
+// Object-level `minProperties`, keyed by the generated object's sorted named
+// property set. The descriptor also records whether unknown properties must be
+// retained before counting, matching JSON Schema's default extra-key behavior.
+// setKey -> Map(signature -> descriptor).
+const minPropertiesIndex = new Map();
 
 function recordObject(properties, file) {
   const setKey = Object.keys(properties).sort().join(",");
@@ -384,6 +393,22 @@ function recordPropertyNames(node, properties, file) {
   propertyNamesIndex.get(setKey).set(signature, descriptor);
 }
 
+function recordMinProperties(node, properties) {
+  if (node.minProperties === undefined) {
+    return;
+  }
+  const setKey = Object.keys(properties).sort().join(",");
+  const descriptor = {
+    minimum: node.minProperties,
+    retainAdditionalProperties: node.additionalProperties !== false,
+  };
+  const signature = JSON.stringify(descriptor);
+  if (!minPropertiesIndex.has(setKey)) {
+    minPropertiesIndex.set(setKey, new Map());
+  }
+  minPropertiesIndex.get(setKey).set(signature, descriptor);
+}
+
 function walkSchema(node, file, seen = new Set(), depth = 0) {
   if (!node || typeof node !== "object" || depth > 64) {
     return;
@@ -402,6 +427,7 @@ function walkSchema(node, file, seen = new Set(), depth = 0) {
   if (resolvedObject) {
     recordObject(resolvedObject.properties, resolvedObject.file);
     recordPropertyNames(node, resolvedObject.properties, file);
+    recordMinProperties(node, resolvedObject.properties);
   }
   if (node.properties && typeof node.properties === "object") {
     for (const child of Object.values(node.properties)) {
@@ -476,6 +502,15 @@ for (const [setKey, bySignature] of propertyNamesIndex) {
     resolvedPropertyNames.set(setKey, [...bySignature.values()][0]);
   } else {
     ambiguous.push({ setKey, name: "<propertyNames>", count: bySignature.size });
+  }
+}
+
+const resolvedMinProperties = new Map();
+for (const [setKey, bySignature] of minPropertiesIndex) {
+  if (bySignature.size === 1) {
+    resolvedMinProperties.set(setKey, [...bySignature.values()][0]);
+  } else {
+    ambiguous.push({ setKey, name: "<minProperties>", count: bySignature.size });
   }
 }
 
@@ -571,6 +606,14 @@ function renderPropertyNamesRefine(pattern) {
   );
 }
 
+function renderMinPropertiesRefine(minimum, retainAdditionalProperties) {
+  return (
+    (retainAdditionalProperties ? `.catchall(z.any())` : "") +
+    `.refine((value) => Object.keys(value).length >= ${minimum}, ` +
+    `{ message: "Object must contain at least ${minimum} property(ies) (minProperties)" })`
+  );
+}
+
 /**
  * Zod methods for a descriptor given the generated field's base kind.
  * Returns null when the base kind is incompatible with the constraint
@@ -593,6 +636,8 @@ function methodsFor(descriptor, baseKind) {
     descriptor.maxItems !== undefined ||
     descriptor.uniqueItems !== undefined ||
     descriptor.containsGroups !== undefined;
+
+  const isRecord = descriptor.minProperties !== undefined;
 
   if (isNumeric) {
     if (baseKind !== "number") return null;
@@ -620,6 +665,11 @@ function methodsFor(descriptor, baseKind) {
     }
     if (descriptor.pattern !== undefined)
       methods.push(`.regex(${toRegexLiteral(descriptor.pattern)})`);
+  } else if (isRecord) {
+    if (baseKind !== "record") return null;
+    methods.push(
+      renderMinPropertiesRefine(descriptor.minProperties, false)
+    );
   } else if (isArray) {
     if (baseKind !== "array") return null;
     if (descriptor.minItems !== undefined)
@@ -671,6 +721,7 @@ function findBaseCall(expression, sourceFile) {
   if (method === "number") kind = "number";
   else if (method === "string") kind = "string";
   else if (method === "array") kind = "array";
+  else if (method === "record") kind = "record";
   else return null;
   return { end: baseCall.getEnd(), kind, baseCall };
 }
@@ -736,6 +787,7 @@ const report = {
   objectsMatched: 0,
   fieldsInjected: 0,
   propertyNamesInjected: 0,
+  minPropertiesInjected: 0,
   fieldsSkippedType: 0,
   fieldsAlreadyDone: 0,
   injections: [],
@@ -763,7 +815,8 @@ function handleObjectLiteral(objectLiteral) {
   const setKey = [...names].sort().join(",");
   const resolvedProperties = resolvedIndex.get(setKey);
   const propertyNamesDescriptor = resolvedPropertyNames.get(setKey);
-  if (!resolvedProperties && !propertyNamesDescriptor) {
+  const minPropertiesDescriptor = resolvedMinProperties.get(setKey);
+  if (!resolvedProperties && !propertyNamesDescriptor && !minPropertiesDescriptor) {
     return;
   }
   let matchedAny = false;
@@ -821,6 +874,26 @@ function handleObjectLiteral(objectLiteral) {
       matchedAny = true;
     }
   }
+  if (minPropertiesDescriptor) {
+    const objectCall = objectLiteral.parent;
+    if (
+      objectCall &&
+      ts.isCallExpression(objectCall) &&
+      !objectAlreadyConstrained(objectCall)
+    ) {
+      const text = renderMinPropertiesRefine(
+        minPropertiesDescriptor.minimum,
+        minPropertiesDescriptor.retainAdditionalProperties
+      );
+      edits.push({ pos: objectCall.getEnd(), text });
+      report.minPropertiesInjected += 1;
+      report.injections.push(`${setKey} :: <minProperties> ${text}`);
+      matchedAny = true;
+    } else if (objectCall && objectAlreadyConstrained(objectCall)) {
+      report.fieldsAlreadyDone += 1;
+      matchedAny = true;
+    }
+  }
   if (matchedAny) {
     report.objectsMatched += 1;
   }
@@ -858,6 +931,7 @@ process.stdout.write(
   `inject-schema-constraints: ${report.fieldsInjected} field(s) constrained ` +
     `across ${report.objectsMatched} object schema(s); ` +
     `${report.propertyNamesInjected} propertyNames key-check(s); ` +
+    `${report.minPropertiesInjected} object minProperties check(s); ` +
     `${report.fieldsAlreadyDone} already constrained; ` +
     `${report.fieldsSkippedType} skipped (base-type mismatch).\n`
 );

--- a/src/spec_generated.ts
+++ b/src/spec_generated.ts
@@ -88,7 +88,12 @@ export const MethodTypeSchema = z.enum(["pickup", "shipping"]);
 export type MethodType = z.infer<typeof MethodTypeSchema>;
 
 export const AvailablePaymentInstrumentSchema = z.object({
-  constraints: z.record(z.string(), z.any()).optional(),
+  constraints: z
+    .record(z.string(), z.any())
+    .refine((value) => Object.keys(value).length >= 1, {
+      message: "Object must contain at least 1 property(ies) (minProperties)",
+    })
+    .optional(),
   type: z.string(),
 });
 export type AvailablePaymentInstrument = z.infer<
@@ -447,11 +452,16 @@ export const CategorySchema = z.object({
 });
 export type Category = z.infer<typeof CategorySchema>;
 
-export const DescriptionSchema = z.object({
-  html: z.string().optional(),
-  markdown: z.string().optional(),
-  plain: z.string().optional(),
-});
+export const DescriptionSchema = z
+  .object({
+    html: z.string().optional(),
+    markdown: z.string().optional(),
+    plain: z.string().optional(),
+  })
+  .catchall(z.any())
+  .refine((value) => Object.keys(value).length >= 1, {
+    message: "Object must contain at least 1 property(ies) (minProperties)",
+  });
 export type Description = z.infer<typeof DescriptionSchema>;
 
 export const PriceSchema = z.object({

--- a/tests/spec-constraints.test.js
+++ b/tests/spec-constraints.test.js
@@ -26,6 +26,8 @@ const {
   TotalResponseSchema,
   MediaSchema,
   ProductOptionSchema,
+  AvailablePaymentInstrumentSchema,
+  DescriptionSchema,
 } = require("./.dist/spec_generated.js");
 
 const accepts = (schema, value) => schema.safeParse(value).success === true;
@@ -108,4 +110,28 @@ test("ProductOptionSchema accepts a non-empty values array", () => {
   assert.ok(
     accepts(ProductOptionSchema, { name: "size", values: [{ label: "S" }] })
   );
+});
+
+test("AvailablePaymentInstrumentSchema enforces constraints minProperties", () => {
+  assert.ok(
+    rejects(AvailablePaymentInstrumentSchema, {
+      type: "card",
+      constraints: {},
+    })
+  );
+  assert.ok(
+    accepts(AvailablePaymentInstrumentSchema, {
+      type: "card",
+      constraints: { network: "visa" },
+    })
+  );
+  assert.ok(accepts(AvailablePaymentInstrumentSchema, { type: "card" }));
+});
+
+test("DescriptionSchema enforces minProperties and retains additional properties", () => {
+  assert.ok(rejects(DescriptionSchema, {}));
+  assert.ok(accepts(DescriptionSchema, { plain: "Description" }));
+  assert.deepEqual(DescriptionSchema.parse({ other: "Description" }), {
+    other: "Description",
+  });
 });


### PR DESCRIPTION
## Description

`inject-schema-constraints.mjs` restores JSON Schema constraints that quicktype's
`typescript-zod` target omits, but it did not handle `minProperties`. The pinned
UCP schema contains two affected shapes:

```json
// common/types/description.json
{
  "properties": { "plain": {}, "html": {}, "markdown": {} },
  "minProperties": 1
}

// shopping/types/available_payment_instrument.json
{
  "constraints": {
    "type": "object",
    "additionalProperties": true,
    "minProperties": 1
  }
}
```

The generated schemas therefore accepted both an empty `Description` and an
empty, present `constraints` record:

```ts
DescriptionSchema.parse({});
AvailablePaymentInstrumentSchema.parse({ type: "card", constraints: {} });
```

**Fix:** index object-level and record-level `minProperties` constraints and
append a Zod refinement during generation. Object schemas retain additional
properties before counting them, matching JSON Schema's default behavior.
Regression tests cover rejection of empty objects, acceptance of non-empty
objects, optional `constraints`, and retention of additional description keys.

## Category (Required)

- [ ] **Core Protocol**: Changes to the base communication layer, global context, or breaking refactors. (Requires Technical Council approval)
- [ ] **Governance/Contributing**: Updates to GOVERNANCE.md, CONTRIBUTING.md, or CODEOWNERS. (Requires Governance Council approval)
- [ ] **Capability**: New schemas (Discovery, Cart, etc.) or extensions. (Requires Maintainer approval)
- [ ] **Documentation**: Updates to README, or documentations regarding schema or capabilities. (Requires Maintainer approval)
- [ ] **Infrastructure**: CI/CD, Linters, or build scripts. (Requires DevOps Maintainer approval)
- [ ] **Maintenance**: Version bumps, lockfile updates, or minor bug fixes. (Requires DevOps Maintainer approval)
- [x] **SDK**: Language-specific SDK updates and releases. (Requires DevOps Maintainer approval)
- [ ] **Samples / Conformance**: Maintaining samples and the conformance suite. (Requires Maintainer approval)
- [ ] **UCP Schema**: Changes to the `ucp-schema` tool (resolver, linter, validator). (Requires Maintainer approval)
- [ ] **Community Health (.github)**: Updates to templates, workflows, or org-level configs. (Requires DevOps Maintainer approval)

## Related Issues

N/A

## Checklist

- [x] I have followed the [Contributing Guide](https://github.com/Universal-Commerce-Protocol/.github/blob/main/CONTRIBUTING.md) (including Conventional Commits title requirements and `!` for breaking changes).
- [x] I have updated the documentation (if applicable).
- [x] My changes pass all local linting and formatting checks.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] (For Core/Capability) I have included/updated the relevant JSON schemas.
- [ ] I have regenerated Python Pydantic models by running generate_models.sh under python_sdk.

## Screenshots / Logs (if applicable)

- `npm test` — 50 tests passed
- `npm run build:noEmit` — passed
- `npm run build` — passed
- `pre-commit run --all-files` — passed
- Regeneration from pinned UCP `release/2026-04-08` produced the committed `src/spec_generated.ts` byte-for-byte after formatting.
