### PR TITLE
fix: enforce line item quantity constraints in event and expectation schemas

### DIFF
--- a/scripts/inject-schema-constraints.mjs
+++ b/scripts/inject-schema-constraints.mjs
@@ -752,6 +752,34 @@ for (const [setKey, bySignature] of conditionalIndex) {
   }
 }
 
+// --- Shared {id,quantity} line-item reference: contextual split --------------
+//
+// adjustment / fulfillment_event / expectation all declare
+// `line_items[].quantity` as `type: integer`, but only fulfillment_event and
+// expectation also add `minimum: 1`; the adjustment quantity is deliberately
+// signed (negative values represent returns/exchanges). quicktype merges the
+// three into a single shared LineItemQuantityRefSchema object, so the generic
+// ambiguity guard above leaves the whole set untouched (two conflicting
+// quantity signatures under one property set). We split the two `minimum: 1`
+// aliases into standalone objects carrying `.int().gte(1)` and keep the signed
+// adjustment on the shared `.int()` alone.
+//
+// Gated strictly on schema evidence inside the "id,quantity" property set: a
+// signed descriptor ({int}) AND a {int, minimum:1} descriptor must both be
+// present. A coincidental same-shape object can never trigger the split.
+const QUANTITY_SPLIT_TARGETS = ["EventLineItem", "ExpectationLineItem"];
+const sharedQuantitySplitNeeded = (() => {
+  const byProperty = constraintIndex.get("id,quantity");
+  if (!byProperty) return false;
+  const quantity = byProperty.get("quantity");
+  if (!quantity || quantity.size < 2) return false;
+  const signatures = [...quantity.keys()];
+  return (
+    signatures.includes(JSON.stringify({ int: true })) &&
+    signatures.some((signature) => JSON.parse(signature).minimum === 1)
+  );
+})();
+
 // --- Zod method rendering --------------------------------------------------
 
 function toRegexLiteral(pattern) {
@@ -1100,13 +1128,14 @@ const sourceFile = ts.createSourceFile(
   ts.ScriptKind.TS
 );
 
-const edits = []; // { pos, text }
+const edits = []; // { pos, remove?, text }
 const report = {
   objectsMatched: 0,
   fieldsInjected: 0,
   propertyNamesInjected: 0,
   minPropertiesInjected: 0,
   conditionalsInjected: 0,
+  sharedQuantityInjected: 0,
   fieldsSkippedType: 0,
   fieldsAlreadyDone: 0,
   injections: [],
@@ -1258,11 +1287,59 @@ function visit(node) {
 
 visit(sourceFile);
 
+// Apply the contextual {id,quantity} split: `.int()` on the shared quantity
+// (all three contexts declare `type: integer`), and the two `minimum: 1`
+// aliases become standalone objects. Idempotent: the shared `.int()` is
+// guarded by a negative lookahead, and a split alias no longer matches the
+// `= LineItemQuantityRefSchema;` pattern.
+if (sharedQuantitySplitNeeded) {
+  const sharedObjectStart = sourceText.indexOf(
+    "export const LineItemQuantityRefSchema = z.object({"
+  );
+  const sharedObjectEnd =
+    sharedObjectStart >= 0 ? sourceText.indexOf("\n});", sharedObjectStart) : -1;
+  if (sharedObjectStart >= 0 && sharedObjectEnd >= 0) {
+    const sharedObjectText = sourceText.slice(sharedObjectStart, sharedObjectEnd);
+    const quantityRef = /["']?quantity["']?: z\.number\(\)(?!\.int\(\))/.exec(
+      sharedObjectText
+    );
+    if (quantityRef) {
+      edits.push({
+        pos: sharedObjectStart + quantityRef.index + quantityRef[0].length,
+        text: ".int()",
+      });
+      report.sharedQuantityInjected += 1;
+    }
+  }
+  for (const name of QUANTITY_SPLIT_TARGETS) {
+    const aliasRef = new RegExp(
+      `export const ${name}Schema = LineItemQuantityRefSchema;`
+    );
+    const matched = aliasRef.exec(sourceText);
+    if (!matched) {
+      continue;
+    }
+    const standalone = `export const ${name}Schema = z.object({\n` +
+      `  id: z.string(),\n` +
+      `  quantity: z.number().int().gte(1),\n` +
+      `});`;
+    edits.push({
+      pos: matched.index,
+      remove: matched[0].length,
+      text: standalone,
+    });
+    report.sharedQuantityInjected += 1;
+  }
+}
+
 // Apply edits back-to-front so positions stay valid.
 edits.sort((a, b) => b.pos - a.pos);
 let output = sourceText;
 for (const edit of edits) {
-  output = output.slice(0, edit.pos) + edit.text + output.slice(edit.pos);
+  output =
+    output.slice(0, edit.pos) +
+    edit.text +
+    output.slice(edit.pos + (edit.remove ?? 0));
 }
 
 fs.writeFileSync(targetPath, output);
@@ -1275,6 +1352,7 @@ process.stdout.write(
     `${report.propertyNamesInjected} propertyNames key-check(s); ` +
     `${report.minPropertiesInjected} object minProperties check(s); ` +
     `${report.conditionalsInjected} conditional check(s); ` +
+    `${report.sharedQuantityInjected} shared-quantity split edit(s); ` +
     `${report.fieldsAlreadyDone} already constrained; ` +
     `${report.fieldsSkippedType} skipped (base-type mismatch).\n`
 );

--- a/src/spec_generated.ts
+++ b/src/spec_generated.ts
@@ -361,14 +361,20 @@ export type ServiceResponse = z.infer<typeof ServiceResponseSchema>;
 
 export const LineItemQuantityRefSchema = z.object({
   id: z.string(),
-  quantity: z.number(),
+  quantity: z.number().int(),
 });
 export type LineItemQuantityRef = z.infer<typeof LineItemQuantityRefSchema>;
 export const AdjustmentLineItemSchema = LineItemQuantityRefSchema;
 export type AdjustmentLineItem = LineItemQuantityRef;
-export const EventLineItemSchema = LineItemQuantityRefSchema;
+export const EventLineItemSchema = z.object({
+  id: z.string(),
+  quantity: z.number().int().gte(1),
+});
 export type EventLineItem = LineItemQuantityRef;
-export const ExpectationLineItemSchema = LineItemQuantityRefSchema;
+export const ExpectationLineItemSchema = z.object({
+  id: z.string(),
+  quantity: z.number().int().gte(1),
+});
 export type ExpectationLineItem = LineItemQuantityRef;
 
 export const QuantitySchema = z.object({

--- a/tests/spec-constraints.test.js
+++ b/tests/spec-constraints.test.js
@@ -39,6 +39,10 @@ const {
   AvailablePaymentInstrumentSchema,
   DescriptionSchema,
   OrderConfirmationSchema,
+  LineItemQuantityRefSchema,
+  AdjustmentLineItemSchema,
+  EventLineItemSchema,
+  ExpectationLineItemSchema,
 } = require("./.dist/spec_generated.js");
 
 const accepts = (schema, value) => schema.safeParse(value).success === true;
@@ -69,6 +73,56 @@ test("PriceSchema: the exact invalid payloads from issue #33 are rejected", () =
   assert.ok(rejects(PriceSchema, { amount: -50 }));
   assert.ok(rejects(PriceSchema, { amount: 9.99 }));
   assert.ok(rejects(PriceSchema, { currency: "usd" }));
+});
+
+// --- Shared line-item quantity refs: contextual split ----------------------
+// adjustment / fulfillment_event / expectation all declare
+// `line_items[].quantity` as `type: integer`. Only the event and expectation
+// quantities add `minimum: 1`; the adjustment quantity is signed (negative =
+// returns). The shared LineItemQuantityRefSchema carries `.int()`; the two
+// `minimum: 1` aliases are split into standalone objects with `.gte(1)`.
+
+test("shared LineItemQuantityRefSchema enforces an integer quantity", () => {
+  assert.ok(rejects(LineItemQuantityRefSchema, { id: "li_1", quantity: 1.5 }));
+  assert.ok(accepts(LineItemQuantityRefSchema, { id: "li_1", quantity: -1 }));
+});
+
+test("AdjustmentLineItemSchema allows a signed integer quantity", () => {
+  assert.ok(accepts(AdjustmentLineItemSchema, { id: "li_1", quantity: -1 }));
+  assert.ok(rejects(AdjustmentLineItemSchema, { id: "li_1", quantity: 1.5 }));
+});
+
+test("EventLineItemSchema rejects a zero quantity (minimum: 1)", () => {
+  assert.ok(rejects(EventLineItemSchema, { id: "li_1", quantity: 0 }));
+});
+
+test("EventLineItemSchema rejects a negative quantity (minimum: 1)", () => {
+  assert.ok(rejects(EventLineItemSchema, { id: "li_1", quantity: -1 }));
+});
+
+test("EventLineItemSchema rejects a fractional quantity (type: integer)", () => {
+  assert.ok(rejects(EventLineItemSchema, { id: "li_1", quantity: 1.5 }));
+});
+
+test("EventLineItemSchema accepts a positive integer quantity", () => {
+  assert.ok(accepts(EventLineItemSchema, { id: "li_1", quantity: 1 }));
+  assert.ok(accepts(EventLineItemSchema, { id: "li_1", quantity: 3 }));
+});
+
+test("ExpectationLineItemSchema rejects a zero quantity (minimum: 1)", () => {
+  assert.ok(rejects(ExpectationLineItemSchema, { id: "li_1", quantity: 0 }));
+});
+
+test("ExpectationLineItemSchema rejects a negative quantity (minimum: 1)", () => {
+  assert.ok(rejects(ExpectationLineItemSchema, { id: "li_1", quantity: -1 }));
+});
+
+test("ExpectationLineItemSchema rejects a fractional quantity (type: integer)", () => {
+  assert.ok(rejects(ExpectationLineItemSchema, { id: "li_1", quantity: 1.5 }));
+});
+
+test("ExpectationLineItemSchema accepts a positive integer quantity", () => {
+  assert.ok(accepts(ExpectationLineItemSchema, { id: "li_1", quantity: 1 }));
 });
 
 // --- Projected request constraints -----------------------------------------


### PR DESCRIPTION
## Description

`adjustment`, `fulfillment_event`, and `expectation` all declare
`line_items[].quantity` as `type: integer`, but only the event and expectation
quantities add `minimum: 1`. The adjustment quantity is deliberately signed
(negative values represent returns/exchanges). quicktype's `typescript-zod`
target merges the three into one shared object, so the generated schema lost
both the integer check and the `minimum: 1` rule:

```ts
export const LineItemQuantityRefSchema = z.object({
  id: z.string(),
  quantity: z.number(),
});
export const EventLineItemSchema = LineItemQuantityRefSchema;
export const ExpectationLineItemSchema = LineItemQuantityRefSchema;
```

Consequently `EventLineItemSchema` / `ExpectationLineItemSchema` accept
spec-invalid inputs such as `{ id: "li_1", quantity: 0 }`, `-1`, and `1.5`.

**Fix:** `inject-schema-constraints.mjs` now injects `.int()` onto the shared
`LineItemQuantityRefSchema` (all three contexts agree on `type: integer`) and
splits the two `minimum: 1` aliases into standalone objects carrying
`.int().gte(1)`, keeping the signed adjustment on the shared `.int()` alone.
The split is gated on the schema evidence (a signed descriptor and a
`minimum: 1` descriptor under the same `id,quantity` property set) and is
idempotent across regeneration.

## Category (Required)

- [ ] **Core Protocol**: ...
- [ ] **Governance/Contributing**: ...
- [ ] **Capability**: ...
- [ ] **Documentation**: ...
- [ ] **Infrastructure**: ...
- [ ] **Maintenance**: ...
- [x] **SDK**: Language-specific SDK updates and releases. (Requires DevOps Maintainer approval)
- [ ] **Samples / Conformance**: ...
- [ ] **UCP Schema**: ...

## Related Issues

- https://github.com/Universal-Commerce-Protocol/js-sdk/issues/33 (value constraints dropped by the generator, extended here)

## Checklist

- [x] I have followed the Contributing Guide ...
- [x] I have updated the documentation (if applicable).
- [x] My changes pass all local linting and formatting checks.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] (For Core/Capability) I have included/updated the relevant JSON schemas.
- [x] I have regenerated the SDK schemas by running `npm run generate` against the pinned UCP 2026-04-08 release.

## Screenshots / Logs (if applicable)

N/A — validated by `npm test` (82 passing, including 10 new regression tests), `npm run build:noEmit`, prettier, and a regeneration + idempotency re-run of `inject-schema-constraints.mjs` (0 further edits on a second pass).
