### PR TITLE
fix: enforce propertyNames on generated records

### DIFF
--- a/scripts/inject-schema-constraints.mjs
+++ b/scripts/inject-schema-constraints.mjs
@@ -309,6 +309,12 @@ function describeConstraint(propertyNode, file) {
   if (eff.uniqueItems === true) descriptor.uniqueItems = true;
   if (eff.minProperties !== undefined)
     descriptor.minProperties = eff.minProperties;
+  const propertyNamesPattern = resolvePropertyNamesPattern(
+    propertyNode.propertyNames,
+    file
+  );
+  if (propertyNamesPattern !== null)
+    descriptor.propertyNamesPattern = propertyNamesPattern;
   const containsGroups = collectContainsGroups(propertyNode, file);
   if (containsGroups.length) descriptor.containsGroups = containsGroups;
   const signature = JSON.stringify(descriptor);
@@ -619,6 +625,13 @@ function renderPropertyNamesRefine(pattern) {
   );
 }
 
+function renderRecordKeyPattern(pattern) {
+  return (
+    `.refine((value) => Object.keys(value).every((key) => ${toRegexLiteral(pattern)}.test(key)), ` +
+    `{ message: "Record keys must match the required pattern (propertyNames)" })`
+  );
+}
+
 function renderMinPropertiesRefine(minimum, retainAdditionalProperties) {
   return (
     (retainAdditionalProperties ? `.catchall(z.any())` : "") +
@@ -649,8 +662,9 @@ function methodsFor(descriptor, baseKind) {
     descriptor.maxItems !== undefined ||
     descriptor.uniqueItems !== undefined ||
     descriptor.containsGroups !== undefined;
-
-  const isRecord = descriptor.minProperties !== undefined;
+  const isRecord =
+    descriptor.minProperties !== undefined ||
+    descriptor.propertyNamesPattern !== undefined;
 
   if (isNumeric) {
     if (baseKind !== "number") return null;
@@ -680,9 +694,14 @@ function methodsFor(descriptor, baseKind) {
       methods.push(`.regex(${toRegexLiteral(descriptor.pattern)})`);
   } else if (isRecord) {
     if (baseKind !== "record") return null;
-    methods.push(
-      renderMinPropertiesRefine(descriptor.minProperties, false)
-    );
+    if (descriptor.minProperties !== undefined) {
+      methods.push(
+        renderMinPropertiesRefine(descriptor.minProperties, false)
+      );
+    }
+    if (descriptor.propertyNamesPattern !== undefined) {
+      methods.push(renderRecordKeyPattern(descriptor.propertyNamesPattern));
+    }
   } else if (isArray) {
     if (baseKind !== "array") return null;
     if (descriptor.minItems !== undefined)

--- a/src/spec_generated.ts
+++ b/src/spec_generated.ts
@@ -646,11 +646,34 @@ export type TotalsResponse = z.infer<typeof TotalsResponseSchema>;
 export const UcpResponseSchema = z.object({
   capabilities: z
     .record(z.string(), z.array(CapabilityResponseSchema))
+    .refine(
+      (value) =>
+        Object.keys(value).every((key) =>
+          /^[a-z][a-z0-9]*(?:\.[a-z][a-z0-9_]*)+$/.test(key)
+        ),
+      { message: "Record keys must match the required pattern (propertyNames)" }
+    )
     .optional(),
   payment_handlers: z
     .record(z.string(), z.array(PaymentHandlerResponseSchema))
+    .refine(
+      (value) =>
+        Object.keys(value).every((key) =>
+          /^[a-z][a-z0-9]*(?:\.[a-z][a-z0-9_]*)+$/.test(key)
+        ),
+      { message: "Record keys must match the required pattern (propertyNames)" }
+    )
     .optional(),
-  services: z.record(z.string(), z.array(ServiceResponseSchema)).optional(),
+  services: z
+    .record(z.string(), z.array(ServiceResponseSchema))
+    .refine(
+      (value) =>
+        Object.keys(value).every((key) =>
+          /^[a-z][a-z0-9]*(?:\.[a-z][a-z0-9_]*)+$/.test(key)
+        ),
+      { message: "Record keys must match the required pattern (propertyNames)" }
+    )
+    .optional(),
   status: UcpResponseStatusSchema.optional(),
   version: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
 });

--- a/tests/response-payment-handlers.test.js
+++ b/tests/response-payment-handlers.test.js
@@ -244,6 +244,32 @@ test("envelope rejects a service missing the required transport / version", () =
   );
 });
 
+test("envelope rejects malformed registry keys", () => {
+  for (const [registry, value] of [
+    ["capabilities", [{ version: "2026-04-08" }]],
+    ["payment_handlers", [{ id: "h", version: "2026-04-08" }]],
+    ["services", [serviceEntry]],
+  ]) {
+    assert.ok(
+      rejects(UcpResponseSchema, {
+        version: "2026-04-08",
+        [registry]: { "bad KEY!": value },
+      }),
+      `${registry} must reject keys outside the reverse-domain pattern`
+    );
+  }
+});
+
+test("envelope accepts reverse-domain registry keys", () => {
+  assert.ok(accepts(UcpResponseSchema, goldenCheckoutEnvelope));
+  assert.ok(
+    accepts(UcpResponseSchema, {
+      version: "2026-04-08",
+      services: { "com.example.service": [serviceEntry] },
+    })
+  );
+});
+
 // --- status: modeled and retained (base enum success/error) -----------------
 
 test("envelope RETAINS status (was stripped); accepts success/error, rejects other", () => {


### PR DESCRIPTION
## Description

The UCP response envelope declares `propertyNames` for its `capabilities`,
`payment_handlers`, and `services` registries:

```json
{
  "type": "object",
  "propertyNames": { "$ref": "common/types/reverse_domain_name.json" },
  "additionalProperties": { "...": "..." }
}
```

quicktype emitted each registry as `z.record(z.string(), valueSchema)`, so keys
outside the required reverse-domain pattern were accepted:

```ts
UcpResponseSchema.parse({
  version: "2026-04-08",
  services: { "bad KEY!": [{ transport: "rest", version: "2026-04-08" }] },
});
```

**Fix:** read `propertyNames.pattern` from record-valued properties and append a
Zod refinement that validates every record key. The pattern comes from the
source schema through the existing `$ref` resolver rather than a copied literal.
Regression tests cover all three registries and keep valid reverse-domain keys
accepted.

## Category (Required)

- [ ] **Core Protocol**: Changes to the base communication layer, global context, or breaking refactors. (Requires Technical Council approval)
- [ ] **Governance/Contributing**: Updates to GOVERNANCE.md, CONTRIBUTING.md, or CODEOWNERS. (Requires Governance Council approval)
- [ ] **Capability**: New schemas (Discovery, Cart, etc.) or extensions. (Requires Maintainer approval)
- [ ] **Documentation**: Updates to README, or documentations regarding schema or capabilities. (Requires Maintainer approval)
- [ ] **Infrastructure**: CI/CD, Linters, or build scripts. (Requires DevOps Maintainer approval)
- [ ] **Maintenance**: Version bumps, lockfile updates, or minor bug fixes. (Requires DevOps Maintainer approval)
- [x] **SDK**: Language-specific SDK updates and releases. (Requires DevOps Maintainer approval)
- [ ] **Samples / Conformance**: Maintaining samples and the conformance suite. (Requires Maintainer approval)
- [ ] **UCP Schema**: Changes to the `ucp-schema` tool (resolver, linter, validator). (Requires Maintainer approval)
- [ ] **Community Health (.github)**: Updates to templates, workflows, or org-level configs. (Requires DevOps Maintainer approval)

## Related Issues

N/A

## Checklist

- [x] I have followed the [Contributing Guide](https://github.com/Universal-Commerce-Protocol/.github/blob/main/CONTRIBUTING.md) (including Conventional Commits title requirements and `!` for breaking changes).
- [x] I have updated the documentation (if applicable).
- [x] My changes pass all local linting and formatting checks.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] (For Core/Capability) I have included/updated the relevant JSON schemas.
- [ ] I have regenerated Python Pydantic models by running generate_models.sh under python_sdk.

## Screenshots / Logs (if applicable)

- `npm test` — 50 tests passed
- `npm run build:noEmit` — passed
- `npm run build` — passed
- `pre-commit run --all-files` — passed
- Regeneration from pinned UCP `release/2026-04-08` produced the committed `src/spec_generated.ts` byte-for-byte after formatting.
