### PR TITLE
fix: enforce capability extends constraints on the discovery projection

### DIFF
--- a/scripts/project-current-ucp-schemas.mjs
+++ b/scripts/project-current-ucp-schemas.mjs
@@ -750,6 +750,29 @@ function toCompatLeaf(schema) {
   return { type: "string" };
 }
 
+// Rewrite every `$ref` inside a cloned source node so it resolves from the
+// discovery/ output directory, which sits beside schemas/ rather than inside it.
+// A raw clone keeps refs written relative to schemas/ (e.g.
+// "common/types/reverse_domain_name.json") and generation dies with
+// "Could not fetch schema" the moment such a node is emitted into discovery/.
+// Keeping the node otherwise intact is the point: the reverse-domain pattern and
+// minItems stay attached, so quicktype emits the real constraint instead of a
+// bare union that then depends on the injector finding it by property set.
+function rewriteDiscoveryRefs(node) {
+  if (Array.isArray(node)) return node.map(rewriteDiscoveryRefs);
+  if (!node || typeof node !== "object") return node;
+  const out = {};
+  for (const [key, value] of Object.entries(node)) {
+    if (key === "$ref" && typeof value === "string" && !value.startsWith("#")) {
+      const [file, fragment = ""] = value.split("#");
+      out.$ref = fragment ? `../schemas/${file}#${fragment}` : `../schemas/${file}`;
+    } else {
+      out[key] = rewriteDiscoveryRefs(value);
+    }
+  }
+  return out;
+}
+
 // Rewrite an array item $ref from its source (schemas-root-relative) path to the
 // path a discovery/ compat file uses to reach the projected type tree.
 function rewriteItemRefForDiscovery(items) {
@@ -833,6 +856,22 @@ function writeCompatibilityDiscoverySchemas() {
   const version = ucpSchema.$defs.version;
   const entityProperties = ucpSchema.$defs.entity.properties;
   const serviceEndpoint = serviceSchema.$defs.base.allOf[1].properties.endpoint;
+  // capability.json declares `extends` once, on $defs/base, as a oneOf of a
+  // reverse-domain-pattern string or a non-empty array of the same -- and both
+  // $defs/platform_schema (this discovery projection) and $defs/response_schema
+  // (capabilityResponse, below) inherit it via allOf from that shared base.
+  // The clone is emitted into discovery/, which sits beside schemas/ rather than
+  // inside it, so its `$ref: common/types/reverse_domain_name.json` does not
+  // resolve there and generation dies with "Could not fetch schema".
+  // rewriteDiscoveryRefs repoints those refs and leaves the node otherwise
+  // intact, which is the point: the pattern and minItems stay attached, so
+  // quicktype emits the constraint directly. Flattening it through toCompatLeaf
+  // instead would resolve the ref but drop both, because the constraint would
+  // then have to be reattached by inject-schema-constraints.mjs, whose index is
+  // keyed by the containing object property set, and this object differs from
+  // capabilityResponse by one property name.
+  const capabilityExtends =
+    capabilitySchema.$defs.base.allOf[1].properties.extends;
 
   const signingKey = {
     $schema: "https://json-schema.org/draft/2020-12/schema",
@@ -879,7 +918,7 @@ function writeCompatibilityDiscoverySchemas() {
     required: ["name", "schema", "spec", "version"],
     properties: {
       config: { type: "object", additionalProperties: true },
-      extends: { type: "string" },
+      extends: rewriteDiscoveryRefs(clone(capabilityExtends)),
       name: { type: "string" },
       schema: clone(entityProperties.schema),
       spec: clone(entityProperties.spec),

--- a/src/spec_generated.ts
+++ b/src/spec_generated.ts
@@ -265,7 +265,24 @@ export type ConstraintExpressionProperty = ConstraintsProperty;
 
 export const CapabilityDiscoverySchema = z.object({
   config: z.record(z.string(), z.any()).optional(),
-  extends: z.string().optional(),
+  extends: z
+    .union([
+      z
+        .array(
+          z
+            .string()
+            .regex(
+              /^[a-z](?:[a-z0-9-]*[a-z0-9])?(?:\.[a-z0-9](?:[a-z0-9_-]*[a-z0-9_])?)+$/
+            )
+        )
+        .min(1),
+      z
+        .string()
+        .regex(
+          /^[a-z](?:[a-z0-9-]*[a-z0-9])?(?:\.[a-z0-9](?:[a-z0-9_-]*[a-z0-9_])?)+$/
+        ),
+    ])
+    .optional(),
   name: z.string(),
   schema: z.string().url(),
   spec: z.string().url(),

--- a/tests/spec-constraints.test.js
+++ b/tests/spec-constraints.test.js
@@ -543,6 +543,70 @@ test("CapabilityResponseSchema accepts valid extends names", () => {
   );
 });
 
+// --- CapabilityDiscoverySchema extends: the #55 twin --------------------
+// capability.json's `extends` oneOf is declared once, on $defs/base, and
+// inherited by BOTH $defs/response_schema (-> CapabilityResponseSchema,
+// fixed by #55) and $defs/platform_schema (-> CapabilityDiscoverySchema,
+// the discovery-profile projection). writeCompatibilityDiscoverySchemas()
+// hand-authors the discovery projection separately from the derived
+// response projection, and its `extends` field was left as a bare
+// `{ type: "string" }` stub -- the same defect #55 fixed on the response
+// side, unfixed on this twin.
+
+test("CapabilityDiscoverySchema rejects an empty extends array", () => {
+  assert.ok(
+    rejects(CapabilityDiscoverySchema, {
+      name: "dev.ucp.shopping.checkout",
+      schema: "https://ucp.dev/schemas/shopping/checkout.json",
+      spec: "https://ucp.dev/specification/checkout",
+      version: "2026-04-08",
+      extends: [],
+    })
+  );
+});
+
+test("CapabilityDiscoverySchema rejects invalid extends names", () => {
+  assert.ok(
+    rejects(CapabilityDiscoverySchema, {
+      name: "dev.ucp.shopping.checkout",
+      schema: "https://ucp.dev/schemas/shopping/checkout.json",
+      spec: "https://ucp.dev/specification/checkout",
+      version: "2026-04-08",
+      extends: "bad name",
+    })
+  );
+  assert.ok(
+    rejects(CapabilityDiscoverySchema, {
+      name: "dev.ucp.shopping.checkout",
+      schema: "https://ucp.dev/schemas/shopping/checkout.json",
+      spec: "https://ucp.dev/specification/checkout",
+      version: "2026-04-08",
+      extends: ["com.example.good", "BadName"],
+    })
+  );
+});
+
+test("CapabilityDiscoverySchema accepts valid extends names", () => {
+  assert.ok(
+    accepts(CapabilityDiscoverySchema, {
+      name: "dev.ucp.shopping.checkout",
+      schema: "https://ucp.dev/schemas/shopping/checkout.json",
+      spec: "https://ucp.dev/specification/checkout",
+      version: "2026-04-08",
+      extends: "dev.ucp.checkout",
+    })
+  );
+  assert.ok(
+    accepts(CapabilityDiscoverySchema, {
+      name: "dev.ucp.shopping.checkout",
+      schema: "https://ucp.dev/schemas/shopping/checkout.json",
+      spec: "https://ucp.dev/specification/checkout",
+      version: "2026-04-08",
+      extends: ["dev.ucp.checkout", "com.example_capability.v1"],
+    })
+  );
+});
+
 test("UcpSchema enforces the discovery version pattern", () => {
   const discovery = { capabilities: [], services: {} };
   assert.ok(rejects(UcpSchema, { ...discovery, version: "not-a-date" }));


### PR DESCRIPTION
Fixes #62

## What

`CapabilityDiscoverySchema.extends` (the discovery profile projection of
`capability.json`) now enforces the same constraint `CapabilityResponseSchema.extends`
already enforces since #55: a string matching the reverse domain pattern
`^[a-z](?:[a-z0-9-]*[a-z0-9])?(?:\.[a-z0-9](?:[a-z0-9_-]*[a-z0-9_])?)+$`, or a non empty array of such strings.

Before this change it accepted any string and rejected every array, including
conformant ones.

## Root cause

`capability.json` declares `extends` once, on `$defs/base`, as a `oneOf` of a
constrained string or a constrained array. Two things in this repo consume that
`oneOf`:

- `capabilityResponse`, in `writeCompatibilityDiscoverySchemas()`, is derived from
  the source through `buildEntityResponseSchema()`, which flattens `$defs/response_schema`
  and runs each property through `toCompatLeaf()`. That path keeps the union shape, so
  quicktype emits a `z.union(...)` for it, and the injector #55 extended
  (`describeStringArrayUnionConstraint`) can find and reattach the pattern and
  `minItems`.
- `capabilityDiscovery`, in the same function, is a hand authored object for
  `$defs/platform_schema` (the discovery profile shape). Its `extends` property was a
  bare `{ type: "string" }` literal, never wired to the source `oneOf`. quicktype had
  no union to render, so there was nothing for the injector to recover, regardless of
  #55.

The two projections exist because `platform_schema` and `response_schema` differ in
required fields (platform requires `spec`/`schema`; response does not, and also has no
`name`), so they cannot share one output type. #55 closed the gap on the response
side; this PR closes the same gap on the discovery side, using the property the fixed
side already draws from:

```js
const capabilityExtends =
  capabilitySchema.$defs.base.allOf[1].properties.extends;
// ...
extends: rewriteDiscoveryRefs(clone(capabilityExtends)),
```

This mirrors how the adjacent `schema`, `spec`, and `version` properties in the same
object are already cloned from the source schemas rather than hand typed, so the fix
follows the shape of an existing helper in the file, rewriteItemRefForDiscovery,
though it does add a small one of its own.

## Testing

All commands run on the exact branch, from a clean clone of
`Universal-Commerce-Protocol/js-sdk` at `dbd0dbec22b699fa6e8171f09c72f7ccf01b0b64`:

- `npm run generate` against a checkout of the pinned `release/2026-08-25` spec:
  regenerated `src/spec_generated.ts`. Ran twice; byte identical both times (the
  repo `model-drift` CI job diffs this file against a fresh regeneration, so this
  PR ships that check already passing).
- `npm run pretest && npm test`: 147 pass, 0 fail (144 pre-existing plus 3 new;
  one of the three, the empty array case, already passed before the fix for an
  unrelated reason and is kept as a named regression guard).
- `npm run build:noEmit`: clean.
- `npm run build`: clean (cjs, esm, types).
- Kill test: reverting the projection change with the tests kept turns exactly the
  two new constraint tests red; restoring returns the suite to 147 passing.
- Pinned `pre-commit run` on the changed files: every hook passes.

## Sweep of the defect class

Swept the projection script for the same class, a hand authored literal shadowing
a constrained source declaration (the constrained leaves elsewhere in the
discovery objects are already cloned from source):

| Literal | Verdict |
| --- | --- |
| `extends` | Fixed, this PR |
| `name` | Not applicable: `capability.json` has no `name` property; the registry keys capabilities via `propertyNames` against `reverse_domain_name.json`, so the discovery `name` field has no source counterpart to derive |
| `signingKey` | Now in scope, and not addressed here: at `release/2026-08-25` `profile.json` declares `$defs/jwk_public_key` and `base.properties.keys`, so this literal does shadow a real source declaration. It was out of scope when this PR was written against the 2026-04-08 pin, where no such schema shipped. Left for a separate change rather than widened here |
| two `ap2_mandate` fallbacks, in `writeCompatibilityAp2Schema()` | Not applicable: dead code against the pinned spec; both referenced `$defs` exist (`ap2_with_checkout_mandate`, and the projected checkout def), so the fallbacks never engage |

## Coexistence

#61 has merged, and the rebase onto it was not trivial. The projection change is
unchanged in substance, but regenerating on top of #61 failed outright: the
shared extends node carries a ref written relative to schemas/, which does not
resolve from the discovery/ output directory. The node is now passed through a
rewrite that repoints its refs the way the response projection already repoints
its item ref, which keeps the pattern and minItems attached rather than relying
on the constraint injector, whose index is keyed by the containing object
property set and so does not carry from the response object to this one.

