### PR TITLE
docs: point model generation to UCP repo root

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,11 +99,11 @@ don't have one, you can clone it via:
 git clone https://github.com/Universal-Commerce-Protocol/ucp.git
 ```
 
-Then, run `npm run generate` pointing to the `spec` folder of the cloned
-repository, e.g.:
+Then, run `npm run generate` pointing to the root of the cloned repository,
+e.g.:
 
 ```bash
-npm run generate -- ucp/spec
+npm run generate -- ucp
 ```
 
 ### Building


### PR DESCRIPTION
## Description

The model generation instructions clone the current UCP repository, then pass
`ucp/spec` to the generator:

```bash
npm run generate -- ucp/spec
```

The current repository stores schemas under `source/schemas/shopping`, so the
cloned repository has no `spec` directory. `generate_models.sh` already accepts
the repository root and resolves that current layout itself; passing `ucp/spec`
ends with `Error: could not find a supported UCP schema directory.`

**Fix:** point the command and its surrounding text to the cloned UCP repository
root (`ucp`).

## Category (Required)

- [ ] **Core Protocol**: Changes to the core UCP specification. (Requires Technical Council approval)
- [ ] **Governance/Contributing**: Changes to governance or contribution processes. (Requires Governance Council approval)
- [ ] **Capability**: Changes to a UCP capability. (Requires Maintainer approval)
- [x] **Documentation**: Documentation-only changes. (Requires Maintainer approval)
- [ ] **Infrastructure**: CI, build, or deployment changes. (Requires DevOps Maintainer approval)
- [ ] **Maintenance**: Dependency or repository maintenance. (Requires DevOps Maintainer approval)
- [ ] **SDK**: Language-specific SDK updates and releases. (Requires DevOps Maintainer approval)
- [ ] **Samples / Conformance**: Maintaining samples and the conformance suite. (Requires Maintainer approval)
- [ ] **UCP Schema**: Changes to the ucp-schema tool. (Requires Maintainer approval)
- [ ] **Community Health (.github)**: Organization-level community files. (Requires DevOps Maintainer approval)

## Related Issues

N/A

## Checklist

- [x] I have followed the Contributing Guide.
- [x] I have updated the documentation (if applicable).
- [x] My changes pass all local linting and formatting checks.
- [x] I have added tests that prove my fix is effective or that my feature works, or documented why no new test is needed.
- [x] New and existing unit tests pass locally with my changes.
- [ ] (For Core/Capability) I have included/updated the relevant JSON schemas.
- [ ] I have regenerated Python Pydantic models by running `generate_models.sh` under `python_sdk` (not applicable).

## Screenshots / Logs (if applicable)

N/A — documentation-only command correction. The old argument exits with status 1;
the repository-root argument completes model generation, and regeneration from
the pinned `release/2026-04-08` schemas leaves `src/spec_generated.ts` unchanged.
