### PR TITLE
fix: enforce discovery URI constraints

### DIFF
--- a/scripts/project-current-ucp-schemas.mjs
+++ b/scripts/project-current-ucp-schemas.mjs
@@ -708,6 +708,8 @@ function writeCompatibilityDiscoverySchemas() {
   };
 
   const version = ucpSchema.$defs.version;
+  const entityProperties = ucpSchema.$defs.entity.properties;
+  const serviceEndpoint = serviceSchema.$defs.base.allOf[1].properties.endpoint;
 
   const signingKey = {
     $schema: "https://json-schema.org/draft/2020-12/schema",
@@ -756,8 +758,8 @@ function writeCompatibilityDiscoverySchemas() {
       config: { type: "object", additionalProperties: true },
       extends: { type: "string" },
       name: { type: "string" },
-      schema: { type: "string" },
-      spec: { type: "string" },
+      schema: clone(entityProperties.schema),
+      spec: clone(entityProperties.spec),
       version: clone(version),
     },
   };
@@ -782,30 +784,30 @@ function writeCompatibilityDiscoverySchemas() {
       a2a: {
         type: "object",
         required: ["endpoint"],
-        properties: { endpoint: { type: "string" } },
+        properties: { endpoint: clone(serviceEndpoint) },
       },
       embedded: {
         type: "object",
         required: ["schema"],
-        properties: { schema: { type: "string" } },
+        properties: { schema: clone(entityProperties.schema) },
       },
       mcp: {
         type: "object",
         required: ["endpoint", "schema"],
         properties: {
-          endpoint: { type: "string" },
-          schema: { type: "string" },
+          endpoint: clone(serviceEndpoint),
+          schema: clone(entityProperties.schema),
         },
       },
       rest: {
         type: "object",
         required: ["endpoint", "schema"],
         properties: {
-          endpoint: { type: "string" },
-          schema: { type: "string" },
+          endpoint: clone(serviceEndpoint),
+          schema: clone(entityProperties.schema),
         },
       },
-      spec: { type: "string" },
+      spec: clone(entityProperties.spec),
       version: clone(version),
     },
   };

--- a/src/spec_generated.ts
+++ b/src/spec_generated.ts
@@ -119,25 +119,25 @@ export const CapabilityDiscoverySchema = z.object({
   config: z.record(z.string(), z.any()).optional(),
   extends: z.string().optional(),
   name: z.string(),
-  schema: z.string(),
-  spec: z.string(),
+  schema: z.string().url(),
+  spec: z.string().url(),
   version: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
 });
 export type CapabilityDiscovery = z.infer<typeof CapabilityDiscoverySchema>;
 
 export const A2ASchema = z.object({
-  endpoint: z.string(),
+  endpoint: z.string().url(),
 });
 export type A2A = z.infer<typeof A2ASchema>;
 
 export const EmbeddedSchema = z.object({
-  schema: z.string(),
+  schema: z.string().url(),
 });
 export type Embedded = z.infer<typeof EmbeddedSchema>;
 
 export const SchemaEndpointSchema = z.object({
-  endpoint: z.string(),
-  schema: z.string(),
+  endpoint: z.string().url(),
+  schema: z.string().url(),
 });
 export type SchemaEndpoint = z.infer<typeof SchemaEndpointSchema>;
 export const McpSchema = SchemaEndpointSchema;
@@ -782,7 +782,7 @@ export const UcpServiceSchema = z.object({
   embedded: EmbeddedSchema.optional(),
   mcp: McpSchema.optional(),
   rest: RestSchema.optional(),
-  spec: z.string(),
+  spec: z.string().url(),
   version: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
 });
 export type UcpService = z.infer<typeof UcpServiceSchema>;

--- a/tests/spec-constraints.test.js
+++ b/tests/spec-constraints.test.js
@@ -51,6 +51,11 @@ const {
   AdjustmentSchema,
   FulfillmentOptionSchema,
   UcpSchema,
+  CapabilityDiscoverySchema,
+  A2ASchema,
+  EmbeddedSchema,
+  SchemaEndpointSchema,
+  UcpServiceSchema,
 } = require("./.dist/spec_generated.js");
 
 const accepts = (schema, value) => schema.safeParse(value).success === true;
@@ -419,6 +424,56 @@ test("UcpSchema enforces the discovery version pattern", () => {
   const discovery = { capabilities: [], services: {} };
   assert.ok(rejects(UcpSchema, { ...discovery, version: "not-a-date" }));
   assert.ok(accepts(UcpSchema, { ...discovery, version: "2026-04-08" }));
+});
+
+test("discovery declarations enforce URI fields", () => {
+  assert.ok(
+    rejects(CapabilityDiscoverySchema, {
+      name: "dev.ucp.shopping.checkout",
+      schema: "/schemas/checkout.json",
+      spec: "not-a-url",
+      version: "2026-04-08",
+    })
+  );
+  assert.ok(rejects(A2ASchema, { endpoint: "agent.example/a2a" }));
+  assert.ok(rejects(EmbeddedSchema, { schema: "./embedded.json" }));
+  assert.ok(
+    rejects(SchemaEndpointSchema, {
+      endpoint: "merchant.example/ucp",
+      schema: "/openapi.json",
+    })
+  );
+  assert.ok(
+    rejects(UcpServiceSchema, {
+      spec: "specification/overview",
+      version: "2026-04-08",
+    })
+  );
+
+  assert.ok(
+    accepts(CapabilityDiscoverySchema, {
+      name: "dev.ucp.shopping.checkout",
+      schema: "https://ucp.dev/schemas/shopping/checkout.json",
+      spec: "https://ucp.dev/specification/checkout",
+      version: "2026-04-08",
+    })
+  );
+  assert.ok(accepts(A2ASchema, { endpoint: "https://agent.example/a2a" }));
+  assert.ok(
+    accepts(EmbeddedSchema, { schema: "https://agent.example/embedded.json" })
+  );
+  assert.ok(
+    accepts(SchemaEndpointSchema, {
+      endpoint: "https://merchant.example/ucp",
+      schema: "https://merchant.example/openapi.json",
+    })
+  );
+  assert.ok(
+    accepts(UcpServiceSchema, {
+      spec: "https://ucp.dev/specification/overview",
+      version: "2026-04-08",
+    })
+  );
 });
 
 test("CapabilityResponseSchema enforces the entity version pattern", () => {


### PR DESCRIPTION
## Description

The discovery compatibility schemas generated `spec`, `schema`, and `endpoint` as unconstrained strings, even though the pinned source schemas declare these fields with `format: uri`:

```ts
CapabilityDiscoverySchema.safeParse({
  name: "dev.ucp.shopping.checkout",
  schema: "/schemas/checkout.json",
  spec: "not-a-url",
  version: "2026-04-08",
}).success === true
```

The response entity projections already produce `.url()` for the same source fields. The discovery projection retained the version pattern after #56, but still replaced URI fields with bare `{ type: "string" }` definitions.

**Fix:** derive discovery `spec`/`schema`/`endpoint` definitions from the pinned entity and service schemas, regenerate the Zod output, and cover capability, service, and transport declarations with regression assertions.

## Category (Required)

- [ ] **Core Protocol**: Changes to core UCP schemas, specification, or protocol behavior. (Requires Technical Council approval)
- [ ] **Governance/Contributing**: Updates to governance documents, contribution guidelines, or project processes. (Requires Governance Council approval)
- [ ] **Capability**: New or updated capability definitions. (Requires Maintainer approval)
- [ ] **Documentation**: Documentation-only changes. (Requires Maintainer approval)
- [ ] **Infrastructure**: CI/CD, build tooling, or repository automation. (Requires DevOps Maintainer approval)
- [ ] **Maintenance**: Dependency updates, refactoring, or non-functional changes. (Requires DevOps Maintainer approval)
- [x] **SDK**: Language-specific SDK updates and releases. (Requires DevOps Maintainer approval)
- [ ] **Samples / Conformance**: Maintaining samples and the conformance suite. (Requires Maintainer approval)
- [ ] **UCP Schema**: Changes to the ucp-schema tool. (Requires Maintainer approval)
- [ ] **Community Health (.github)**: Issue templates, code of conduct, or community files. (Requires DevOps Maintainer approval)

## Related Issues

N/A

## Checklist

- [x] I have followed the Contributing Guide and Code of Conduct.
- [x] I have updated the documentation (if applicable).
- [x] My changes pass all local linting and formatting checks.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] (For Core/Capability) I have included/updated the relevant JSON schemas.
- [ ] I have regenerated Python Pydantic models by running generate_models.sh under python_sdk.

## Screenshots / Logs (if applicable)

- `npm test` (107/107)
- `npm run build:noEmit`
- `npm run build`
- fixed-version regeneration against `v2026-04-08` (idempotent)
- `uvx pre-commit run --all-files`
- `git diff --check`
