### PR TITLE
fix: preserve unit price measure number type

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@ucp-js/sdk",
-  "version": "0.4.5",
+  "version": "0.4.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@ucp-js/sdk",
-      "version": "0.4.5",
+      "version": "0.4.6",
       "license": "Apache-2.0",
       "dependencies": {
         "zod": "^3.23.8"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ucp-js/sdk",
-  "version": "0.4.5",
+  "version": "0.4.6",
   "description": "UCP SDK for JavaScript",
   "license": "Apache-2.0",
   "main": "./dist/cjs/index.js",

--- a/scripts/inject-schema-constraints.mjs
+++ b/scripts/inject-schema-constraints.mjs
@@ -444,6 +444,13 @@ function describeStringArrayUnionConstraint(
 // setKey -> Map(propertyName -> Map(signature -> descriptor))
 const constraintIndex = new Map();
 
+// Scalar number kinds are also indexed even when they carry no value constraint.
+// The generic constraint index deliberately omits an unconstrained `number`, but
+// contextual splits must be able to distinguish it from `integer` when quicktype
+// merges two same-shape objects.
+// setKey -> Map(propertyName -> Set("number" | "integer"))
+const scalarTypeIndex = new Map();
+
 // Constrained scalar unions (`string | array<string>`) keyed like field
 // constraints, but rendered by replacing the generated `z.union(...)` call
 // rather than appending one method to a single base constructor.
@@ -484,13 +491,27 @@ function recordObject(properties, file, propertyFiles) {
   if (!constraintIndex.has(setKey)) {
     constraintIndex.set(setKey, new Map());
   }
+  if (!scalarTypeIndex.has(setKey)) {
+    scalarTypeIndex.set(setKey, new Map());
+  }
   const byProperty = constraintIndex.get(setKey);
+  const scalarTypesByProperty = scalarTypeIndex.get(setKey);
   for (const [name, propertyNode] of Object.entries(properties)) {
     // Each property carries the file it was authored in (it may have been
     // inherited into this object via a cross-file `$ref`/`allOf`, in which
     // case its own relative `$ref`s must resolve against that file, not the
     // inheriting object's). Fall back to the object's file when unset.
     const propertyFile = (propertyFiles && propertyFiles[name]) || file;
+    const effective = effectiveConstraints(propertyNode, propertyFile);
+    const scalarType = Array.isArray(effective.type)
+      ? effective.type.find((entry) => entry !== "null")
+      : effective.type;
+    if (scalarType === "number" || scalarType === "integer") {
+      if (!scalarTypesByProperty.has(name)) {
+        scalarTypesByProperty.set(name, new Set());
+      }
+      scalarTypesByProperty.get(name).add(scalarType);
+    }
     const described = describeConstraint(propertyNode, propertyFile);
     if (described) {
       if (!byProperty.has(name)) {
@@ -1133,6 +1154,24 @@ const sharedQuantitySplitNeeded = (() => {
   );
 })();
 
+// --- Shared {unit,value} unit-price measure/reference: contextual split ------
+//
+// A catalog unit price declares two same-shape objects: `measure.value` is a
+// JSON Schema `number`, while `reference.value` is an `integer`. quicktype
+// merges both (and duplicate projected occurrences) into one shared measure
+// object, so the generic ambiguity guard cannot choose whether `.int()` belongs
+// on `value`. Keep the number-shaped measure on `z.number()` and split the two
+// generated reference aliases into standalone integer-valued objects.
+//
+// Trigger only when the source schemas themselves contain both numeric kinds
+// for `value` under the exact {unit,value} shape. Names merely identify the
+// quicktype aliases to repair after that source-evidence gate has passed.
+const REFERENCE_SPLIT_TARGETS = ["FluffyReference", "PurpleReference"];
+const sharedMeasureSplitNeeded = (() => {
+  const valueTypes = scalarTypeIndex.get("unit,value")?.get("value");
+  return valueTypes?.has("number") && valueTypes.has("integer");
+})();
+
 // --- Zod method rendering --------------------------------------------------
 
 function toRegexLiteral(pattern) {
@@ -1617,6 +1656,7 @@ const report = {
   minPropertiesInjected: 0,
   conditionalsInjected: 0,
   sharedQuantityInjected: 0,
+  sharedMeasureInjected: 0,
   fieldsSkippedType: 0,
   fieldsAlreadyDone: 0,
   injections: [],
@@ -1702,6 +1742,17 @@ function handleObjectLiteral(objectLiteral) {
       continue;
     }
     if (!resolvedProperties) {
+      continue;
+    }
+    // The {unit,value} number/integer conflict is resolved by the contextual
+    // split below. Do not queue the generic `.int()` edit on the shared object
+    // in the same pass, because contextual edits are computed from the original
+    // source text and cannot observe another pending edit.
+    if (
+      sharedMeasureSplitNeeded &&
+      setKey === "unit,value" &&
+      name === "value"
+    ) {
       continue;
     }
     const descriptor = resolvedProperties.get(name);
@@ -1878,6 +1929,58 @@ if (sharedQuantitySplitNeeded) {
   }
 }
 
+// Apply the contextual {unit,value} split. The shared measure object may arrive
+// as either unconstrained `z.number()` or incorrectly constrained
+// `z.number().int()` depending on traversal order; normalize it to the source
+// `number`, then replace reference aliases with integer-valued standalone
+// objects. A second injector pass is a no-op because neither pattern remains.
+if (sharedMeasureSplitNeeded) {
+  const sharedObjectStart = sourceText.indexOf(
+    "export const PurpleMeasureSchema = z.object({"
+  );
+  const sharedObjectEnd =
+    sharedObjectStart >= 0
+      ? sourceText.indexOf("\n});", sharedObjectStart)
+      : -1;
+  if (sharedObjectStart >= 0 && sharedObjectEnd >= 0) {
+    const sharedObjectText = sourceText.slice(
+      sharedObjectStart,
+      sharedObjectEnd
+    );
+    const integerValue = /["']?value["']?: z\.number\(\)\.int\(\)/.exec(
+      sharedObjectText
+    );
+    if (integerValue) {
+      edits.push({
+        pos: sharedObjectStart + integerValue.index,
+        remove: integerValue[0].length,
+        text: integerValue[0].replace(".int()", ""),
+      });
+      report.sharedMeasureInjected += 1;
+    }
+  }
+  for (const name of REFERENCE_SPLIT_TARGETS) {
+    const aliasRef = new RegExp(
+      `export const ${name}Schema = PurpleMeasureSchema;`
+    );
+    const matched = aliasRef.exec(sourceText);
+    if (!matched) {
+      continue;
+    }
+    const standalone =
+      `export const ${name}Schema = z.object({\n` +
+      `  unit: z.string(),\n` +
+      `  value: z.number().int(),\n` +
+      `});`;
+    edits.push({
+      pos: matched.index,
+      remove: matched[0].length,
+      text: standalone,
+    });
+    report.sharedMeasureInjected += 1;
+  }
+}
+
 // Apply edits back-to-front so positions stay valid.
 edits.sort((a, b) => b.pos - a.pos);
 let output = sourceText;
@@ -1900,6 +2003,7 @@ process.stdout.write(
     `${report.minPropertiesInjected} object minProperties check(s); ` +
     `${report.conditionalsInjected} conditional check(s); ` +
     `${report.sharedQuantityInjected} shared-quantity split edit(s); ` +
+    `${report.sharedMeasureInjected} shared-measure split edit(s); ` +
     `${report.fieldsAlreadyDone} already constrained; ` +
     `${report.fieldsSkippedType} skipped (base-type mismatch).\n`
 );

--- a/src/spec_generated.ts
+++ b/src/spec_generated.ts
@@ -685,14 +685,20 @@ export type FluffySeller = PurpleSeller;
 
 export const PurpleMeasureSchema = z.object({
   unit: z.string(),
-  value: z.number().int(),
+  value: z.number(),
 });
 export type PurpleMeasure = z.infer<typeof PurpleMeasureSchema>;
 export const FluffyMeasureSchema = PurpleMeasureSchema;
 export type FluffyMeasure = PurpleMeasure;
-export const FluffyReferenceSchema = PurpleMeasureSchema;
+export const FluffyReferenceSchema = z.object({
+  unit: z.string(),
+  value: z.number().int(),
+});
 export type FluffyReference = PurpleMeasure;
-export const PurpleReferenceSchema = PurpleMeasureSchema;
+export const PurpleReferenceSchema = z.object({
+  unit: z.string(),
+  value: z.number().int(),
+});
 export type PurpleReference = PurpleMeasure;
 
 export const SearchRequestPaginationSchema = z.object({

--- a/tests/spec-constraints.test.js
+++ b/tests/spec-constraints.test.js
@@ -50,6 +50,7 @@ const {
   FulfillmentEventSchema,
   AdjustmentSchema,
   FulfillmentOptionSchema,
+  PurpleUnitPriceSchema,
   UcpSchema,
 } = require("./.dist/spec_generated.js");
 
@@ -131,6 +132,28 @@ test("ExpectationLineItemSchema rejects a fractional quantity (type: integer)", 
 
 test("ExpectationLineItemSchema accepts a positive integer quantity", () => {
   assert.ok(accepts(ExpectationLineItemSchema, { id: "li_1", quantity: 1 }));
+});
+
+// --- Unit price measure/reference: contextual split -------------------------
+// Both objects have {unit,value}, but the pinned schema declares measure.value
+// as `number` and reference.value as `integer`. The generated schemas must not
+// let quicktype's shared-object merge apply the integer rule to both contexts.
+
+const unitPrice = (measureValue, referenceValue) => ({
+  amount: 125,
+  currency: "USD",
+  measure: { unit: "kg", value: measureValue },
+  reference: { unit: "kg", value: referenceValue },
+});
+
+test("unit price measure accepts fractional and integer values", () => {
+  assert.ok(accepts(PurpleUnitPriceSchema, unitPrice(0.5, 100)));
+  assert.ok(accepts(PurpleUnitPriceSchema, unitPrice(1, 100)));
+});
+
+test("unit price reference requires an integer value", () => {
+  assert.ok(rejects(PurpleUnitPriceSchema, unitPrice(0.5, 0.5)));
+  assert.ok(accepts(PurpleUnitPriceSchema, unitPrice(0.5, 100)));
 });
 
 // --- Projected request constraints -----------------------------------------


### PR DESCRIPTION
## Description

The generated unit-price schemas currently merge `measure` and `reference` into one shared object and apply the reference's integer constraint to both:

```ts
PurpleUnitPriceSchema.safeParse({
  amount: 125,
  currency: "USD",
  measure: { unit: "kg", value: 0.5 },
  reference: { unit: "kg", value: 100 },
}).success === false
```

The pinned `v2026-04-08` schema declares `measure.value` as `type: number` and `reference.value` as `type: integer`. The current output therefore rejects valid fractional package measures.

**Fix:** record source numeric kinds even when they carry no additional constraint, use that evidence to split quicktype's shared `{unit,value}` schema by context, regenerate the Zod models, and add regression coverage for fractional/integer measure and reference values.

## Category (Required)

- [ ] **Core Protocol**: Changes to the base communication layer, global context, or breaking refactors. (Requires Technical Council approval)
- [ ] **Governance/Contributing**: Updates to GOVERNANCE.md, CONTRIBUTING.md, or CODEOWNERS. (Requires Governance Council approval)
- [ ] **Capability**: New schemas (Discovery, Cart, etc.) or extensions. (Requires Maintainer approval)
- [ ] **Documentation**: Updates to README, or documentations regarding schema or capabilities. (Requires Maintainer approval)
- [ ] **Infrastructure**: CI/CD, Linters, or build scripts. (Requires DevOps Maintainer approval)
- [ ] **Maintenance**: Version bumps, lockfile updates, or minor bug fixes. (Requires DevOps Maintainer approval)
- [x] **SDK**: Language-specific SDK updates and releases. (Requires DevOps Maintainer approval)
- [ ] **Samples / Conformance**: Maintaining samples and the conformance suite. (Requires Maintainer approval)
- [ ] **UCP Schema**: Changes to the `ucp-schema` tool (resolver, linter, validator). (Requires Maintainer approval)
- [ ] **Community Health (.github)**: Updates to templates, workflows, or org-level configs. (Requires DevOps Maintainer approval)

## Related Issues

N/A

## Checklist

- [x] I have followed the [Contributing Guide](https://github.com/Universal-Commerce-Protocol/.github/blob/main/CONTRIBUTING.md) (including Conventional Commits title requirements and `!` for breaking changes).
- [x] I have updated the documentation (if applicable).
- [x] My changes pass all local linting and formatting checks.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] (For Core/Capability) I have included/updated the relevant JSON schemas.
- [ ] I have regenerated Python Pydantic models by running generate_models.sh under python_sdk.

## Screenshots / Logs (if applicable)

- `npm test` (108/108)
- `npm run build:noEmit`
- `npm run build`
- fixed-version regeneration against `v2026-04-08` twice (byte-identical)
- `uvx pre-commit run --all-files`
- `git diff --check`
