### PR TITLE
fix: resolve cross-file refs when injecting schema constraints

### DIFF
--- a/scripts/inject-schema-constraints.mjs
+++ b/scripts/inject-schema-constraints.mjs
@@ -200,18 +200,27 @@ function resolveObject(node, file, seen = new Set(), depth = 0) {
     return resolveObject(resolved.node, resolved.file, seen, depth + 1);
   }
   let properties = {};
+  let propertyFiles = {};
   if (Array.isArray(node.allOf)) {
     for (const sub of node.allOf) {
       const resolved = resolveObject(sub, file, new Set(seen), depth + 1);
       if (resolved) {
         properties = { ...resolved.properties, ...properties };
+        propertyFiles = { ...resolved.propertyFiles, ...propertyFiles };
       }
     }
   }
   if (node.properties && typeof node.properties === "object") {
     properties = { ...properties, ...node.properties };
+    // Own properties live in this file, so their (possibly relative) $refs
+    // resolve against it, not against the object that inherits them via allOf.
+    for (const name of Object.keys(node.properties)) {
+      propertyFiles[name] = file;
+    }
   }
-  return Object.keys(properties).length ? { properties, file } : null;
+  return Object.keys(properties).length
+    ? { properties, propertyFiles, file }
+    : null;
 }
 
 /**
@@ -366,14 +375,21 @@ const minPropertiesIndex = new Map();
 // is left untouched. setKey -> Map(signature -> rules).
 const conditionalIndex = new Map();
 
-function recordObject(properties, file) {
+function recordObject(properties, file, propertyFiles) {
   const setKey = Object.keys(properties).sort().join(",");
   if (!constraintIndex.has(setKey)) {
     constraintIndex.set(setKey, new Map());
   }
   const byProperty = constraintIndex.get(setKey);
   for (const [name, propertyNode] of Object.entries(properties)) {
-    const described = describeConstraint(propertyNode, file);
+    // Each property carries the file it was authored in (it may have been
+    // inherited into this object via a cross-file `$ref`/`allOf`, in which
+    // case its own relative `$ref`s must resolve against that file, not the
+    // inheriting object's). Fall back to the object's file when unset.
+    const described = describeConstraint(
+      propertyNode,
+      (propertyFiles && propertyFiles[name]) || file
+    );
     if (!described) {
       continue;
     }
@@ -629,7 +645,11 @@ function walkSchema(node, file, seen = new Set(), depth = 0) {
   }
   const resolvedObject = resolveObject(node, file);
   if (resolvedObject) {
-    recordObject(resolvedObject.properties, resolvedObject.file);
+    recordObject(
+      resolvedObject.properties,
+      resolvedObject.file,
+      resolvedObject.propertyFiles
+    );
     recordPropertyNames(node, resolvedObject.properties, file);
     recordMinProperties(node, resolvedObject.properties);
     recordConditionalRules(node, resolvedObject.properties);

--- a/src/spec_generated.ts
+++ b/src/spec_generated.ts
@@ -344,7 +344,7 @@ export const CapabilityResponseSchema = z.object({
   id: z.string().optional(),
   schema: z.string().url().optional(),
   spec: z.string().url().optional(),
-  version: z.string(),
+  version: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
 });
 export type CapabilityResponse = z.infer<typeof CapabilityResponseSchema>;
 
@@ -355,7 +355,7 @@ export const ServiceResponseSchema = z.object({
   schema: z.string().url().optional(),
   spec: z.string().url().optional(),
   transport: TransportSchema,
-  version: z.string(),
+  version: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
 });
 export type ServiceResponse = z.infer<typeof ServiceResponseSchema>;
 
@@ -682,7 +682,7 @@ export const PaymentHandlerResponseSchema = z.object({
   id: z.string(),
   schema: z.string().url().optional(),
   spec: z.string().url().optional(),
-  version: z.string(),
+  version: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
 });
 export type PaymentHandlerResponse = z.infer<
   typeof PaymentHandlerResponseSchema
@@ -1378,7 +1378,7 @@ export const LookupRequestSchema = z.object({
   attribution: z.record(z.string(), z.string()).optional(),
   context: LookupRequestContextSchema.optional(),
   filters: SearchFiltersSchema.optional(),
-  ids: z.array(z.string()),
+  ids: z.array(z.string()).min(1),
   signals: LookupRequestSignalsSchema.optional(),
 });
 export type LookupRequest = z.infer<typeof LookupRequestSchema>;
@@ -1401,7 +1401,7 @@ export const CatalogLookupSchema = z.object({
   tags: z.array(z.string()).optional(),
   title: z.string(),
   unit_price: PurpleUnitPriceSchema.optional(),
-  url: z.string().optional(),
+  url: z.string().url().optional(),
   inputs: z.array(InputCorrelationSchema).min(1),
 });
 export type CatalogLookup = z.infer<typeof CatalogLookupSchema>;
@@ -1644,8 +1644,8 @@ export const ProductSchema = z.object({
   rating: RatingSchema.optional(),
   tags: z.array(z.string()).optional(),
   title: z.string(),
-  url: z.string().optional(),
-  variants: z.array(VariantSchema),
+  url: z.string().url().optional(),
+  variants: z.array(VariantSchema).min(1),
 });
 export type Product = z.infer<typeof ProductSchema>;
 

--- a/tests/spec-constraints.test.js
+++ b/tests/spec-constraints.test.js
@@ -28,6 +28,11 @@ const {
   SearchResponsePaginationSchema,
   MediaSchema,
   ProductOptionSchema,
+  ProductSchema,
+  LookupRequestSchema,
+  CapabilityResponseSchema,
+  ServiceResponseSchema,
+  PaymentHandlerResponseSchema,
   AvailablePaymentInstrumentSchema,
   DescriptionSchema,
   OrderConfirmationSchema,
@@ -241,5 +246,111 @@ test("OrderConfirmationSchema rejects a non-URL permalink_url (format: uri)", ()
       id: "o_1",
       permalink_url: "https://shop.example/orders/1",
     })
+  );
+});
+
+// --- Cross-file $ref provenance: entity version patterns --------------------
+// Every UCP entity inherits `version` from ucp.json#/$defs/entity via a
+// cross-file allOf `$ref`. The injector must resolve that property's own
+// file (ucp.json) so the YYYY-MM-DD pattern survives on derived schemas.
+
+test("CapabilityResponseSchema enforces the entity version pattern", () => {
+  assert.ok(
+    rejects(CapabilityResponseSchema, { version: "not-a-date", id: "cap" })
+  );
+  assert.ok(
+    accepts(CapabilityResponseSchema, {
+      version: "2026-04-08",
+      id: "cap",
+    })
+  );
+});
+
+test("ServiceResponseSchema enforces the entity version pattern", () => {
+  assert.ok(
+    rejects(ServiceResponseSchema, {
+      version: "v2",
+      transport: "rest",
+    })
+  );
+  assert.ok(
+    accepts(ServiceResponseSchema, {
+      version: "2026-04-08",
+      transport: "rest",
+    })
+  );
+});
+
+test("PaymentHandlerResponseSchema enforces the entity version pattern", () => {
+  assert.ok(
+    rejects(PaymentHandlerResponseSchema, {
+      version: "abc123",
+      id: "handler",
+      available_instruments: [{ type: "card", constraints: {} }],
+    })
+  );
+  assert.ok(
+    accepts(PaymentHandlerResponseSchema, {
+      version: "2026-04-08",
+      id: "handler",
+      available_instruments: [
+        { type: "card", constraints: { network: "visa" } },
+      ],
+    })
+  );
+});
+
+// --- Array minItems restored alongside the same provenance fix --------------
+// LookupRequest.ids and Product.variants are non-empty arrays per their
+// schemas; quicktype drops minItems, and the injector recovers it.
+
+test("LookupRequestSchema rejects an empty ids array (minItems: 1)", () => {
+  assert.ok(rejects(LookupRequestSchema, { ids: [] }));
+  assert.ok(accepts(LookupRequestSchema, { ids: ["shoes-red-42"] }));
+});
+
+const validProduct = (variants) => ({
+  description: { plain: "A product" },
+  id: "p1",
+  price_range: {
+    min: { amount: 10, currency: "USD" },
+    max: { amount: 20, currency: "USD" },
+  },
+  title: "Shoes",
+  variants,
+});
+
+test("ProductSchema rejects a product without variants (minItems: 1)", () => {
+  assert.ok(rejects(ProductSchema, validProduct([])));
+  assert.ok(
+    accepts(
+      ProductSchema,
+      validProduct([
+        {
+          id: "v1",
+          title: "Red",
+          description: { plain: "Red variant" },
+          price: { amount: 10, currency: "USD" },
+        },
+      ])
+    )
+  );
+});
+
+test("ProductSchema rejects a non-URL url (format: uri via cross-file)", () => {
+  const productWithUrl = (url) => ({
+    ...validProduct([
+      {
+        id: "v1",
+        title: "Red",
+        description: { plain: "Red variant" },
+        price: { amount: 10, currency: "USD" },
+      },
+    ]),
+    url,
+  });
+  assert.ok(rejects(ProductSchema, productWithUrl("not a url")));
+  assert.ok(
+    accepts(ProductSchema, productWithUrl("https://cdn.example/1.png"))
   );
 });


### PR DESCRIPTION
## Description

The schema constraint injector loses scalar constraints on properties inherited via a **cross-file** `$ref`/`allOf`. When `resolveObject` merges an `allOf` branch from another file (e.g. every UCP entity's `version` inherited from `ucp.json#/$defs/entity`), it drops each property's source file, so a relative `$ref` like `#/$defs/version` is later resolved against the *inheriting* object's file instead of `ucp.json` -- the constraint resolves to nothing and the generated zod schema stays unconstrained:

- `CapabilityResponseSchema`, `ServiceResponseSchema`, `PaymentHandlerResponseSchema`: `version` accepted any string (schema requires `^\d{4}-\d{2}-\d{2}$`).
- `LookupRequestSchema.ids`, `ProductSchema.variants`: accepted empty arrays (`minItems: 1` in schema).
- `ProductSchema.url` / `CatalogLookupSchema.url`: accepted non-URL strings (`format: uri`) -- the same root cause leaves #44's `uri` mechanism blind on these inherited properties.

**Fix:** `resolveObject` now tracks each property's authoring file (`propertyFiles`) and `recordObject` resolves each property's `$ref` against that file (falling back to the object's file). This restores every constraint on cross-file-inherited properties deterministically; idempotency and the ambiguity guard are unchanged.

## Category (Required)

- [ ] **Core Protocol**
- [ ] **Governance/Contributing**
- [ ] **Capability**
- [ ] **Documentation**
- [ ] **Infrastructure**
- [ ] **Maintenance**
- [x] **SDK**
- [ ] **Samples / Conformance**
- [ ] **UCP Schema**
- [ ] **Community Health (.github)**

## Related Issues

N/A

## Checklist

- [x] I have followed the Contributing Guide and Code of Conduct.
- [x] I have updated the documentation (if applicable).
- [x] My changes pass all local linting and formatting checks.
- [x] I have added tests that prove the fix is effective.
- [x] New and existing unit tests pass locally with my changes.
- [ ] I have included/updated the relevant JSON schemas (Core/Capability only).
- [ ] I have regenerated Python Pydantic models (not applicable).

## Screenshots / Logs (if applicable)

- `npm test`: 69 passed
- `npm run build:noEmit`: passed
- `pre-commit run --all-files`: passed (prettier, codespell, ShellCheck)
- pinned `release/2026-04-08` generation: no regeneration drift
