### PR TITLE
fix: enforce display_text on custom total types

### DIFF
--- a/scripts/inject-schema-constraints.mjs
+++ b/scripts/inject-schema-constraints.mjs
@@ -471,7 +471,7 @@ function describeConditionalRule(branch, properties) {
     !Array.isArray(condition.required) ||
     condition.required.length !== 1 ||
     condition.required[0] !== discriminator ||
-    !rawDiscriminatorNode ||
+    rawDiscriminatorNode == null ||
     typeof rawDiscriminatorNode !== "object"
   ) {
     return null;
@@ -483,7 +483,7 @@ function describeConditionalRule(branch, properties) {
   let discriminatorNode = rawDiscriminatorNode;
   if (
     Object.keys(rawDiscriminatorNode).length === 1 &&
-    rawDiscriminatorNode.not &&
+    rawDiscriminatorNode.not != null &&
     typeof rawDiscriminatorNode.not === "object" &&
     !Array.isArray(rawDiscriminatorNode.not)
   ) {
@@ -838,9 +838,10 @@ function renderConditionalRefine(rules) {
     `.superRefine((value, ctx) => {` +
     `for (const rule of ${JSON.stringify(normalized)}) {` +
     `const record = value as Record<string, unknown>;` +
-    `if (rule.negated ` +
-    `? rule.values.includes(record[rule.discriminator] as never) ` +
-    `: !rule.values.includes(record[rule.discriminator] as never)) continue;` +
+    `const discriminatorVal = record[rule.discriminator];` +
+    `if (discriminatorVal === undefined) continue;` +
+    `const matches = (rule.values as readonly unknown[]).includes(discriminatorVal);` +
+    `if (rule.negated ? matches : !matches) continue;` +
     `if (rule.kind === "required") {` +
     `for (const field of rule.required) {` +
     `if (!(field in record)) ctx.addIssue({ code: z.ZodIssueCode.custom, ` +

--- a/scripts/inject-schema-constraints.mjs
+++ b/scripts/inject-schema-constraints.mjs
@@ -466,13 +466,31 @@ function describeConditionalRule(branch, properties) {
   if (conditionEntries.length !== 1) {
     return null;
   }
-  const [discriminator, discriminatorNode] = conditionEntries[0];
+  const [discriminator, rawDiscriminatorNode] = conditionEntries[0];
   if (
     !Array.isArray(condition.required) ||
     condition.required.length !== 1 ||
     condition.required[0] !== discriminator ||
-    !discriminatorNode ||
-    typeof discriminatorNode !== "object" ||
+    !rawDiscriminatorNode ||
+    typeof rawDiscriminatorNode !== "object"
+  ) {
+    return null;
+  }
+  // A `not` wrapper negates the match: the rule fires for every discriminator
+  // value EXCEPT the wrapped set (e.g. `type: { not: { enum: [...] } }` ->
+  // custom total types, which the schema requires to carry display_text).
+  let negated = false;
+  let discriminatorNode = rawDiscriminatorNode;
+  if (
+    Object.keys(rawDiscriminatorNode).length === 1 &&
+    rawDiscriminatorNode.not &&
+    typeof rawDiscriminatorNode.not === "object" &&
+    !Array.isArray(rawDiscriminatorNode.not)
+  ) {
+    negated = true;
+    discriminatorNode = rawDiscriminatorNode.not;
+  }
+  if (
     Object.keys(discriminatorNode).some(
       (key) => key !== "const" && key !== "enum"
     )
@@ -514,6 +532,7 @@ function describeConditionalRule(branch, properties) {
       kind: "required",
       discriminator,
       values,
+      negated,
       required: [...consequence.required].sort(),
     };
   }
@@ -533,7 +552,7 @@ function describeConditionalRule(branch, properties) {
   if (!bounds || Object.keys(targetNode).some((key) => !(key in bounds))) {
     return null;
   }
-  return { kind: "numeric", discriminator, values, target, ...bounds };
+  return { kind: "numeric", discriminator, values, negated, target, ...bounds };
 }
 
 function recordConditionalRules(node, properties) {
@@ -807,6 +826,7 @@ function renderConditionalRefine(rules) {
     kind: rule.kind,
     discriminator: rule.discriminator,
     values: rule.values,
+    negated: rule.negated ?? false,
     required: rule.required ?? [],
     target: rule.target ?? null,
     minimum: rule.minimum ?? null,
@@ -818,7 +838,9 @@ function renderConditionalRefine(rules) {
     `.superRefine((value, ctx) => {` +
     `for (const rule of ${JSON.stringify(normalized)}) {` +
     `const record = value as Record<string, unknown>;` +
-    `if (!rule.values.includes(record[rule.discriminator] as never)) continue;` +
+    `if (rule.negated ` +
+    `? rule.values.includes(record[rule.discriminator] as never) ` +
+    `: !rule.values.includes(record[rule.discriminator] as never)) continue;` +
     `if (rule.kind === "required") {` +
     `for (const field of rule.required) {` +
     `if (!(field in record)) ctx.addIssue({ code: z.ZodIssueCode.custom, ` +

--- a/src/spec_generated.ts
+++ b/src/spec_generated.ts
@@ -244,6 +244,7 @@ export const TotalResponseSchema = z
         kind: "numeric",
         discriminator: "type",
         values: ["discount", "items_discount"],
+        negated: false,
         required: [],
         target: "amount",
         minimum: null,
@@ -255,6 +256,7 @@ export const TotalResponseSchema = z
         kind: "numeric",
         discriminator: "type",
         values: ["subtotal", "fulfillment", "tax", "fee"],
+        negated: false,
         required: [],
         target: "amount",
         minimum: 0,
@@ -264,7 +266,12 @@ export const TotalResponseSchema = z
       },
     ]) {
       const record = value as Record<string, unknown>;
-      if (!rule.values.includes(record[rule.discriminator] as never)) continue;
+      if (
+        rule.negated
+          ? rule.values.includes(record[rule.discriminator] as never)
+          : !rule.values.includes(record[rule.discriminator] as never)
+      )
+        continue;
       if (rule.kind === "required") {
         for (const field of rule.required) {
           if (!(field in record))
@@ -619,6 +626,7 @@ export const SearchResponsePaginationSchema = z
         kind: "required",
         discriminator: "has_next_page",
         values: [true],
+        negated: false,
         required: ["cursor"],
         target: null,
         minimum: null,
@@ -628,7 +636,12 @@ export const SearchResponsePaginationSchema = z
       },
     ]) {
       const record = value as Record<string, unknown>;
-      if (!rule.values.includes(record[rule.discriminator] as never)) continue;
+      if (
+        rule.negated
+          ? rule.values.includes(record[rule.discriminator] as never)
+          : !rule.values.includes(record[rule.discriminator] as never)
+      )
+        continue;
       if (rule.kind === "required") {
         for (const field of rule.required) {
           if (!(field in record))
@@ -734,12 +747,70 @@ export const LineItemResponseSchema = z.object({
 });
 export type LineItemResponse = z.infer<typeof LineItemResponseSchema>;
 
-export const TotalsResponseSchema = z.object({
-  amount: z.number().int(),
-  display_text: z.string().optional(),
-  type: z.string(),
-  lines: z.array(LineSchema).optional(),
-});
+export const TotalsResponseSchema = z
+  .object({
+    amount: z.number().int(),
+    display_text: z.string().optional(),
+    type: z.string(),
+    lines: z.array(LineSchema).optional(),
+  })
+  .superRefine((value, ctx) => {
+    for (const rule of [
+      {
+        kind: "required",
+        discriminator: "type",
+        values: [
+          "subtotal",
+          "items_discount",
+          "discount",
+          "fulfillment",
+          "tax",
+          "fee",
+          "total",
+        ],
+        negated: true,
+        required: ["display_text"],
+        target: null,
+        minimum: null,
+        maximum: null,
+        exclusiveMinimum: null,
+        exclusiveMaximum: null,
+      },
+    ]) {
+      const record = value as Record<string, unknown>;
+      if (
+        rule.negated
+          ? rule.values.includes(record[rule.discriminator] as never)
+          : !rule.values.includes(record[rule.discriminator] as never)
+      )
+        continue;
+      if (rule.kind === "required") {
+        for (const field of rule.required) {
+          if (!(field in record))
+            ctx.addIssue({
+              code: z.ZodIssueCode.custom,
+              path: [field],
+              message: "Field is required by a conditional constraint",
+            });
+        }
+        continue;
+      }
+      if (rule.target === null) continue;
+      const target = record[rule.target];
+      if (typeof target !== "number") continue;
+      const invalid =
+        (rule.minimum !== null && target < rule.minimum) ||
+        (rule.maximum !== null && target > rule.maximum) ||
+        (rule.exclusiveMinimum !== null && target <= rule.exclusiveMinimum) ||
+        (rule.exclusiveMaximum !== null && target >= rule.exclusiveMaximum);
+      if (invalid)
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: [rule.target],
+          message: "Value violates a conditional numeric constraint",
+        });
+    }
+  });
 export type TotalsResponse = z.infer<typeof TotalsResponseSchema>;
 
 export const UcpResponseSchema = z.object({

--- a/src/spec_generated.ts
+++ b/src/spec_generated.ts
@@ -266,12 +266,12 @@ export const TotalResponseSchema = z
       },
     ]) {
       const record = value as Record<string, unknown>;
-      if (
-        rule.negated
-          ? rule.values.includes(record[rule.discriminator] as never)
-          : !rule.values.includes(record[rule.discriminator] as never)
-      )
-        continue;
+      const discriminatorVal = record[rule.discriminator];
+      if (discriminatorVal === undefined) continue;
+      const matches = (rule.values as readonly unknown[]).includes(
+        discriminatorVal
+      );
+      if (rule.negated ? matches : !matches) continue;
       if (rule.kind === "required") {
         for (const field of rule.required) {
           if (!(field in record))
@@ -636,12 +636,12 @@ export const SearchResponsePaginationSchema = z
       },
     ]) {
       const record = value as Record<string, unknown>;
-      if (
-        rule.negated
-          ? rule.values.includes(record[rule.discriminator] as never)
-          : !rule.values.includes(record[rule.discriminator] as never)
-      )
-        continue;
+      const discriminatorVal = record[rule.discriminator];
+      if (discriminatorVal === undefined) continue;
+      const matches = (rule.values as readonly unknown[]).includes(
+        discriminatorVal
+      );
+      if (rule.negated ? matches : !matches) continue;
       if (rule.kind === "required") {
         for (const field of rule.required) {
           if (!(field in record))
@@ -778,12 +778,12 @@ export const TotalsResponseSchema = z
       },
     ]) {
       const record = value as Record<string, unknown>;
-      if (
-        rule.negated
-          ? rule.values.includes(record[rule.discriminator] as never)
-          : !rule.values.includes(record[rule.discriminator] as never)
-      )
-        continue;
+      const discriminatorVal = record[rule.discriminator];
+      if (discriminatorVal === undefined) continue;
+      const matches = (rule.values as readonly unknown[]).includes(
+        discriminatorVal
+      );
+      if (rule.negated ? matches : !matches) continue;
       if (rule.kind === "required") {
         for (const field of rule.required) {
           if (!(field in record))

--- a/tests/spec-constraints.test.js
+++ b/tests/spec-constraints.test.js
@@ -24,6 +24,7 @@ const assert = require("node:assert/strict");
 const {
   PriceSchema,
   TotalResponseSchema,
+  TotalsResponseSchema,
   SearchResponsePaginationSchema,
   MediaSchema,
   ProductOptionSchema,
@@ -88,6 +89,40 @@ test("TotalResponseSchema accepts amounts with valid conditional signs", () => {
 
 test("TotalResponseSchema still rejects a non-integer amount", () => {
   assert.ok(rejects(TotalResponseSchema, { amount: 1.5, type: "discount" }));
+});
+
+// --- TotalsResponseSchema: conditional display_text for custom types --------
+// totals.json: when `type` is NOT one of the well-known categories, the entry
+// must carry display_text so the platform can render it by label.
+
+test("TotalsResponseSchema requires display_text for a custom type", () => {
+  assert.ok(
+    rejects(TotalsResponseSchema, { type: "shipping_surcharge", amount: 500 })
+  );
+});
+
+test("TotalsResponseSchema accepts a custom type with display_text", () => {
+  assert.ok(
+    accepts(TotalsResponseSchema, {
+      type: "shipping_surcharge",
+      amount: 500,
+      display_text: "Shipping surcharge",
+    })
+  );
+});
+
+test("TotalsResponseSchema does not require display_text for well-known types", () => {
+  for (const type of [
+    "subtotal",
+    "items_discount",
+    "discount",
+    "fulfillment",
+    "tax",
+    "fee",
+    "total",
+  ]) {
+    assert.ok(accepts(TotalsResponseSchema, { type, amount: 100 }), type);
+  }
 });
 
 // --- SearchResponsePaginationSchema: conditional required ------------------

--- a/tests/spec-constraints.test.js
+++ b/tests/spec-constraints.test.js
@@ -122,7 +122,23 @@ test("TotalsResponseSchema does not require display_text for well-known types", 
     "total",
   ]) {
     assert.ok(accepts(TotalsResponseSchema, { type, amount: 100 }), type);
+    assert.ok(
+      accepts(TotalsResponseSchema, {
+        type,
+        amount: 100,
+        display_text: "Label",
+      }),
+      `${type} with display_text`
+    );
   }
+});
+
+test("TotalsResponseSchema does not trigger conditional display_text constraint when type is missing", () => {
+  const result = TotalsResponseSchema.safeParse({ amount: 100 });
+  assert.strictEqual(result.success, false);
+  const issues = result.error.issues;
+  assert.ok(issues.some((issue) => issue.path[0] === "type"));
+  assert.ok(!issues.some((issue) => issue.path[0] === "display_text"));
 });
 
 // --- SearchResponsePaginationSchema: conditional required ------------------


### PR DESCRIPTION
## Description

The generated Zod schemas omit conditional constraints whose discriminator is a negated set. `totals.json` requires every total entry whose `type` is **not** one of the well-known categories (`subtotal`, `items_discount`, `discount`, `fulfillment`, `tax`, `fee`, `total`) to carry `display_text`, so platforms can render custom entries by label. The generated `TotalsResponseSchema` dropped that rule: `TotalsResponseSchema.safeParse({ type: "shipping_surcharge", amount: 500 })` succeeded despite the missing `display_text`.

**Fix:** extend the schema constraint injector to recognize a single-key `not` wrapper on the discriminator (`type: { not: { enum: [...] } }`), negate the runtime match, and restore the conditional `display_text` requirement on `TotalsResponseSchema`. Rich/ambiguous conditions are skipped as before; existing rules now carry an explicit `negated: false` with identical semantics.

## Category (Required)

- [ ] **Core Protocol**
- [ ] **Governance/Contributing**
- [ ] **Capability**
- [ ] **Documentation**
- [ ] **Infrastructure**
- [ ] **Maintenance**
- [x] **SDK**
- [ ] **Samples / Conformance**
- [ ] **UCP Schema**
- [ ] **Community Health (.github)**

## Related Issues

N/A

## Checklist

- [x] I have followed the Contributing Guide and Code of Conduct.
- [x] I have updated the documentation (if applicable).
- [x] My changes pass all local linting and formatting checks.
- [x] I have added tests that prove the fix is effective.
- [x] New and existing unit tests pass locally with my changes.
- [ ] I have included/updated the relevant JSON schemas (Core/Capability only).
- [ ] I have regenerated Python Pydantic models (not applicable).

## Screenshots / Logs (if applicable)

- `npm test`: 59 passed (previous 52 + 7 new)
- `npm run build:noEmit`: passed
- `pre-commit run --all-files`: passed (prettier, codespell, ShellCheck)
- pinned `release/2026-04-08` generation: no regeneration drift
