### PR TITLE
fix: inject constraints from projected schemas

### DIFF
--- a/generate_models.sh
+++ b/generate_models.sh
@@ -44,10 +44,10 @@ else
   exit 1
 fi
 
-# Schema tree (with intact $refs) used to recover the value constraints
-# quicktype's typescript-zod target drops. Captured before any projection so
-# cross-file $refs resolve as authored.
-CONSTRAINT_SCHEMA_DIR="$SPEC_DIR/schemas"
+# Raw schema tree (with intact authored $refs) used to recover the value
+# constraints quicktype's typescript-zod target drops.
+RAW_CONSTRAINT_SCHEMA_DIR="$SPEC_DIR/schemas"
+PROJECTED_CONSTRAINT_SCHEMA_DIR=""
 
 TMP_OUTPUT="$(mktemp "${TMPDIR:-/tmp}/ucp-spec-generated.XXXXXX.ts")"
 PROJECTED_SPEC_DIR=""
@@ -63,6 +63,7 @@ if [[ "$SCHEMA_LAYOUT" == "source" ]]; then
   PROJECTED_SPEC_DIR="$(mktemp -d "${TMPDIR:-/tmp}/ucp-js-sdk-projected.XXXXXX")"
   node scripts/project-current-ucp-schemas.mjs "$SPEC_DIR" "$PROJECTED_SPEC_DIR"
   SPEC_DIR="$PROJECTED_SPEC_DIR"
+  PROJECTED_CONSTRAINT_SCHEMA_DIR="$SPEC_DIR/schemas"
 fi
 
 QUICKTYPE_ARGS=(
@@ -115,5 +116,10 @@ npx quicktype "${QUICKTYPE_ARGS[@]}"
 node scripts/normalize-generated-schemas.mjs "$TMP_OUTPUT" src/spec_generated.ts
 
 # Re-attach the value constraints (minimum, pattern, type: integer, ...) that
-# quicktype's typescript-zod target drops. See scripts/inject-schema-constraints.mjs.
-node scripts/inject-schema-constraints.mjs "$CONSTRAINT_SCHEMA_DIR" src/spec_generated.ts
+# quicktype's typescript-zod target drops. The raw schema pass preserves
+# authored cross-file constraints; the projected pass then fills constraints on
+# create/update schemas that only exist after request projection.
+node scripts/inject-schema-constraints.mjs "$RAW_CONSTRAINT_SCHEMA_DIR" src/spec_generated.ts
+if [[ -n "$PROJECTED_CONSTRAINT_SCHEMA_DIR" ]]; then
+  node scripts/inject-schema-constraints.mjs "$PROJECTED_CONSTRAINT_SCHEMA_DIR" src/spec_generated.ts
+fi

--- a/src/spec_generated.ts
+++ b/src/spec_generated.ts
@@ -503,8 +503,8 @@ export type FulfillmentDestinationResponse = z.infer<
 >;
 
 export const PriceFilterSchema = z.object({
-  max: z.number().optional(),
-  min: z.number().optional(),
+  max: z.number().int().gte(0).optional(),
+  min: z.number().int().gte(0).optional(),
 });
 export type PriceFilter = z.infer<typeof PriceFilterSchema>;
 
@@ -700,7 +700,7 @@ export type UcpService = z.infer<typeof UcpServiceSchema>;
 
 export const LineItemCreateRequestSchema = z.object({
   item: ItemCreateRequestSchema,
-  quantity: z.number(),
+  quantity: z.number().int().gte(1),
 });
 export type LineItemCreateRequest = z.infer<typeof LineItemCreateRequestSchema>;
 
@@ -721,7 +721,7 @@ export const LineItemUpdateRequestSchema = z.object({
   id: z.string().optional(),
   item: ItemUpdateRequestSchema,
   parent_id: z.string().optional(),
-  quantity: z.number(),
+  quantity: z.number().int().gte(1),
 });
 export type LineItemUpdateRequest = z.infer<typeof LineItemUpdateRequestSchema>;
 

--- a/tests/spec-constraints.test.js
+++ b/tests/spec-constraints.test.js
@@ -23,6 +23,7 @@ const assert = require("node:assert/strict");
 
 const {
   PriceSchema,
+  PriceFilterSchema,
   TotalResponseSchema,
   TotalsResponseSchema,
   SearchResponsePaginationSchema,
@@ -30,6 +31,8 @@ const {
   ProductOptionSchema,
   ProductSchema,
   LookupRequestSchema,
+  LineItemCreateRequestSchema,
+  LineItemUpdateRequestSchema,
   CapabilityResponseSchema,
   ServiceResponseSchema,
   PaymentHandlerResponseSchema,
@@ -66,6 +69,58 @@ test("PriceSchema: the exact invalid payloads from issue #33 are rejected", () =
   assert.ok(rejects(PriceSchema, { amount: -50 }));
   assert.ok(rejects(PriceSchema, { amount: 9.99 }));
   assert.ok(rejects(PriceSchema, { currency: "usd" }));
+});
+
+// --- Projected request constraints -----------------------------------------
+// create/update projections must retain the constraints from their source
+// schemas even after omitted fields change the generated object's property set.
+
+test("PriceFilterSchema enforces amount constraints on min and max", () => {
+  assert.ok(rejects(PriceFilterSchema, { min: -1 }));
+  assert.ok(rejects(PriceFilterSchema, { max: 9.99 }));
+  assert.ok(accepts(PriceFilterSchema, { min: 0, max: 500 }));
+});
+
+test("LineItemCreateRequestSchema enforces positive integer quantity", () => {
+  assert.ok(
+    rejects(LineItemCreateRequestSchema, {
+      item: { id: "item_1" },
+      quantity: 0,
+    })
+  );
+  assert.ok(
+    rejects(LineItemCreateRequestSchema, {
+      item: { id: "item_1" },
+      quantity: 1.5,
+    })
+  );
+  assert.ok(
+    accepts(LineItemCreateRequestSchema, {
+      item: { id: "item_1" },
+      quantity: 1,
+    })
+  );
+});
+
+test("LineItemUpdateRequestSchema enforces positive integer quantity", () => {
+  assert.ok(
+    rejects(LineItemUpdateRequestSchema, {
+      item: { id: "item_1" },
+      quantity: 0,
+    })
+  );
+  assert.ok(
+    rejects(LineItemUpdateRequestSchema, {
+      item: { id: "item_1" },
+      quantity: 1.5,
+    })
+  );
+  assert.ok(
+    accepts(LineItemUpdateRequestSchema, {
+      item: { id: "item_1" },
+      quantity: 1,
+    })
+  );
 });
 
 // --- TotalResponseSchema: object-scoped correctness ------------------------


### PR DESCRIPTION
## Description

The generated zod schemas still lost constraints on request/response **projections** because the constraint injector only indexed the raw authored schema tree. quicktype consumes the projected schema tree for source-layout specs, so generated objects such as `LineItemCreateRequestSchema` and `LineItemUpdateRequestSchema` no longer have the same property set as their raw source object (`line_item.json` omits `id` / `totals` in requests). That made the injector miss `quantity: { type: integer, minimum: 1 }`.

Separately, `PriceFilterSchema` has the same `{ min, max }` property set as other schemas, so the raw-only pass correctly left it ambiguous. In the projected tree, the generated `PriceFilterSchema` has an unambiguous numeric source and can safely receive the `amount.json` constraints.

**Fix:** keep the existing raw constraint pass (so all authored cross-file constraints and conditional rules from #43–#46 stay intact), then run a second injector pass over the projected schema tree. The second pass only adds constraints that are visible after projection and leaves already-constrained fields unchanged.

This restores:

- `PriceFilterSchema.min/max`: `z.number().int().gte(0).optional()`
- `LineItemCreateRequestSchema.quantity`: `z.number().int().gte(1)`
- `LineItemUpdateRequestSchema.quantity`: `z.number().int().gte(1)`

## Category (Required)

- [ ] **Core Protocol**
- [ ] **Governance/Contributing**
- [ ] **Capability**
- [ ] **Documentation**
- [ ] **Infrastructure**
- [ ] **Maintenance**
- [x] **SDK**
- [ ] **Samples / Conformance**
- [ ] **UCP Schema**
- [ ] **Community Health (.github)**

## Related Issues

N/A

## Checklist

- [x] I have followed the Contributing Guide and Code of Conduct.
- [x] I have updated the documentation (if applicable).
- [x] My changes pass all local linting and formatting checks.
- [x] I have added tests that prove the fix is effective.
- [x] New and existing unit tests pass locally with my changes.
- [ ] I have included/updated the relevant JSON schemas (Core/Capability only).
- [ ] I have regenerated Python Pydantic models (not applicable).

## Screenshots / Logs (if applicable)

- `npm test`: 72 passed
- `npm run build:noEmit`: passed
- `pre-commit run --all-files`: passed (prettier, codespell, ShellCheck)
- pinned `release/2026-04-08` generation: no regeneration drift
