### PR TITLE
fix: enforce discovery version constraints

### DIFF
--- a/generate_models.sh
+++ b/generate_models.sh
@@ -123,6 +123,9 @@ node scripts/inject-schema-constraints.mjs "$RAW_CONSTRAINT_SCHEMA_DIR" src/spec
 if [[ -n "$PROJECTED_CONSTRAINT_SCHEMA_DIR" ]]; then
   node scripts/inject-schema-constraints.mjs "$PROJECTED_CONSTRAINT_SCHEMA_DIR" src/spec_generated.ts
 fi
+if [[ -d "$SPEC_DIR/discovery" ]]; then
+  node scripts/inject-schema-constraints.mjs "$SPEC_DIR/discovery" src/spec_generated.ts
+fi
 
 # Format the generated output to match the repo's Prettier config (the checked-in
 # file is formatted with .prettierrc; without this step regenerated output drifts

--- a/scripts/project-current-ucp-schemas.mjs
+++ b/scripts/project-current-ucp-schemas.mjs
@@ -707,6 +707,8 @@ function writeCompatibilityDiscoverySchemas() {
     "capability.json": capabilitySchema,
   };
 
+  const version = ucpSchema.$defs.version;
+
   const signingKey = {
     $schema: "https://json-schema.org/draft/2020-12/schema",
     title: "Signing Key",
@@ -756,7 +758,7 @@ function writeCompatibilityDiscoverySchemas() {
       name: { type: "string" },
       schema: { type: "string" },
       spec: { type: "string" },
-      version: { type: "string" },
+      version: clone(version),
     },
   };
 
@@ -804,7 +806,7 @@ function writeCompatibilityDiscoverySchemas() {
         },
       },
       spec: { type: "string" },
-      version: { type: "string" },
+      version: clone(version),
     },
   };
 
@@ -858,7 +860,7 @@ function writeCompatibilityDiscoverySchemas() {
             type: "object",
             additionalProperties: { $ref: "ucp_service.json" },
           },
-          version: { type: "string" },
+          version: clone(version),
         },
       },
     },

--- a/src/spec_generated.ts
+++ b/src/spec_generated.ts
@@ -121,7 +121,7 @@ export const CapabilityDiscoverySchema = z.object({
   name: z.string(),
   schema: z.string(),
   spec: z.string(),
-  version: z.string(),
+  version: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
 });
 export type CapabilityDiscovery = z.infer<typeof CapabilityDiscoverySchema>;
 
@@ -783,7 +783,7 @@ export const UcpServiceSchema = z.object({
   mcp: McpSchema.optional(),
   rest: RestSchema.optional(),
   spec: z.string(),
-  version: z.string(),
+  version: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
 });
 export type UcpService = z.infer<typeof UcpServiceSchema>;
 
@@ -1316,7 +1316,7 @@ export type Payment = z.infer<typeof PaymentSchema>;
 export const UcpSchema = z.object({
   capabilities: z.array(CapabilityDiscoverySchema),
   services: z.record(z.string(), UcpServiceSchema),
-  version: z.string(),
+  version: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
 });
 export type Ucp = z.infer<typeof UcpSchema>;
 

--- a/tests/spec-constraints.test.js
+++ b/tests/spec-constraints.test.js
@@ -50,6 +50,7 @@ const {
   FulfillmentEventSchema,
   AdjustmentSchema,
   FulfillmentOptionSchema,
+  UcpSchema,
 } = require("./.dist/spec_generated.js");
 
 const accepts = (schema, value) => schema.safeParse(value).success === true;
@@ -412,6 +413,12 @@ test("CapabilityResponseSchema accepts valid extends names", () => {
       extends: ["dev.ucp.checkout", "com.example_capability.v1"],
     })
   );
+});
+
+test("UcpSchema enforces the discovery version pattern", () => {
+  const discovery = { capabilities: [], services: {} };
+  assert.ok(rejects(UcpSchema, { ...discovery, version: "not-a-date" }));
+  assert.ok(accepts(UcpSchema, { ...discovery, version: "2026-04-08" }));
 });
 
 test("CapabilityResponseSchema enforces the entity version pattern", () => {


### PR DESCRIPTION
## Description

`UcpSchema.version` in the generated discovery profile type accepted any string even though `ucp.json#/$defs/version` defines UCP versions as `YYYY-MM-DD`:

```ts
UcpSchema.safeParse({
  version: "not-a-date",
  capabilities: [],
  services: {},
}).success === true
```

The response envelope already recovered the same source `version` pattern, but the discovery compatibility schema lived under `discovery/`, while the post-generation constraint injection only scanned the projected `schemas/` tree.

**Fix:** carry the source `version` definition into the projected discovery schemas, scan the projected discovery files during constraint injection, regenerate the Zod output, and add a regression test for `UcpSchema`.

## Category (Required)

- [ ] **Core Protocol**: Changes to core UCP schemas, specification, or protocol behavior. (Requires Technical Council approval)
- [ ] **Governance/Contributing**: Updates to governance documents, contribution guidelines, or project processes. (Requires Governance Council approval)
- [ ] **Capability**: New or updated capability definitions. (Requires Maintainer approval)
- [ ] **Documentation**: Documentation-only changes. (Requires Maintainer approval)
- [ ] **Infrastructure**: CI/CD, build tooling, or repository automation. (Requires DevOps Maintainer approval)
- [ ] **Maintenance**: Dependency updates, refactoring, or non-functional changes. (Requires DevOps Maintainer approval)
- [x] **SDK**: Language-specific SDK updates and releases. (Requires DevOps Maintainer approval)
- [ ] **Samples / Conformance**: Maintaining samples and the conformance suite. (Requires Maintainer approval)
- [ ] **UCP Schema**: Changes to the ucp-schema tool. (Requires Maintainer approval)
- [ ] **Community Health (.github)**: Issue templates, code of conduct, or community files. (Requires DevOps Maintainer approval)

## Related Issues

N/A

## Checklist

- [x] I have followed the Contributing Guide and Code of Conduct.
- [x] I have updated the documentation (if applicable).
- [x] My changes pass all local linting and formatting checks.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] (For Core/Capability) I have included/updated the relevant JSON schemas.
- [ ] I have regenerated Python Pydantic models by running generate_models.sh under python_sdk.

## Screenshots / Logs (if applicable)

- `npm test` (106/106)
- `npm run build:noEmit`
- `npm run build`
- `npm run generate -- /tmp/ucp-pinned-2026-04-08` (idempotent)
- `uvx pre-commit run --all-files`
- `git diff --check`
