### PR TITLE
fix: enforce the uri string format in generated schemas

### DIFF
--- a/scripts/inject-schema-constraints.mjs
+++ b/scripts/inject-schema-constraints.mjs
@@ -124,7 +124,21 @@ const CONSTRAINT_KEYS = [
   "maxItems",
   "uniqueItems",
   "minProperties",
+  "format",
 ];
+
+/**
+ * JSON Schema `format` values with a direct zod string refinement.
+ *
+ * Deliberately partial. `date-time` is absent because quicktype already emits
+ * `z.coerce.date()` for it, so the base is not a string. `uri-reference` is
+ * absent because a relative reference is not a URL and `.url()` would reject
+ * valid values. An unlisted format contributes no constraint rather than a
+ * wrong one.
+ */
+const STRING_FORMAT_METHODS = {
+  uri: ".url()",
+};
 
 /** Effective value constraints for a schema node, following $ref + allOf. */
 function effectiveConstraints(node, file, seen = new Set(), depth = 0) {
@@ -304,6 +318,10 @@ function describeConstraint(propertyNode, file) {
   if (eff.minLength !== undefined) descriptor.minLength = eff.minLength;
   if (eff.maxLength !== undefined) descriptor.maxLength = eff.maxLength;
   if (eff.pattern !== undefined) descriptor.pattern = eff.pattern;
+  // Only a format this generator can express is carried; anything else is
+  // dropped here so it can never reach methodsFor or alter a signature.
+  if (STRING_FORMAT_METHODS[eff.format] !== undefined)
+    descriptor.format = eff.format;
   if (eff.minItems !== undefined) descriptor.minItems = eff.minItems;
   if (eff.maxItems !== undefined) descriptor.maxItems = eff.maxItems;
   if (eff.uniqueItems === true) descriptor.uniqueItems = true;
@@ -854,7 +872,8 @@ function methodsFor(descriptor, baseKind) {
   const isString =
     descriptor.minLength !== undefined ||
     descriptor.maxLength !== undefined ||
-    descriptor.pattern !== undefined;
+    descriptor.pattern !== undefined ||
+    descriptor.format !== undefined;
   const isArray =
     descriptor.minItems !== undefined ||
     descriptor.maxItems !== undefined ||
@@ -890,6 +909,8 @@ function methodsFor(descriptor, baseKind) {
     }
     if (descriptor.pattern !== undefined)
       methods.push(`.regex(${toRegexLiteral(descriptor.pattern)})`);
+    if (descriptor.format !== undefined)
+      methods.push(STRING_FORMAT_METHODS[descriptor.format]);
   } else if (isRecord) {
     if (baseKind !== "record") return null;
     if (descriptor.minProperties !== undefined) {
@@ -977,6 +998,11 @@ function alreadyConstrained(baseCall) {
       "regex",
       "refine",
       "superRefine",
+      // Derived so a new entry in STRING_FORMAT_METHODS cannot reintroduce
+      // double injection: ".url()" -> "url".
+      ...Object.values(STRING_FORMAT_METHODS).map((method) =>
+        method.replace(/^\.|\(\)$/g, "")
+      ),
     ]);
     if (CONSTRAINT_METHODS.has(method)) {
       return true;

--- a/src/spec_generated.ts
+++ b/src/spec_generated.ts
@@ -226,7 +226,7 @@ export type LookupRequestSignals = CheckoutCreateRequestSignals;
 
 export const ItemResponseSchema = z.object({
   id: z.string(),
-  image_url: z.string().optional(),
+  image_url: z.string().url().optional(),
   price: z.number().int().gte(0),
   title: z.string(),
 });
@@ -297,7 +297,7 @@ export type TotalResponse = z.infer<typeof TotalResponseSchema>;
 export const LinkSchema = z.object({
   title: z.string().optional(),
   type: z.string(),
-  url: z.string(),
+  url: z.string().url(),
 });
 export type Link = z.infer<typeof LinkSchema>;
 
@@ -321,7 +321,7 @@ export type LookupResponseMessage = CheckoutResponseMessage;
 export const OrderConfirmationSchema = z.object({
   id: z.string(),
   label: z.string().optional(),
-  permalink_url: z.string(),
+  permalink_url: z.string().url(),
 });
 export type OrderConfirmation = z.infer<typeof OrderConfirmationSchema>;
 
@@ -335,18 +335,18 @@ export const CapabilityResponseSchema = z.object({
   config: z.record(z.string(), z.any()).optional(),
   extends: z.union([z.array(z.string()), z.string()]).optional(),
   id: z.string().optional(),
-  schema: z.string().optional(),
-  spec: z.string().optional(),
+  schema: z.string().url().optional(),
+  spec: z.string().url().optional(),
   version: z.string(),
 });
 export type CapabilityResponse = z.infer<typeof CapabilityResponseSchema>;
 
 export const ServiceResponseSchema = z.object({
   config: z.record(z.string(), z.any()).optional(),
-  endpoint: z.string().optional(),
+  endpoint: z.string().url().optional(),
   id: z.string().optional(),
-  schema: z.string().optional(),
-  spec: z.string().optional(),
+  schema: z.string().url().optional(),
+  spec: z.string().url().optional(),
   transport: TransportSchema,
   version: z.string(),
 });
@@ -529,7 +529,7 @@ export const MediaSchema = z.object({
   alt_text: z.string().optional(),
   height: z.number().int().gte(1).optional(),
   type: z.string(),
-  url: z.string(),
+  url: z.string().url(),
   width: z.number().int().gte(1).optional(),
 });
 export type Media = z.infer<typeof MediaSchema>;
@@ -667,8 +667,8 @@ export const PaymentHandlerResponseSchema = z.object({
     .optional(),
   config: z.record(z.string(), z.any()).optional(),
   id: z.string(),
-  schema: z.string().optional(),
-  spec: z.string().optional(),
+  schema: z.string().url().optional(),
+  spec: z.string().url().optional(),
   version: z.string(),
 });
 export type PaymentHandlerResponse = z.infer<
@@ -796,7 +796,7 @@ export const FulfillmentEventSchema = z.object({
   line_items: z.array(EventLineItemSchema),
   occurred_at: z.coerce.date(),
   tracking_number: z.string().optional(),
-  tracking_url: z.string().optional(),
+  tracking_url: z.string().url().optional(),
   type: z.string(),
 });
 export type FulfillmentEvent = z.infer<typeof FulfillmentEventSchema>;
@@ -837,7 +837,7 @@ export const CheckoutWithAp2MandateSchema = z.object({
   attribution: z.record(z.string(), z.string()).optional(),
   buyer: BuyerSchema.optional(),
   context: CheckoutCreateRequestContextSchema.optional(),
-  continue_url: z.string().optional(),
+  continue_url: z.string().url().optional(),
   currency: z.string(),
   expires_at: z.coerce.date().optional(),
   id: z.string(),
@@ -968,7 +968,7 @@ export const CartResponseSchema = z.object({
   attribution: z.record(z.string(), z.string()).optional(),
   buyer: BuyerSchema.optional(),
   context: CheckoutCreateRequestContextSchema.optional(),
-  continue_url: z.string().optional(),
+  continue_url: z.string().url().optional(),
   currency: z.string(),
   expires_at: z.coerce.date().optional(),
   id: z.string(),
@@ -1022,7 +1022,7 @@ export const CheckoutWithCartResponseSchema = z.object({
   attribution: z.record(z.string(), z.string()).optional(),
   buyer: BuyerSchema.optional(),
   context: CheckoutCreateRequestContextSchema.optional(),
-  continue_url: z.string().optional(),
+  continue_url: z.string().url().optional(),
   currency: z.string(),
   expires_at: z.coerce.date().optional(),
   id: z.string(),
@@ -1138,7 +1138,7 @@ export const CheckoutResponseSchema = z.object({
   attribution: z.record(z.string(), z.string()).optional(),
   buyer: BuyerSchema.optional(),
   context: CheckoutCreateRequestContextSchema.optional(),
-  continue_url: z.string().optional(),
+  continue_url: z.string().url().optional(),
   currency: z.string(),
   expires_at: z.coerce.date().optional(),
   id: z.string(),
@@ -1211,7 +1211,7 @@ export const CheckoutWithBuyerConsentResponseSchema = z.object({
   attribution: z.record(z.string(), z.string()).optional(),
   buyer: BuyerWithConsentResponseSchema.optional(),
   context: CheckoutCreateRequestContextSchema.optional(),
-  continue_url: z.string().optional(),
+  continue_url: z.string().url().optional(),
   currency: z.string(),
   expires_at: z.coerce.date().optional(),
   id: z.string(),
@@ -1353,7 +1353,7 @@ export const VariantSchema = z.object({
   tags: z.array(z.string()).optional(),
   title: z.string(),
   unit_price: FluffyUnitPriceSchema.optional(),
-  url: z.string().optional(),
+  url: z.string().url().optional(),
 });
 export type Variant = z.infer<typeof VariantSchema>;
 
@@ -1370,7 +1370,7 @@ export const SearchResponseProductSchema = z.object({
   rating: RatingSchema.optional(),
   tags: z.array(z.string()).optional(),
   title: z.string(),
-  url: z.string().optional(),
+  url: z.string().url().optional(),
   variants: z.array(VariantSchema).min(1),
 });
 export type SearchResponseProduct = z.infer<typeof SearchResponseProductSchema>;
@@ -1402,7 +1402,7 @@ export const OrderSchema = z.object({
   label: z.string().optional(),
   line_items: z.array(OrderLineItemSchema),
   messages: z.array(CheckoutResponseMessageSchema).optional(),
-  permalink_url: z.string(),
+  permalink_url: z.string().url(),
   totals: z.array(TotalsResponseSchema).superRefine((items, ctx) => {
     for (const rule of [
       { property: "type", value: "subtotal", min: 1, max: 1 },
@@ -1435,7 +1435,7 @@ export const CheckoutWithDiscountResponseSchema = z.object({
   attribution: z.record(z.string(), z.string()).optional(),
   buyer: BuyerSchema.optional(),
   context: CheckoutCreateRequestContextSchema.optional(),
-  continue_url: z.string().optional(),
+  continue_url: z.string().url().optional(),
   currency: z.string(),
   expires_at: z.coerce.date().optional(),
   id: z.string(),
@@ -1499,7 +1499,7 @@ export const CheckoutWithFulfillmentResponseSchema = z.object({
   attribution: z.record(z.string(), z.string()).optional(),
   buyer: BuyerSchema.optional(),
   context: CheckoutCreateRequestContextSchema.optional(),
-  continue_url: z.string().optional(),
+  continue_url: z.string().url().optional(),
   currency: z.string(),
   expires_at: z.coerce.date().optional(),
   id: z.string(),
@@ -1554,7 +1554,7 @@ export const LookupResponseProductSchema = z.object({
   rating: RatingSchema.optional(),
   tags: z.array(z.string()).optional(),
   title: z.string(),
-  url: z.string().optional(),
+  url: z.string().url().optional(),
   variants: z.array(CatalogLookupSchema).min(1),
 });
 export type LookupResponseProduct = z.infer<typeof LookupResponseProductSchema>;

--- a/tests/injector-idempotency.test.js
+++ b/tests/injector-idempotency.test.js
@@ -1,0 +1,76 @@
+// Copyright 2026 UCP Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+const { test } = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+const { execFileSync } = require("node:child_process");
+
+const SCRIPT = path.join(
+  __dirname,
+  "..",
+  "scripts",
+  "inject-schema-constraints.mjs"
+);
+
+// The injector documents itself as safe to re-run, and generate_models.sh is
+// not the only caller — the script advertises a standalone usage. Idempotency
+// rests on alreadyConstrained() recognising every method the injector emits,
+// so a new emit path that is not listed there silently double-applies.
+test("running the constraint injector twice leaves the file unchanged", () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "ucp-injector-"));
+  const schemaDir = path.join(dir, "schemas");
+  fs.mkdirSync(schemaDir);
+  fs.writeFileSync(
+    path.join(schemaDir, "media.json"),
+    JSON.stringify({
+      $id: "https://ucp.dev/schemas/media.json",
+      title: "Media",
+      type: "object",
+      properties: {
+        url: { type: "string", format: "uri" },
+        alt_text: { type: "string", minLength: 1 },
+      },
+      required: ["url"],
+    })
+  );
+
+  const target = path.join(dir, "spec_generated.ts");
+  fs.writeFileSync(
+    target,
+    'import * as z from "zod";\n' +
+      "\n" +
+      "export const MediaSchema = z.object({\n" +
+      "  url: z.string(),\n" +
+      "  alt_text: z.string().optional(),\n" +
+      "});\n"
+  );
+
+  execFileSync("node", [SCRIPT, schemaDir, target], { stdio: "pipe" });
+  const afterFirst = fs.readFileSync(target, "utf8");
+  assert.match(
+    afterFirst,
+    /url: z\.string\(\)\.url\(\)/,
+    "the first pass applies the uri format"
+  );
+
+  execFileSync("node", [SCRIPT, schemaDir, target], { stdio: "pipe" });
+  assert.equal(
+    fs.readFileSync(target, "utf8"),
+    afterFirst,
+    "a second pass must not re-apply an existing constraint"
+  );
+});

--- a/tests/spec-constraints.test.js
+++ b/tests/spec-constraints.test.js
@@ -29,6 +29,7 @@ const {
   ProductOptionSchema,
   AvailablePaymentInstrumentSchema,
   DescriptionSchema,
+  OrderConfirmationSchema,
 } = require("./.dist/spec_generated.js");
 
 const accepts = (schema, value) => schema.safeParse(value).success === true;
@@ -168,4 +169,26 @@ test("DescriptionSchema enforces minProperties and retains additional properties
   assert.deepEqual(DescriptionSchema.parse({ other: "Description" }), {
     other: "Description",
   });
+});
+
+test("MediaSchema rejects a url that is not a URL (format: uri)", () => {
+  assert.ok(rejects(MediaSchema, { type: "image", url: "not a url" }));
+  assert.ok(
+    rejects(MediaSchema, { type: "image", url: "cdn.example.com/1.png" })
+  );
+  assert.ok(
+    accepts(MediaSchema, { type: "image", url: "https://cdn.example/1.png" })
+  );
+});
+
+test("OrderConfirmationSchema rejects a non-URL permalink_url (format: uri)", () => {
+  assert.ok(
+    rejects(OrderConfirmationSchema, { id: "o_1", permalink_url: "/orders/1" })
+  );
+  assert.ok(
+    accepts(OrderConfirmationSchema, {
+      id: "o_1",
+      permalink_url: "https://shop.example/orders/1",
+    })
+  );
 });


### PR DESCRIPTION
## Summary

- Carry JSON Schema `format` through the constraint injector and emit `.url()`
  for `format: "uri"`.
- Add the emitted method to the idempotency check so re-running the injector
  cannot double-apply it, plus a regression test for that invariant.

## Motivation

The injector restores constraints quicktype drops, keyed off a `CONSTRAINT_KEYS`
allowlist. `format` was not on it, so every `format: "uri"` field generated a
bare `z.string()`:

```
OrderConfirmationSchema.parse({ id: "o_1", permalink_url: "/orders/1" })  // accepted
MediaSchema.parse({ type: "image", url: "cdn.example.com/1.png" })        // accepted
```

python-sdk already models the same fields as `AnyUrl` and rejects both, so the
two SDKs disagreed on 13 generated fields. This repo's own hand-written
`src/extensions.ts:43` also uses `z.string().url()` for `order.json`'s
`webhook_url` — the same `format: uri` declaration — so the mapping is already
the house convention.

`.url()` and pydantic's `AnyUrl` were compared over 39 inputs and **agree on
every one**, including `mailto:`, `urn:`, `tel:`, `data:`, `ftp://`, and IRIs
such as `https://例え.jp/商品/1` (all accepted), and relative references such as
`/orders/1` and `img/1.png` (all rejected). Rejecting relative references is
what `format: uri` means, so no spec-valid value becomes invalid.

## Scope

`STRING_FORMAT_METHODS` is deliberately partial and filtered in
`describeConstraint`, so an unmappable format contributes nothing rather than
something wrong: `date-time` is excluded because quicktype already emits
`z.coerce.date()`, and `uri-reference` because a relative reference is not a URL.
Verified by generating against a synthetic schema for both.

Types are unchanged (`z.infer` is still `string`); only runtime validation
tightens, matching #40–#43 which all shipped as `fix:`.

**Known gaps left open**, both pre-existing structural limits of property-set
matching rather than something this change introduces:

- `message_warning.json`'s `image_url` / `url` stay unvalidated. Their generated
  object carries an extra `severity` from the flattened `message.json` `oneOf`,
  so the property set never matches. python-sdk does enforce these.
- The synthesized `discovery/*.json` inputs carry no `format`, so
  `A2ASchema.endpoint` stays bare while its `schemas/`-derived twin
  `ServiceResponseSchema.endpoint` now validates.

Happy to file both as follow-ups.

## Validation

`npm test` 59 passed / 0 failed. `npm run build:noEmit` exit 0.
`prettier --check` clean.

Regeneration reproduces byte-for-byte against `release/2026-04-08` both before
and after, and the artifact diff is 23 lines, all `z.string()` → `z.string().url()`,
with no other change. Running the injector a second time reports
`0 field(s) constrained; 74 already constrained` and leaves the file unchanged.

Each new test fails against the pre-change artifact and passes after; the
idempotency test fails if the `alreadyConstrained` entry is removed.
