### PR TITLE
fix: require payment_handlers on checkout response envelope

### DIFF
--- a/generate_models.sh
+++ b/generate_models.sh
@@ -123,3 +123,8 @@ node scripts/inject-schema-constraints.mjs "$RAW_CONSTRAINT_SCHEMA_DIR" src/spec
 if [[ -n "$PROJECTED_CONSTRAINT_SCHEMA_DIR" ]]; then
   node scripts/inject-schema-constraints.mjs "$PROJECTED_CONSTRAINT_SCHEMA_DIR" src/spec_generated.ts
 fi
+
+# Format the generated output to match the repo's Prettier config (the checked-in
+# file is formatted with .prettierrc; without this step regenerated output drifts
+# by indentation and formatting noise).
+npx prettier --write src/spec_generated.ts

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "zod": "^3.23.8"
       },
       "devDependencies": {
+        "prettier": "^3.9.6",
         "quicktype": "^23.2.6",
         "typescript": "^5.4.5"
       }
@@ -742,6 +743,22 @@
       "license": "MIT",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.9.6",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.9.6.tgz",
+      "integrity": "sha512-OpN0zzVdiaiAhxpuuj5efpIS4sY9j7bY6uR5mnj5yPzGkdkjNKSJeUThPb60Jw29QuAZgA4o+/iB49kFiaBX6g==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "node_modules/process": {

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "zod": "^3.23.8"
   },
   "devDependencies": {
+    "prettier": "^3.9.6",
     "quicktype": "^23.2.6",
     "typescript": "^5.4.5"
   },

--- a/scripts/project-current-ucp-schemas.mjs
+++ b/scripts/project-current-ucp-schemas.mjs
@@ -664,7 +664,7 @@ function buildEntityResponseSchema(title, entitySchema, rootDocs) {
 // their per-entity RESPONSE compat shape, and scalars/enums (version, status)
 // are carried through. An unknown registry entity fails loudly rather than
 // silently dropping the field.
-function buildResponseEnvelopeSchema(ucpSchema) {
+function buildResponseEnvelopeSchema(ucpSchema, extraRequired = []) {
   const base = ucpSchema.$defs.base;
   const properties = {};
   for (const [name, schema] of Object.entries(base.properties)) {
@@ -690,7 +690,7 @@ function buildResponseEnvelopeSchema(ucpSchema) {
     $schema: "https://json-schema.org/draft/2020-12/schema",
     title: "UCP Response",
     type: "object",
-    required: [...(base.required ?? [])],
+    required: [...(base.required ?? []), ...extraRequired],
     properties,
   };
 }
@@ -818,6 +818,14 @@ function writeCompatibilityDiscoverySchemas() {
   // the checkout-only requirement needs a distinct type and is filed as a
   // follow-up so order/cart/catalog responses are not falsely rejected.
   const ucpResponse = buildResponseEnvelopeSchema(ucpSchema);
+  // Checkout responses additionally require `payment_handlers`
+  // (ucp.json#/$defs/response_checkout_schema.allOf[1]), which the shared
+  // envelope cannot express without also demanding it on order/cart/catalog
+  // responses -- so only checkout aliases this distinct type.
+  const ucpCheckoutResponse = {
+    ...buildResponseEnvelopeSchema(ucpSchema, ["payment_handlers"]),
+    title: "UCP Checkout Response",
+  };
 
   const ucpDiscoveryProfile = {
     $schema: "https://json-schema.org/draft/2020-12/schema",
@@ -876,6 +884,10 @@ function writeCompatibilityDiscoverySchemas() {
   writeJson(path.join(outputDiscoveryRoot, "ucp_service.json"), ucpService);
   writeJson(path.join(outputDiscoveryRoot, "ucp_response.json"), ucpResponse);
   writeJson(
+    path.join(outputDiscoveryRoot, "ucp_checkout_response.json"),
+    ucpCheckoutResponse
+  );
+  writeJson(
     path.join(outputDiscoveryRoot, "ucp_discovery_profile.json"),
     ucpDiscoveryProfile
   );
@@ -885,7 +897,9 @@ function writeCompatibilityCoreSchemas() {
   const ucpSchema = {
     $schema: "https://json-schema.org/draft/2020-12/schema",
     $defs: {
-      response_checkout_schema: { $ref: "../discovery/ucp_response.json" },
+      response_checkout_schema: {
+        $ref: "../discovery/ucp_checkout_response.json",
+      },
       response_order_schema: { $ref: "../discovery/ucp_response.json" },
       response_cart_schema: { $ref: "../discovery/ucp_response.json" },
       response_catalog_schema: { $ref: "../discovery/ucp_response.json" },

--- a/src/spec_generated.ts
+++ b/src/spec_generated.ts
@@ -45,8 +45,10 @@ export type CheckoutResponseStatus = z.infer<
 export const TransportSchema = z.enum(["a2a", "embedded", "mcp", "rest"]);
 export type Transport = z.infer<typeof TransportSchema>;
 
-export const UcpResponseStatusSchema = z.enum(["error", "success"]);
-export type UcpResponseStatus = z.infer<typeof UcpResponseStatusSchema>;
+export const UcpCheckoutResponseStatusSchema = z.enum(["error", "success"]);
+export type UcpCheckoutResponseStatus = z.infer<
+  typeof UcpCheckoutResponseStatusSchema
+>;
 
 // Adjustment status.
 
@@ -819,7 +821,7 @@ export const TotalsResponseSchema = z
   });
 export type TotalsResponse = z.infer<typeof TotalsResponseSchema>;
 
-export const UcpResponseSchema = z.object({
+export const UcpCheckoutResponseSchema = z.object({
   capabilities: z
     .record(z.string(), z.array(CapabilityResponseSchema))
     .refine(
@@ -838,8 +840,7 @@ export const UcpResponseSchema = z.object({
           /^[a-z][a-z0-9]*(?:\.[a-z][a-z0-9_]*)+$/.test(key)
         ),
       { message: "Record keys must match the required pattern (propertyNames)" }
-    )
-    .optional(),
+    ),
   services: z
     .record(z.string(), z.array(ServiceResponseSchema))
     .refine(
@@ -850,10 +851,10 @@ export const UcpResponseSchema = z.object({
       { message: "Record keys must match the required pattern (propertyNames)" }
     )
     .optional(),
-  status: UcpResponseStatusSchema.optional(),
+  status: UcpCheckoutResponseStatusSchema.optional(),
   version: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
 });
-export type UcpResponse = z.infer<typeof UcpResponseSchema>;
+export type UcpCheckoutResponse = z.infer<typeof UcpCheckoutResponseSchema>;
 
 export const AdjustmentSchema = z.object({
   description: z.string().optional(),
@@ -897,6 +898,42 @@ export const OrderLineItemSchema = z.object({
   totals: z.array(TotalResponseSchema),
 });
 export type OrderLineItem = z.infer<typeof OrderLineItemSchema>;
+
+export const UcpResponseSchema = z.object({
+  capabilities: z
+    .record(z.string(), z.array(CapabilityResponseSchema))
+    .refine(
+      (value) =>
+        Object.keys(value).every((key) =>
+          /^[a-z][a-z0-9]*(?:\.[a-z][a-z0-9_]*)+$/.test(key)
+        ),
+      { message: "Record keys must match the required pattern (propertyNames)" }
+    )
+    .optional(),
+  payment_handlers: z
+    .record(z.string(), z.array(PaymentHandlerResponseSchema))
+    .refine(
+      (value) =>
+        Object.keys(value).every((key) =>
+          /^[a-z][a-z0-9]*(?:\.[a-z][a-z0-9_]*)+$/.test(key)
+        ),
+      { message: "Record keys must match the required pattern (propertyNames)" }
+    )
+    .optional(),
+  services: z
+    .record(z.string(), z.array(ServiceResponseSchema))
+    .refine(
+      (value) =>
+        Object.keys(value).every((key) =>
+          /^[a-z][a-z0-9]*(?:\.[a-z][a-z0-9_]*)+$/.test(key)
+        ),
+      { message: "Record keys must match the required pattern (propertyNames)" }
+    )
+    .optional(),
+  status: UcpCheckoutResponseStatusSchema.optional(),
+  version: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
+});
+export type UcpResponse = z.infer<typeof UcpResponseSchema>;
 
 export const PaymentDataSchema = z.object({
   payment_data: PaymentInstrumentSchema,
@@ -949,7 +986,7 @@ export const CheckoutWithAp2MandateSchema = z.object({
       }
     }
   }),
-  ucp: UcpResponseSchema,
+  ucp: UcpCheckoutResponseSchema,
   ap2: CheckoutWithAp2MandateAp2Schema.optional(),
 });
 export type CheckoutWithAp2Mandate = z.infer<
@@ -1134,7 +1171,7 @@ export const CheckoutWithCartResponseSchema = z.object({
       }
     }
   }),
-  ucp: UcpResponseSchema,
+  ucp: UcpCheckoutResponseSchema,
   cart_id: z.string().optional(),
 });
 export type CheckoutWithCartResponse = z.infer<
@@ -1250,7 +1287,7 @@ export const CheckoutResponseSchema = z.object({
       }
     }
   }),
-  ucp: UcpResponseSchema,
+  ucp: UcpCheckoutResponseSchema,
 });
 export type CheckoutResponse = z.infer<typeof CheckoutResponseSchema>;
 
@@ -1323,7 +1360,7 @@ export const CheckoutWithBuyerConsentResponseSchema = z.object({
       }
     }
   }),
-  ucp: UcpResponseSchema,
+  ucp: UcpCheckoutResponseSchema,
 });
 export type CheckoutWithBuyerConsentResponse = z.infer<
   typeof CheckoutWithBuyerConsentResponseSchema
@@ -1547,7 +1584,7 @@ export const CheckoutWithDiscountResponseSchema = z.object({
       }
     }
   }),
-  ucp: UcpResponseSchema,
+  ucp: UcpCheckoutResponseSchema,
   discounts: CheckoutWithDiscountResponseDiscountsSchema.optional(),
 });
 export type CheckoutWithDiscountResponse = z.infer<
@@ -1611,7 +1648,7 @@ export const CheckoutWithFulfillmentResponseSchema = z.object({
       }
     }
   }),
-  ucp: UcpResponseSchema,
+  ucp: UcpCheckoutResponseSchema,
   fulfillment: FulfillmentResponseSchema.optional(),
 });
 export type CheckoutWithFulfillmentResponse = z.infer<

--- a/tests/response-payment-handlers.test.js
+++ b/tests/response-payment-handlers.test.js
@@ -325,3 +325,52 @@ test("CheckoutResponseSchema.ucp models payment_handlers, services, and status",
     );
   }
 });
+
+// --- the checkout response type must REQUIRE payment_handlers ---------------
+// ucp.json#/$defs/response_checkout_schema.allOf[1] adds payment_handlers to
+// base's required set, so the checkout-only envelope cannot be the shared one
+// (which keeps everything optional so order/cart/catalog are not false-rejected).
+
+test("CheckoutResponseSchema.ucp REQUIRES payment_handlers", () => {
+  const checkoutWithoutHandlers = {
+    id: "co_1",
+    currency: "USD",
+    status: "completed",
+    totals: [
+      { type: "subtotal", amount: 100 },
+      { type: "total", amount: 100 },
+    ],
+    links: [],
+    line_items: [],
+    ucp: { version: "2026-04-08" }, // no payment_handlers -> must reject
+  };
+  assert.ok(rejects(CheckoutResponseSchema, checkoutWithoutHandlers));
+});
+
+test("CheckoutResponseSchema.ucp accepts payment_handlers when present", () => {
+  const checkoutWithHandlers = {
+    id: "co_1",
+    currency: "USD",
+    status: "completed",
+    totals: [
+      { type: "subtotal", amount: 100 },
+      { type: "total", amount: 100 },
+    ],
+    links: [],
+    line_items: [],
+    ucp: {
+      version: "2026-04-08",
+      payment_handlers: {
+        "com.example": [{ id: "h", version: "2026-04-08" }],
+      },
+    },
+  };
+  assert.ok(accepts(CheckoutResponseSchema, checkoutWithHandlers));
+});
+
+// The shared envelope stays permissive so order/cart/catalog responses are not
+// false-rejected: they must still pass with a bare ucp { version }.
+
+test("shared UcpResponseSchema keeps payment_handlers optional for other responses", () => {
+  assert.ok(accepts(UcpResponseSchema, { version: "2026-04-08" }));
+});


### PR DESCRIPTION
## Description

`scripts/project-current-ucp-schemas.mjs` derives one shared response envelope (`discovery/ucp_response.json`) and aliases it for the checkout/order/cart/catalog responses. The envelope models `base`'s own required-ness (only `version`), so `payment_handlers` ends up OPTIONAL everywhere — including on the checkout response, whose `ucp.json#/$defs/response_checkout_schema.allOf[1]` adds `payment_handlers` to the required set. The script itself flags this:

> payment_handlers is therefore OPTIONAL here even though response_checkout_schema requires it — enforcing the checkout-only requirement needs a distinct type and is filed as a follow-up

Net effect: `CheckoutResponseSchema` accepts a checkout response whose `ucp` carries no `payment_handlers` at all, though the spec requires it.

**Fix:**
- `buildResponseEnvelopeSchema(ucpSchema, extraRequired)` plus a distinct `UcpCheckoutResponseSchema` (`discovery/ucp_checkout_response.json`) whose `payment_handlers` is required; only the checkout response types alias it.
- order/cart/catalog keep the shared permissive envelope, so they are not false-rejected.
- `generate_models.sh` now formats the generated file with the repo's `.prettierrc` (the checked-in output is Prettier-formatted; without this step regeneration differs by formatting noise across the whole file), keeping regeneration idempotent and the diff minimal.

## Category (Required)
- [ ] **Core Protocol**: A change to the Core Protocol or an Extension. (Requires Technical Council approval)
- [ ] **Governance/Contributing**: Changes to contribution guidelines, governance, or community documents. (Requires Governance Council approval)
- [ ] **Capability**: A change to a core capability, or configuration deployed alongside a capability. (Requires Maintainer approval)
- [ ] **Documentation**: Documentation-only updates or technical writing. (Requires Maintainer approval)
- [ ] **Infrastructure**: Changes to build & release tooling, CI/CD pipelines, or repository infrastructure. (Requires DevOps Maintainer approval)
- [ ] **Maintenance**: Dependency updates, small housekeeping, security patches. (Requires DevOps Maintainer approval)
- [x] **SDK**: Language-specific SDK updates and releases. (Requires DevOps Maintainer approval)
- [ ] **Samples / Conformance**: Maintaining samples and the conformance suite. (Requires Maintainer approval)
- [ ] **UCP Schema**: Changes to the ucp-schema tool. (Requires Maintainer approval)
- [ ] **Community Health (.github)**: Changes to community health files. (Requires DevOps Maintainer approval)

## Related Issues
N/A

## Checklist
- [x] I have followed the Contributing Guide.
- [x] I have updated the documentation (if applicable).
- [x] My changes pass all local linting and formatting checks.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] (For Core/Capability) I have included/updated the relevant JSON schemas. (N/A)
- [x] I have regenerated Python Pydantic models by running generate_models.sh under python_sdk. (N/A — no Python code changed; regenerated js-sdk `src/spec_generated.ts`.)

## Screenshots / Logs (if applicable)
N/A — `npm test` 85/85 pass; `npm run build:noEmit` clean; regeneration is idempotent (repeat `npm run generate` yields the same diff: +50/-13 in `src/spec_generated.ts`).
