### PR TITLE
fix: enforce warning message URI constraints

### DIFF
--- a/scripts/inject-schema-constraints.mjs
+++ b/scripts/inject-schema-constraints.mjs
@@ -486,6 +486,13 @@ const conditionalIndex = new Map();
 // setKey -> Map(signature -> rules).
 const variantUnionIndex = new Map();
 
+// Per-variant scalar constraints for discriminated object unions. quicktype
+// flattens the branches into one z.object, so fields that occur only in a
+// subset of variants cannot safely receive a global method. Retain them as
+// discriminator-scoped rules and render them inside the existing superRefine.
+// setKey -> Map(signature -> rules).
+const variantUnionFieldIndex = new Map();
+
 function recordObject(properties, file, propertyFiles) {
   const setKey = Object.keys(properties).sort().join(",");
   if (!constraintIndex.has(setKey)) {
@@ -946,13 +953,39 @@ function recordVariantUnionRules(node, file) {
   ) {
     return;
   }
-  rules.sort((left, right) =>
+  const fieldRules = [];
+  for (const [index, variant] of variants.entries()) {
+    for (const [name, propertyNode] of Object.entries(variant.properties)) {
+      const descriptor = describeConstraint(
+        propertyNode,
+        variant.propertyFiles[name] || variant.file
+      );
+      if (!descriptor || !descriptor.descriptor.format) {
+        continue;
+      }
+      fieldRules.push({
+        kind: "format",
+        discriminator,
+        values: [values[index]],
+        field: name,
+        format: descriptor.descriptor.format,
+      });
+    }
+  }
+  fieldRules.sort((left, right) =>
     JSON.stringify(left).localeCompare(JSON.stringify(right))
   );
   const setKey = [...unionNames].sort().join(",");
   const signature = JSON.stringify(rules);
   if (!variantUnionIndex.has(setKey)) variantUnionIndex.set(setKey, new Map());
   variantUnionIndex.get(setKey).set(signature, rules);
+  if (fieldRules.length) {
+    const fieldSignature = JSON.stringify(fieldRules);
+    if (!variantUnionFieldIndex.has(setKey)) {
+      variantUnionFieldIndex.set(setKey, new Map());
+    }
+    variantUnionFieldIndex.get(setKey).set(fieldSignature, fieldRules);
+  }
 }
 
 function walkSchema(node, file, seen = new Set(), depth = 0) {
@@ -1123,7 +1156,14 @@ for (const [setKey, bySignature] of variantUnionIndex) {
     ambiguous.push({ setKey, name: "<variant-union/conditional>", count: 2 });
     continue;
   }
-  resolvedVariantUnions.set(setKey, [...bySignature.values()][0]);
+  const requiredRules = [...bySignature.values()][0];
+  const fields = variantUnionFieldIndex.get(setKey);
+  if (fields?.size > 1) {
+    ambiguous.push({ setKey, name: "<variant-union-field>", count: fields.size });
+    continue;
+  }
+  const fieldRules = fields ? [...fields.values()][0] : [];
+  resolvedVariantUnions.set(setKey, [...requiredRules, ...fieldRules]);
 }
 
 // --- Shared {id,quantity} line-item reference: contextual split --------------
@@ -1286,6 +1326,8 @@ function renderConditionalRefine(rules) {
     values: rule.values,
     negated: rule.negated ?? false,
     required: rule.required ?? [],
+    field: rule.field ?? null,
+    format: rule.format ?? null,
     target: rule.target ?? null,
     minimum: rule.minimum ?? null,
     maximum: rule.maximum ?? null,
@@ -1304,6 +1346,13 @@ function renderConditionalRefine(rules) {
     `for (const field of rule.required) {` +
     `if (!(field in record)) ctx.addIssue({ code: z.ZodIssueCode.custom, ` +
     `path: [field], message: "Field is required by a conditional constraint" });` +
+    `}continue;}` +
+    `if (rule.kind === "format") {` +
+    `const field = rule.field;` +
+    `const fieldValue = field === null ? undefined : record[field];` +
+    `if (rule.format === "uri" && typeof fieldValue === "string") {` +
+    `try { new URL(fieldValue); } catch { if (field !== null) ctx.addIssue({ code: z.ZodIssueCode.custom, ` +
+    `path: [field], message: "Value must be a valid URI" }); }` +
     `}continue;}` +
     `if (rule.target === null) continue;` +
     `const target = record[rule.target];` +

--- a/src/spec_generated.ts
+++ b/src/spec_generated.ts
@@ -248,6 +248,8 @@ export const TotalResponseSchema = z
         values: ["discount", "items_discount"],
         negated: false,
         required: [],
+        field: null,
+        format: null,
         target: "amount",
         minimum: null,
         maximum: null,
@@ -260,6 +262,8 @@ export const TotalResponseSchema = z
         values: ["subtotal", "fulfillment", "tax", "fee"],
         negated: false,
         required: [],
+        field: null,
+        format: null,
         target: "amount",
         minimum: 0,
         maximum: null,
@@ -282,6 +286,23 @@ export const TotalResponseSchema = z
               path: [field],
               message: "Field is required by a conditional constraint",
             });
+        }
+        continue;
+      }
+      if (rule.kind === "format") {
+        const field = rule.field;
+        const fieldValue = field === null ? undefined : record[field];
+        if (rule.format === "uri" && typeof fieldValue === "string") {
+          try {
+            new URL(fieldValue);
+          } catch {
+            if (field !== null)
+              ctx.addIssue({
+                code: z.ZodIssueCode.custom,
+                path: [field],
+                message: "Value must be a valid URI",
+              });
+          }
         }
         continue;
       }
@@ -330,18 +351,8 @@ export const CheckoutResponseMessageSchema = z
         values: ["error"],
         negated: false,
         required: ["code", "content", "severity", "type"],
-        target: null,
-        minimum: null,
-        maximum: null,
-        exclusiveMinimum: null,
-        exclusiveMaximum: null,
-      },
-      {
-        kind: "required",
-        discriminator: "type",
-        values: ["info"],
-        negated: false,
-        required: ["content", "type"],
+        field: null,
+        format: null,
         target: null,
         minimum: null,
         maximum: null,
@@ -354,6 +365,50 @@ export const CheckoutResponseMessageSchema = z
         values: ["warning"],
         negated: false,
         required: ["code", "content", "type"],
+        field: null,
+        format: null,
+        target: null,
+        minimum: null,
+        maximum: null,
+        exclusiveMinimum: null,
+        exclusiveMaximum: null,
+      },
+      {
+        kind: "required",
+        discriminator: "type",
+        values: ["info"],
+        negated: false,
+        required: ["content", "type"],
+        field: null,
+        format: null,
+        target: null,
+        minimum: null,
+        maximum: null,
+        exclusiveMinimum: null,
+        exclusiveMaximum: null,
+      },
+      {
+        kind: "format",
+        discriminator: "type",
+        values: ["warning"],
+        negated: false,
+        required: [],
+        field: "image_url",
+        format: "uri",
+        target: null,
+        minimum: null,
+        maximum: null,
+        exclusiveMinimum: null,
+        exclusiveMaximum: null,
+      },
+      {
+        kind: "format",
+        discriminator: "type",
+        values: ["warning"],
+        negated: false,
+        required: [],
+        field: "url",
+        format: "uri",
         target: null,
         minimum: null,
         maximum: null,
@@ -376,6 +431,23 @@ export const CheckoutResponseMessageSchema = z
               path: [field],
               message: "Field is required by a conditional constraint",
             });
+        }
+        continue;
+      }
+      if (rule.kind === "format") {
+        const field = rule.field;
+        const fieldValue = field === null ? undefined : record[field];
+        if (rule.format === "uri" && typeof fieldValue === "string") {
+          try {
+            new URL(fieldValue);
+          } catch {
+            if (field !== null)
+              ctx.addIssue({
+                code: z.ZodIssueCode.custom,
+                path: [field],
+                message: "Value must be a valid URI",
+              });
+          }
         }
         continue;
       }
@@ -723,6 +795,8 @@ export const SearchResponsePaginationSchema = z
         values: [true],
         negated: false,
         required: ["cursor"],
+        field: null,
+        format: null,
         target: null,
         minimum: null,
         maximum: null,
@@ -745,6 +819,23 @@ export const SearchResponsePaginationSchema = z
               path: [field],
               message: "Field is required by a conditional constraint",
             });
+        }
+        continue;
+      }
+      if (rule.kind === "format") {
+        const field = rule.field;
+        const fieldValue = field === null ? undefined : record[field];
+        if (rule.format === "uri" && typeof fieldValue === "string") {
+          try {
+            new URL(fieldValue);
+          } catch {
+            if (field !== null)
+              ctx.addIssue({
+                code: z.ZodIssueCode.custom,
+                path: [field],
+                message: "Value must be a valid URI",
+              });
+          }
         }
         continue;
       }
@@ -865,6 +956,8 @@ export const TotalsResponseSchema = z
         ],
         negated: true,
         required: ["display_text"],
+        field: null,
+        format: null,
         target: null,
         minimum: null,
         maximum: null,
@@ -887,6 +980,23 @@ export const TotalsResponseSchema = z
               path: [field],
               message: "Field is required by a conditional constraint",
             });
+        }
+        continue;
+      }
+      if (rule.kind === "format") {
+        const field = rule.field;
+        const fieldValue = field === null ? undefined : record[field];
+        if (rule.format === "uri" && typeof fieldValue === "string") {
+          try {
+            new URL(fieldValue);
+          } catch {
+            if (field !== null)
+              ctx.addIssue({
+                code: z.ZodIssueCode.custom,
+                path: [field],
+                message: "Value must be a valid URI",
+              });
+          }
         }
         continue;
       }

--- a/tests/spec-constraints.test.js
+++ b/tests/spec-constraints.test.js
@@ -394,6 +394,57 @@ test("OrderConfirmationSchema rejects a non-URL permalink_url (format: uri)", ()
   );
 });
 
+// --- Discriminated response messages: branch-local URI fields ---------------
+// The warning branch declares URL-formatted optional fields, but quicktype
+// flattens the error/info/warning oneOf into one object. URI checks must apply
+// only when `type` selects the warning branch.
+
+const warningMessage = {
+  type: "warning",
+  code: "w1",
+  content: "notice",
+  severity: "recoverable",
+};
+
+test("warning messages reject non-URI url and image_url values", () => {
+  assert.ok(
+    rejects(CheckoutResponseMessageSchema, {
+      ...warningMessage,
+      url: "not-a-url",
+    })
+  );
+  assert.ok(
+    rejects(CheckoutResponseMessageSchema, {
+      ...warningMessage,
+      image_url: "not-a-url",
+    })
+  );
+});
+
+test("response messages keep valid warning URLs and non-warning variants", () => {
+  assert.ok(
+    accepts(CheckoutResponseMessageSchema, {
+      ...warningMessage,
+      url: "https://merchant.example/help",
+      image_url: "https://cdn.example/notice.png",
+    })
+  );
+  assert.ok(
+    accepts(CheckoutResponseMessageSchema, {
+      type: "error",
+      code: "e1",
+      content: "failed",
+      severity: "recoverable",
+    })
+  );
+  assert.ok(
+    accepts(LookupResponseMessageSchema, {
+      ...warningMessage,
+      url: "https://merchant.example/help",
+    })
+  );
+});
+
 // --- Cross-file $ref provenance: entity version patterns --------------------
 // Every UCP entity inherits `version` from ucp.json#/$defs/entity via a
 // cross-file allOf `$ref`. The injector must resolve that property's own


### PR DESCRIPTION
## Description

`CheckoutResponseMessageSchema` is generated from the error/info/warning
message `oneOf`. quicktype flattens the variants into one object, so the warning
branch's URI fields were left as plain optional strings:

```ts
image_url: z.string().optional(),
url: z.string().optional(),
```

The pinned `message_warning.json` schema declares both fields as
`type: string, format: uri`, and sibling URI fields such as `LinkSchema.url`,
`MediaSchema.url`, and `OrderConfirmationSchema.permalink_url` already enforce
`.url()`. As a result, a complete warning payload with `url: "not-a-url"` or
`image_url: "not-a-url"` parsed successfully while equivalent URI fields were
rejected elsewhere.

**Fix:** recover branch-local URI rules for discriminated object unions and
apply them inside the existing `superRefine` only when the discriminator selects
the matching variant.

## Category (Required)

- [ ] **Core Protocol**: Changes to the core protocol specification or schemas. (Requires Technical Council approval)
- [ ] **Governance/Contributing**: Changes to governance, processes, or contribution rules. (Requires Governance Council approval)
- [ ] **Capability**: New or updated capabilities. (Requires Maintainer approval)
- [ ] **Documentation**: Documentation-only changes. (Requires Maintainer approval)
- [ ] **Infrastructure**: CI, build, release, or repository infrastructure. (Requires DevOps Maintainer approval)
- [ ] **Maintenance**: Refactors, dependency updates, or non-functional cleanup. (Requires DevOps Maintainer approval)
- [x] **SDK**: Language-specific SDK updates and releases. (Requires DevOps Maintainer approval)
- [ ] **Samples / Conformance**: Maintaining samples and the conformance suite. (Requires Maintainer approval)
- [ ] **UCP Schema**: Changes to the ucp-schema tool. (Requires Maintainer approval)
- [ ] **Community Health (.github)**: Organization-level community health files. (Requires DevOps Maintainer approval)

## Related Issues

N/A

## Checklist

- [x] I have followed the Contributing Guide and Code of Conduct.
- [x] I have updated the documentation (if applicable).
- [x] My changes pass all local linting and formatting checks.
- [x] I have added tests that prove my fix is effective.
- [x] New and existing unit tests pass locally with my changes.
- [ ] (For Core/Capability) I have included/updated the relevant JSON schemas.
- [x] I have regenerated JavaScript SDK models by running `generate_models.sh` against the pinned release source.

## Screenshots / Logs (if applicable)

- `npm test` — 111/111 passed
- `npm run build:noEmit`
- `npm run build`
- `uvx pre-commit run --all-files`
- pinned `origin/release/2026-04-08` regeneration is byte-identical after the first generated update
