### PR TITLE
fix: enforce per-variant required fields on collapsed message unions

### DIFF
--- a/scripts/inject-schema-constraints.mjs
+++ b/scripts/inject-schema-constraints.mjs
@@ -381,6 +381,13 @@ const minPropertiesIndex = new Map();
 // is left untouched. setKey -> Map(signature -> rules).
 const conditionalIndex = new Map();
 
+// Per-variant required rules recovered from discriminated variant unions
+// (recordVariantUnionRules), keyed by the UNION property set -- the property
+// set of the z.object quicktype collapses the union into. Kept separate from
+// conditionalIndex; see recordVariantUnionRules for the interplay rules.
+// setKey -> Map(signature -> rules).
+const variantUnionIndex = new Map();
+
 function recordObject(properties, file, propertyFiles) {
   const setKey = Object.keys(properties).sort().join(",");
   if (!constraintIndex.has(setKey)) {
@@ -635,6 +642,196 @@ function recordConditionalRules(node, properties) {
   conditionalIndex.get(setKey).set(signature, rules);
 }
 
+/**
+ * Resolve a union branch to its full variant form: properties, per-property
+ * source files, and the variant's own `required` list ($ref and allOf
+ * followed, like resolveObject, which does not collect `required`).
+ */
+function resolveVariant(node, file, seen = new Set(), depth = 0) {
+  if (!node || typeof node !== "object" || depth > 32) {
+    return null;
+  }
+  if (typeof node.$ref === "string") {
+    const key = `${file}|${node.$ref}`;
+    if (seen.has(key)) {
+      return null;
+    }
+    seen.add(key);
+    const resolved = resolveRef(node.$ref, file);
+    return resolveVariant(resolved.node, resolved.file, seen, depth + 1);
+  }
+  let properties = {};
+  let propertyFiles = {};
+  let required = [];
+  if (Array.isArray(node.allOf)) {
+    for (const sub of node.allOf) {
+      const resolved = resolveVariant(sub, file, new Set(seen), depth + 1);
+      if (resolved) {
+        properties = { ...resolved.properties, ...properties };
+        propertyFiles = { ...resolved.propertyFiles, ...propertyFiles };
+        required = [...new Set([...required, ...resolved.required])];
+      }
+    }
+  }
+  if (node.properties && typeof node.properties === "object") {
+    properties = { ...properties, ...node.properties };
+    for (const name of Object.keys(node.properties)) {
+      propertyFiles[name] = file;
+    }
+  }
+  if (Array.isArray(node.required)) {
+    const own = node.required.filter((name) => typeof name === "string");
+    required = [...new Set([...required, ...own])];
+  }
+  return Object.keys(properties).length
+    ? { properties, propertyFiles, required, file }
+    : null;
+}
+
+/** Literal scalar `const` of a property node, following $ref. */
+function resolveConstValue(node, file, seen = new Set(), depth = 0) {
+  if (!node || typeof node !== "object" || depth > 32) {
+    return undefined;
+  }
+  if (typeof node.$ref === "string") {
+    const key = `${file}|${node.$ref}`;
+    if (seen.has(key)) {
+      return undefined;
+    }
+    seen.add(key);
+    const resolved = resolveRef(node.$ref, file);
+    return resolveConstValue(resolved.node, resolved.file, seen, depth + 1);
+  }
+  const value = node.const;
+  return typeof value === "string" ||
+    typeof value === "number" ||
+    typeof value === "boolean"
+    ? value
+    : undefined;
+}
+
+/**
+ * A oneOf/anyOf of complete object variants discriminated by a shared
+ * required const property (types/message.json: the error/warning/info
+ * variants each pin `type` and declare their own `required` list). quicktype
+ * collapses such a union into ONE z.object carrying the UNION of the variant
+ * property sets and the INTERSECTION of their required lists, so every
+ * per-variant `required` is dropped: an error message parses without its
+ * mandatory `code`/`severity`. Recover the per-variant lists as
+ * conditional-required rules keyed on the discriminator const and indexed
+ * under the UNION property set (the collapsed object's set), enforced by the
+ * existing conditional superRefine.
+ *
+ * The rules live in their own index (variantUnionIndex), not in
+ * conditionalIndex: a union's own constituent variants are walked as plain
+ * objects and record EMPTY if/then rule lists, and when one variant subsumes
+ * the others its property set EQUALS the union set, so sharing the index
+ * would make every such union self-ambiguous. An empty if/then record is
+ * absence of evidence, not a conflict (per-field descriptors treat
+ * unconstrained same-shape occurrences the same way). Real conflicts still
+ * veto injection: two variant unions resolving to the same property set with
+ * different rules are ambiguous, and a property set claimed by BOTH an
+ * if/then rule list and a variant union injects neither.
+ *
+ * Strictly gated so a union this cannot faithfully represent contributes
+ * nothing: every branch must resolve to an object, share a discriminator that
+ * is required in every branch and carries a DISTINCT scalar const per branch
+ * (fulfillment_destination and the discovery profile union have no such
+ * discriminator and are skipped; the service transport anyOf never requires
+ * its discriminator inside the branches and is skipped).
+ */
+function recordVariantUnionRules(node, file) {
+  if (!node || typeof node !== "object") {
+    return;
+  }
+  const branches = Array.isArray(node.oneOf) ? node.oneOf : node.anyOf;
+  if (
+    !Array.isArray(branches) ||
+    branches.length < 2 ||
+    node.properties !== undefined ||
+    node.allOf !== undefined ||
+    "if" in node ||
+    "then" in node ||
+    "else" in node
+  ) {
+    return;
+  }
+  const variants = [];
+  for (const branch of branches) {
+    const variant = resolveVariant(branch, file);
+    if (!variant) {
+      return;
+    }
+    variants.push(variant);
+  }
+  // Discriminator: present and required in every variant, with a distinct
+  // scalar const per variant. Candidates are tried in sorted order so the
+  // choice is deterministic.
+  const candidateNames = Object.keys(variants[0].properties)
+    .filter((name) =>
+      variants.every(
+        (variant) =>
+          name in variant.properties && variant.required.includes(name)
+      )
+    )
+    .sort();
+  let discriminator = null;
+  let values = null;
+  for (const name of candidateNames) {
+    const consts = variants.map((variant) =>
+      resolveConstValue(
+        variant.properties[name],
+        variant.propertyFiles[name] || variant.file
+      )
+    );
+    if (
+      consts.every((value) => value !== undefined) &&
+      new Set(consts).size === variants.length
+    ) {
+      discriminator = name;
+      values = consts;
+      break;
+    }
+  }
+  if (!discriminator) {
+    return;
+  }
+  const unionNames = new Set();
+  for (const variant of variants) {
+    for (const name of Object.keys(variant.properties)) {
+      unionNames.add(name);
+    }
+  }
+  const rules = [];
+  for (const [index, variant] of variants.entries()) {
+    if (!variant.required.length) {
+      continue;
+    }
+    rules.push({
+      kind: "required",
+      discriminator,
+      values: [values[index]],
+      negated: false,
+      required: [...variant.required].sort(),
+    });
+  }
+  if (
+    !rules.length ||
+    !rules.every((rule) =>
+      rule.required.every((name) => unionNames.has(name))
+    )
+  ) {
+    return;
+  }
+  rules.sort((left, right) =>
+    JSON.stringify(left).localeCompare(JSON.stringify(right))
+  );
+  const setKey = [...unionNames].sort().join(",");
+  const signature = JSON.stringify(rules);
+  if (!variantUnionIndex.has(setKey)) variantUnionIndex.set(setKey, new Map());
+  variantUnionIndex.get(setKey).set(signature, rules);
+}
+
 function walkSchema(node, file, seen = new Set(), depth = 0) {
   if (!node || typeof node !== "object" || depth > 64) {
     return;
@@ -660,6 +857,7 @@ function walkSchema(node, file, seen = new Set(), depth = 0) {
     recordMinProperties(node, resolvedObject.properties);
     recordConditionalRules(node, resolvedObject.properties);
   }
+  recordVariantUnionRules(node, file);
   if (node.properties && typeof node.properties === "object") {
     for (const child of Object.values(node.properties)) {
       walkSchema(child, file, new Set(seen), depth + 1);
@@ -756,6 +954,27 @@ for (const [setKey, bySignature] of conditionalIndex) {
   } else {
     ambiguous.push({ setKey, name: "<conditional>", count: bySignature.size });
   }
+}
+
+// Variant-union rules resolve like the other indexes: a single agreed rule
+// list per property set, or nothing. A set claimed by BOTH an if/then rule
+// list and a variant union is a cross-index conflict: neither is injected.
+const resolvedVariantUnions = new Map();
+for (const [setKey, bySignature] of variantUnionIndex) {
+  if (bySignature.size !== 1) {
+    ambiguous.push({
+      setKey,
+      name: "<variant-union>",
+      count: bySignature.size,
+    });
+    continue;
+  }
+  if (resolvedConditionals.has(setKey)) {
+    resolvedConditionals.delete(setKey);
+    ambiguous.push({ setKey, name: "<variant-union/conditional>", count: 2 });
+    continue;
+  }
+  resolvedVariantUnions.set(setKey, [...bySignature.values()][0]);
 }
 
 // --- Shared {id,quantity} line-item reference: contextual split --------------
@@ -1194,7 +1413,10 @@ function handleObjectLiteral(objectLiteral) {
   const resolvedProperties = resolvedIndex.get(setKey);
   const propertyNamesDescriptor = resolvedPropertyNames.get(setKey);
   const minPropertiesDescriptor = resolvedMinProperties.get(setKey);
-  const conditionalRules = resolvedConditionals.get(setKey);
+  // If/then rules and variant-union rules render through the same conditional
+  // superRefine; cross-index conflicts were already resolved to neither.
+  const conditionalRules =
+    resolvedConditionals.get(setKey) ?? resolvedVariantUnions.get(setKey);
   if (
     !resolvedProperties &&
     !propertyNamesDescriptor &&

--- a/src/spec_generated.ts
+++ b/src/spec_generated.ts
@@ -310,17 +310,91 @@ export const LinkSchema = z.object({
 });
 export type Link = z.infer<typeof LinkSchema>;
 
-export const CheckoutResponseMessageSchema = z.object({
-  code: z.string().optional(),
-  content: z.string(),
-  content_type: ContentTypeSchema.optional(),
-  path: z.string().optional(),
-  severity: SeveritySchema.optional(),
-  type: MessageTypeSchema,
-  image_url: z.string().optional(),
-  presentation: z.string().optional(),
-  url: z.string().optional(),
-});
+export const CheckoutResponseMessageSchema = z
+  .object({
+    code: z.string().optional(),
+    content: z.string(),
+    content_type: ContentTypeSchema.optional(),
+    path: z.string().optional(),
+    severity: SeveritySchema.optional(),
+    type: MessageTypeSchema,
+    image_url: z.string().optional(),
+    presentation: z.string().optional(),
+    url: z.string().optional(),
+  })
+  .superRefine((value, ctx) => {
+    for (const rule of [
+      {
+        kind: "required",
+        discriminator: "type",
+        values: ["error"],
+        negated: false,
+        required: ["code", "content", "severity", "type"],
+        target: null,
+        minimum: null,
+        maximum: null,
+        exclusiveMinimum: null,
+        exclusiveMaximum: null,
+      },
+      {
+        kind: "required",
+        discriminator: "type",
+        values: ["info"],
+        negated: false,
+        required: ["content", "type"],
+        target: null,
+        minimum: null,
+        maximum: null,
+        exclusiveMinimum: null,
+        exclusiveMaximum: null,
+      },
+      {
+        kind: "required",
+        discriminator: "type",
+        values: ["warning"],
+        negated: false,
+        required: ["code", "content", "type"],
+        target: null,
+        minimum: null,
+        maximum: null,
+        exclusiveMinimum: null,
+        exclusiveMaximum: null,
+      },
+    ]) {
+      const record = value as Record<string, unknown>;
+      const discriminatorVal = record[rule.discriminator];
+      if (discriminatorVal === undefined) continue;
+      const matches = (rule.values as readonly unknown[]).includes(
+        discriminatorVal
+      );
+      if (rule.negated ? matches : !matches) continue;
+      if (rule.kind === "required") {
+        for (const field of rule.required) {
+          if (!(field in record))
+            ctx.addIssue({
+              code: z.ZodIssueCode.custom,
+              path: [field],
+              message: "Field is required by a conditional constraint",
+            });
+        }
+        continue;
+      }
+      if (rule.target === null) continue;
+      const target = record[rule.target];
+      if (typeof target !== "number") continue;
+      const invalid =
+        (rule.minimum !== null && target < rule.minimum) ||
+        (rule.maximum !== null && target > rule.maximum) ||
+        (rule.exclusiveMinimum !== null && target <= rule.exclusiveMinimum) ||
+        (rule.exclusiveMaximum !== null && target >= rule.exclusiveMaximum);
+      if (invalid)
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: [rule.target],
+          message: "Value violates a conditional numeric constraint",
+        });
+    }
+  });
 export type CheckoutResponseMessage = z.infer<
   typeof CheckoutResponseMessageSchema
 >;

--- a/tests/injector-idempotency.test.js
+++ b/tests/injector-idempotency.test.js
@@ -128,3 +128,74 @@ test("the date-time conversion applies once and is idempotent", () => {
     "a second pass must not re-apply the conversion"
   );
 });
+
+// Variant-union recovery goes through the conditional superRefine path; its
+// idempotency rests on conditionalAlreadyConstrained recognising the emitted
+// message on a re-run.
+test("the variant-union required rules apply once and are idempotent", () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "ucp-injector-vu-"));
+  const schemaDir = path.join(dir, "schemas");
+  fs.mkdirSync(schemaDir);
+  fs.writeFileSync(
+    path.join(schemaDir, "message.json"),
+    JSON.stringify({
+      $id: "https://ucp.dev/schemas/message.json",
+      title: "Message",
+      type: "object",
+      oneOf: [
+        {
+          type: "object",
+          required: ["type", "code", "content", "severity"],
+          properties: {
+            type: { type: "string", const: "error" },
+            code: { type: "string" },
+            content: { type: "string" },
+            severity: { type: "string" },
+          },
+        },
+        {
+          type: "object",
+          required: ["type", "content"],
+          properties: {
+            type: { type: "string", const: "info" },
+            code: { type: "string" },
+            content: { type: "string" },
+          },
+        },
+      ],
+    })
+  );
+
+  const target = path.join(dir, "spec_generated.ts");
+  fs.writeFileSync(
+    target,
+    'import * as z from "zod";\n' +
+      "\n" +
+      "export const MessageSchema = z.object({\n" +
+      '  type: z.enum(["error", "info"]),\n' +
+      "  code: z.string().optional(),\n" +
+      "  content: z.string(),\n" +
+      "  severity: z.string().optional(),\n" +
+      "});\n"
+  );
+
+  execFileSync("node", [SCRIPT, schemaDir, target], { stdio: "pipe" });
+  const afterFirst = fs.readFileSync(target, "utf8");
+  assert.match(
+    afterFirst,
+    /superRefine/,
+    "the first pass appends the conditional-required refine"
+  );
+  assert.match(
+    afterFirst,
+    /"discriminator":"type"|discriminator: "type"|"discriminator": "type"/,
+    "the rules are keyed on the type discriminator"
+  );
+
+  execFileSync("node", [SCRIPT, schemaDir, target], { stdio: "pipe" });
+  assert.equal(
+    fs.readFileSync(target, "utf8"),
+    afterFirst,
+    "a second pass must not re-apply the variant rules"
+  );
+});

--- a/tests/spec-constraints.test.js
+++ b/tests/spec-constraints.test.js
@@ -43,6 +43,8 @@ const {
   AdjustmentLineItemSchema,
   EventLineItemSchema,
   ExpectationLineItemSchema,
+  CheckoutResponseMessageSchema,
+  LookupResponseMessageSchema,
   CheckoutResponseSchema,
   CartResponseSchema,
   FulfillmentEventSchema,
@@ -522,4 +524,77 @@ test("fulfillment option times enforce the same string format", () => {
 test("a date-time field round-trips verbatim (string in, same string out)", () => {
   const wire = "2026-04-08T10:00:00+02:00";
   assert.equal(OccurredAtSchema.parse(wire), wire);
+});
+
+// --- message oneOf: per-variant required fields ------------------------------
+// types/message.json is a oneOf of error/warning/info variants discriminated
+// by a `type` const. Per the source schemas: an error message REQUIRES code,
+// content and severity; a warning REQUIRES code and content; an info only
+// content. quicktype collapses the union into one object with the
+// INTERSECTION of the required lists ({type, content}), so an error message
+// without code/severity used to parse. python-sdk rejects the same input.
+
+const errorMessage = {
+  type: "error",
+  code: "payment_failed",
+  content: "The payment could not be processed.",
+  severity: "recoverable",
+};
+
+test("an error message without code and severity is rejected", () => {
+  assert.ok(
+    rejects(CheckoutResponseMessageSchema, { type: "error", content: "x" })
+  );
+});
+
+test("an error message without severity is rejected", () => {
+  const { severity, ...noSeverity } = errorMessage;
+  assert.ok(rejects(CheckoutResponseMessageSchema, noSeverity));
+});
+
+test("an error message without code is rejected", () => {
+  const { code, ...noCode } = errorMessage;
+  assert.ok(rejects(CheckoutResponseMessageSchema, noCode));
+});
+
+test("a complete error message is accepted", () => {
+  assert.ok(accepts(CheckoutResponseMessageSchema, errorMessage));
+});
+
+test("a warning message without code is rejected", () => {
+  assert.ok(
+    rejects(CheckoutResponseMessageSchema, { type: "warning", content: "x" })
+  );
+});
+
+test("a warning message with code and content is accepted", () => {
+  assert.ok(
+    accepts(CheckoutResponseMessageSchema, {
+      type: "warning",
+      code: "low_stock",
+      content: "Only 2 left.",
+    })
+  );
+});
+
+test("an info message needs only type and content", () => {
+  assert.ok(
+    accepts(CheckoutResponseMessageSchema, { type: "info", content: "x" })
+  );
+  // Variants do not set additionalProperties: false, so optional fields from
+  // the union stay legal on any variant.
+  assert.ok(
+    accepts(CheckoutResponseMessageSchema, {
+      type: "info",
+      content: "x",
+      path: "$.line_items[0]",
+    })
+  );
+});
+
+test("the lookup message alias enforces the same variant rules", () => {
+  assert.ok(
+    rejects(LookupResponseMessageSchema, { type: "error", content: "x" })
+  );
+  assert.ok(accepts(LookupResponseMessageSchema, errorMessage));
 });


### PR DESCRIPTION
## Observed

At main (e4c52bf), an error message without its mandatory fields parses:

```js
const { CheckoutResponseMessageSchema } = require("./tests/.dist/spec_generated.js");
CheckoutResponseMessageSchema.parse({ type: "error", content: "x" });
// -> accepted, though message_error.json requires code, content, severity
CheckoutResponseMessageSchema.parse({ type: "warning", content: "x" });
// -> accepted, though message_warning.json requires code
```

python-sdk (0.4.4, d790602) rejects the identical inputs, so the two SDKs disagree live on an error path payload:

```
PY-MSG-1 {type:error, content:x}  REJECTED (MessageError.code, MessageError.severity missing)
PY-MSG-2 error w/o severity       REJECTED
PY-MSG-5 warning w/o code         REJECTED
PY-MSG-4 full error               ACCEPTED
PY-MSG-7 info minimal             ACCEPTED
```

## Expected

`schemas/shopping/types/message.json` in ucp `release/2026-04-08` (the pinned generation source) is a `oneOf` of three object variants discriminated by a `type` const, each with its own `required` list: error requires type, code, content, severity; warning requires type, code, content; info requires type, content. No variant restricts additional properties, so the per-variant `required` lists are the entire enforceable delta.

## Cause

quicktype collapses the oneOf into one `z.object` carrying the UNION of the variant property sets and the INTERSECTION of their required lists ({type, content}), so every per-variant `required` is dropped.

## Fix

Generator level, in `scripts/inject-schema-constraints.mjs`: a new recognizer (`recordVariantUnionRules`) detects a oneOf or anyOf whose branches all resolve to object variants sharing a discriminator that is required in every branch and carries a distinct scalar const per branch. It derives one conditional-required rule per variant, indexes the rules under the union property set (the property set of the object quicktype collapses the union into), and enforces them through the existing conditional superRefine from #43. The rules live in their own index: a constituent variant records an empty if/then list when walked as a plain object, and a variant that subsumes the others shares the union property set, so empty records do not veto. Real conflicts still inject nothing: two unions resolving to one property set with different rules, or a property set claimed by both if/then rules and a union.

In the generated file only `CheckoutResponseMessageSchema` changes (its alias `LookupResponseMessageSchema` inherits).

## Union sweep (accounting, every oneOf/anyOf in the release source)

| site | disposition |
|---|---|
| types/message.json | ENFORCED by this PR (const discriminated, collapsed) |
| types/fulfillment_destination.json | skipped by the gate: no const discriminator (shipping vs retail); enforcement needs full variant validation, a separate change |
| service.json platform/business/response anyOf | skipped by the gate: the transport branches never require the discriminator; also quicktype dedups all three service variants into one ServiceResponseSchema with conflicting rules, so any set-keyed injection would be ambiguous. Known residual: js accepts a business service with transport mcp and no endpoint, python rejects it because it generates separate classes per variant. Needs a generated-schema split, out of scope here |
| capability.json extends oneOf | already correct: rendered as a type union |
| discovery/profile_schema.json anyOf | skipped by the gate: no const discriminator (platform vs business profile) |
| shopping/fulfillment.json embedded method result oneOf | outside the generation roots |

## Tests

Eight behavior tests (the three rejection classes, full error, warning with code, minimal info, extra optional fields stay legal on a variant, the lookup alias) plus a variant-union idempotency test that also pins the superset-variant shape. Suite grows 93 to 102, all green. Regeneration from `release/2026-04-08` is byte identical, so the model-drift job passes.
