### PR TITLE
fix: add .js extensions to ESM exports for Node.js resolution

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1,2 +1,2 @@
-export * from "./src/extensions";
-export * from "./src/spec_generated";
+export * from "./src/extensions.js";
+export * from "./src/spec_generated.js";

--- a/src/extensions.ts
+++ b/src/extensions.ts
@@ -30,7 +30,7 @@ import {
   CheckoutWithFulfillmentUpdateRequestSchema,
   OrderSchema,
   PaymentCredentialSchema,
-} from "./spec_generated";
+} from "./spec_generated.js";
 
 export const ExtendedPaymentCredentialSchema = PaymentCredentialSchema.extend({
   token: z.string().optional(),


### PR DESCRIPTION
\`index.ts\` and \`src/extensions.ts\` re-export sibling modules without a
file extension:

    export * from "./src/extensions";
    export * from "./src/spec_generated";

TypeScript compiles these through unchanged into the ESM build
(\`dist/esm/\`), but Node's ESM resolver requires explicit extensions on
relative specifiers. Any consumer running under strict ESM resolution
(Vite/Vitest, \`node --experimental-vm-modules\`, native ESM \`import\`)
hits:

    Error: Cannot find module '.../dist/esm/src/extensions'

Fix: add the \`.js\` extension in the TypeScript source, which carries
through to the compiled \`.js\` output. The CJS build is untouched.

This is the same root cause reported and fixed in #3, which was closed
for inactivity before landing. Filing again with the CLA now complete.

Verified locally: \`@ucp-js/sdk@0.4.6\` fails to resolve under Vitest
without this fix (26 test files erroring), and resolves cleanly with
it applied via \`pnpm patch\`.