### PR TITLE
fix: regenerate against the 2026-08-25 UCP spec reorg

### DIFF
--- a/generate_models.sh
+++ b/generate_models.sh
@@ -49,10 +49,24 @@ fi
 RAW_CONSTRAINT_SCHEMA_DIR="$SPEC_DIR/schemas"
 PROJECTED_CONSTRAINT_SCHEMA_DIR=""
 
-TMP_OUTPUT="$(mktemp "${TMPDIR:-/tmp}/ucp-spec-generated.XXXXXX.ts")"
+# No suffix after the X's: BSD/macOS mktemp (unlike GNU mktemp) only
+# randomizes a TRAILING run of X's, so a template ending in a literal
+# suffix ("...XXXXXX.ts") is used completely unsubstituted, and every call
+# with this exact template returns the identical path. Harmless for a
+# single quicktype invocation per run (the previous, and only, use of this
+# file), but the discovery-last retry below now writes to this SAME path a
+# second time in the same run: on a real regeneration, the retry silently
+# reused the first (failed/incomplete) attempt's own output as its starting
+# point instead of a clean file, corrupting the result in a way that
+# depended on which mktemp implementation the machine runs (invisible on
+# GNU/Linux CI, reproducible every time on macOS). No suffix keeps both
+# platforms honest.
+TMP_OUTPUT="$(mktemp "${TMPDIR:-/tmp}/ucp-spec-generated.XXXXXX")"
 PROJECTED_SPEC_DIR=""
+FRAGMENT_FILES=()
 cleanup() {
   rm -f "$TMP_OUTPUT"
+  rm -f "${FRAGMENT_FILES[@]+"${FRAGMENT_FILES[@]}"}"
   if [[ -n "$PROJECTED_SPEC_DIR" ]]; then
     rm -rf "$PROJECTED_SPEC_DIR"
   fi
@@ -69,7 +83,6 @@ fi
 QUICKTYPE_ARGS=(
   --lang typescript-zod
   --src-lang schema
-  --src "$SPEC_DIR"/discovery/*.json
   --src "$SPEC_DIR/schemas/shopping/checkout.create_req.json"
   --src "$SPEC_DIR/schemas/shopping/checkout.update_req.json"
   --src "$SPEC_DIR/schemas/shopping/checkout.complete_req.json"
@@ -103,15 +116,181 @@ QUICKTYPE_ARGS=(
   --src "$SPEC_DIR/schemas/shopping/catalog_lookup.json#/\$defs/get_product_response"
   --src "$SPEC_DIR/schemas/shopping/catalog_search.json#/\$defs/search_request"
   --src "$SPEC_DIR/schemas/shopping/catalog_search.json#/\$defs/search_response"
-
-  -o "$TMP_OUTPUT"
 )
 
 if [[ "$SCHEMA_LAYOUT" == "legacy" ]]; then
   QUICKTYPE_ARGS+=(--src "$SPEC_DIR"/schemas/shopping/types/*.json)
 fi
 
-npx quicktype "${QUICKTYPE_ARGS[@]}"
+# quicktype's type-ordering pass has a fixed iteration budget ("Exceeded
+# maximum number of passes when determining output order"). Against
+# 2026-08-25's larger combined schema graph, putting discovery/*.json (the
+# response envelope family) FIRST -- the original, and only, order this
+# script has ever used -- exhausts that budget before the graph is fully
+# ordered and silently drops several response-envelope types
+# (CheckoutResponseSchema, UcpResponseSchema, UcpCheckoutResponseSchema,
+# UcpDiscoveryProfileSchema -- reproduced with only the nine pre-existing
+# pinned resources, no newly-discovered capability involved: this is a
+# pre-existing quicktype limitation exposed by 2026-08-25's larger content,
+# not something this fix introduces). Putting discovery/*.json LAST resolves
+# the same graph within budget, but also changes declaration ORDER in the
+# output (not content), which would break byte-identity against the pinned
+# 2026-04-08 release for no reason -- it never needs the fallback.
+# So: try the original (discovery-first) order first, exactly as before.
+# Only if quicktype warns it exhausted the pass budget, retry once with
+# discovery-last and use that output instead. This is keyed on the observed
+# quicktype WARNING, not on which spec version is running, so it stays
+# correct if a future release grows the graph further (or shrinks it back).
+QUICKTYPE_LOG="$(mktemp "${TMPDIR:-/tmp}/ucp-quicktype-log.XXXXXX")"
+set +e
+npx quicktype --src "$SPEC_DIR"/discovery/*.json "${QUICKTYPE_ARGS[@]}" -o "$TMP_OUTPUT" >"$QUICKTYPE_LOG" 2>&1
+QUICKTYPE_STATUS=$?
+set -e
+cat "$QUICKTYPE_LOG" >&2
+if [[ $QUICKTYPE_STATUS -ne 0 ]] || grep -q "maximum number of passes" "$QUICKTYPE_LOG"; then
+  echo "generate_models.sh: quicktype exhausted its ordering pass budget with discovery/*.json first; retrying with it last (output order only, not content, changes)." >&2
+  # Force a clean slate: quicktype's -o target being a pre-existing (here,
+  # incomplete/failed) file must not influence the retry.
+  rm -f "$TMP_OUTPUT"
+  npx quicktype "${QUICKTYPE_ARGS[@]}" --src "$SPEC_DIR"/discovery/*.json -o "$TMP_OUTPUT"
+fi
+rm -f "$QUICKTYPE_LOG"
+
+# Capabilities and transport envelopes the projector discovered by shape
+# (any new lookup/search/checkout-order-cart-extension capability under
+# schemas/common/, or a new transport message envelope) are not hardcoded
+# below: they are read from the manifest project-current-ucp-schemas.mjs
+# writes, so a spec release adding another one does not require editing this
+# script. See discoverAdditionalCapabilities/discoverTransportEnvelopes.
+#
+# Each discovered capability is generated in its OWN small quicktype
+# invocation (grouped by capability, so its create/update/response fragments
+# travel together), rather than joining the main invocation's --src list.
+# Two independent reasons:
+#   1. quicktype's typescript-zod target cannot represent every JSON Schema
+#      shape -- e.g. an allOf that re-adds named properties alongside a host
+#      object whose own additionalProperties is a schema, not a boolean (hit
+#      by payment_authentication's checkout attachment: it re-embeds
+#      checkout.json via $ref and layers named "actions" entries on top of
+#      checkout's own open action map). A newly-discovered capability hitting
+#      that limitation must not abort generation for every other capability
+#      and the pinned resources.
+#   2. quicktype's type-ordering pass has a fixed iteration budget
+#      ("Exceeded maximum number of passes when determining output order").
+#      Folding every discovered family into the SAME invocation as the nine
+#      pinned resources pushes the combined graph over that budget, and
+#      quicktype does not fail loudly when this happens -- it silently drops
+#      types instead (reproduced: CheckoutResponseSchema/
+#      UcpDiscoveryProfileSchema vanished with no non-zero exit code or
+#      per-type error). Keeping each family in its own bounded invocation,
+#      proven to stay under budget individually, avoids the failure mode
+#      entirely rather than working around its symptom.
+# This runs AFTER the main invocation above, not before: quicktype's own
+# ordering pass turned out to be sensitive to how many prior `npx quicktype`
+# processes had already run in the same shell session (observed: the main
+# invocation alone succeeds consistently; the identical invocation run after
+# nine preceding quicktype calls fails consistently, on the identical input
+# -- almost certainly process/resource churn in quicktype's own tooling, not
+# a property of the schemas). Generating the pinned resources FIRST, while
+# nothing else has run yet, keeps their generation deterministic; the
+# per-family probes below going second cannot un-succeed something already
+# written to disk.
+# A family whose invocation fails outright is EXCLUDED from this
+# regeneration -- there is no way to hand quicktype a shape it cannot
+# represent -- but that exclusion must never be silent. Two outcomes,
+# decided by scripts/check-generation-completeness.mjs after this loop:
+#   - the family is on that script's KNOWN_UNREPRESENTABLE_FAMILIES: a human
+#     has already verified quicktype cannot do this, so it is logged loudly
+#     as a WARNING and the run continues.
+#   - the family is NOT on that list: this is a NEW, unreviewed failure --
+#     it must not be silently swallowed as "the isolation mechanism just
+#     protected the rest of the run" (that fail-open is exactly how a real
+#     regression -- the isolation mechanism itself breaking, or a genuinely
+#     fixable schema bug -- would hide forever). Generation FAILS, forcing
+#     a human to either fix the schema/mechanism or add a reviewed,
+#     justified entry to KNOWN_UNREPRESENTABLE_FAMILIES.
+# A family whose invocation succeeds is kept as a fragment file and merged
+# into the main output (via merge-generated-fragment.mjs, below) rather than
+# redeclaring the shared discovery/*.json types a second time.
+#
+# The reviewed-exclusion allowlist and the accept/reject decision both live
+# in scripts/check-generation-completeness.mjs, not here: pure string-list
+# logic with no shell quoting is easier to get right and directly unit-
+# testable (tests/check-generation-completeness.test.js) independent of
+# whether the full pipeline can run end to end against any given spec tree.
+# This loop only collects the family names that failed; the decision (and
+# the exit) happens once, after the loop, below.
+FAILED_FAMILIES=()
+FRAGMENT_FILES=()
+MANIFEST_FILE="$SPEC_DIR/generated-src-manifest.json"
+if [[ -f "$MANIFEST_FILE" ]]; then
+  while IFS= read -r family; do
+    [[ -n "$family" ]] || continue
+    FAMILY_ARGS=()
+    while IFS= read -r entry; do
+      [[ -n "$entry" ]] || continue
+      FAMILY_ARGS+=(--src "$SPEC_DIR/schemas/$entry")
+    done < <(node -e '
+      const manifest = require(process.argv[1]);
+      const family = process.argv[2];
+      for (const entry of [...manifest.capabilities, ...manifest.transports]) {
+        if (familyKeyOf(entry) === family) {
+          process.stdout.write(entry + "\n");
+        }
+      }
+      function familyKeyOf(entry) {
+        const [file] = entry.split("#");
+        return file.replace(/\.(create_req|update_req)\.json$/, "").replace(/_resp\.json$/, "").replace(/\.json$/, "");
+      }
+    ' "$MANIFEST_FILE" "$family")
+
+    # No suffix after the X's: BSD/macOS mktemp (unlike GNU mktemp) only
+    # randomizes a trailing run of X's, so "prefix.XXXXXX.ts" is used
+    # literally unchanged, and a second call in the same loop collides on
+    # the identical path ("File exists"). This runs once per discovered
+    # family, so it must be genuinely unique each time.
+    FRAGMENT_OUTPUT="$(mktemp "${TMPDIR:-/tmp}/ucp-fragment.XXXXXX")"
+    FRAGMENT_LOG="$(mktemp "${TMPDIR:-/tmp}/ucp-fragment-log.XXXXXX")"
+    if npx quicktype --lang typescript-zod --src-lang schema \
+        --src "$SPEC_DIR"/discovery/*.json \
+        "${FAMILY_ARGS[@]}" \
+        -o "$FRAGMENT_OUTPUT" >"$FRAGMENT_LOG" 2>&1; then
+      FRAGMENT_FILES+=("$FRAGMENT_OUTPUT")
+    else
+      echo "generate_models.sh: \"$family\" failed its quicktype invocation:" >&2
+      tail -n 5 "$FRAGMENT_LOG" >&2
+      FAILED_FAMILIES+=("$family")
+      rm -f "$FRAGMENT_OUTPUT"
+    fi
+    rm -f "$FRAGMENT_LOG"
+  done < <(node -e '
+    const manifest = require(process.argv[1]);
+    const families = new Set();
+    for (const entry of [...manifest.capabilities, ...manifest.transports]) {
+      const [file] = entry.split("#");
+      const family = file.replace(/\.(create_req|update_req)\.json$/, "").replace(/_resp\.json$/, "").replace(/\.json$/, "");
+      families.add(family);
+    }
+    for (const family of families) {
+      process.stdout.write(family + "\n");
+    }
+  ' "$MANIFEST_FILE")
+fi
+
+# Never let a family failure pass silently: every name in FAILED_FAMILIES
+# must be on the reviewed KNOWN_UNREPRESENTABLE_FAMILIES allowlist in
+# scripts/check-generation-completeness.mjs, or this exits non-zero and
+# generation FAILS. See that script for the full reasoning (and
+# tests/check-generation-completeness.test.js for direct unit coverage of
+# this exact decision).
+node scripts/check-generation-completeness.mjs "${FAILED_FAMILIES[@]+"${FAILED_FAMILIES[@]}"}"
+
+# Merge in each discovered family's independently-generated fragment (see
+# above). Order does not matter here: each fragment only contributes
+# declarations the main output does not already have.
+for FRAGMENT_FILE in "${FRAGMENT_FILES[@]+"${FRAGMENT_FILES[@]}"}"; do
+  node scripts/merge-generated-fragment.mjs "$TMP_OUTPUT" "$FRAGMENT_FILE"
+done
 
 node scripts/normalize-generated-schemas.mjs "$TMP_OUTPUT" src/spec_generated.ts
 

--- a/scripts/check-generation-completeness.mjs
+++ b/scripts/check-generation-completeness.mjs
@@ -1,0 +1,84 @@
+// Copyright 2026 UCP Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Decides whether a set of discovered-family quicktype failures should fail
+// the whole generate_models.sh run, or be waved through as already-reviewed.
+//
+// Why this is its own script rather than inline bash: generate_models.sh's
+// per-family isolation loop (see the comment there) generates each newly-
+// discovered capability in its own quicktype invocation so ONE unrepresentable
+// shape cannot abort generation for every other family and the pinned
+// resources. That isolation was itself found to be a fail-open: a failing
+// family was logged and skipped, but the script still exited 0, so a NEW,
+// unreviewed failure (a mechanism regression, or a genuinely fixable schema
+// issue) could silently ship an incomplete src/spec_generated.ts. The fix is
+// this gate: every family that fails must be on KNOWN_UNREPRESENTABLE_FAMILIES
+// below (WARNING, continue) or the run FAILS (ERROR, exit 1). Isolating the
+// decision here -- pure string-list logic, no shell quoting, no quicktype,
+// no fixture spec tree -- makes it directly unit-testable
+// (tests/check-generation-completeness.test.js) independent of whether the
+// full pipeline can run end to end against any given spec tree.
+//
+// Usage: node scripts/check-generation-completeness.mjs <failedFamily> ...
+// Exits 0 if every failed family is reviewed (or there are none), 1 otherwise.
+
+// Reviewed, justified exclusions only -- each entry here must cite the exact
+// quicktype failure and why it is a genuine tool limitation, not a mechanism
+// bug this script could instead fix. Keep this list and generate_models.sh's
+// own copy of the reasoning in sync; this file is the single source of truth
+// for WHICH families are excluded, generate_models.sh's comment carries the
+// full WHY.
+export const KNOWN_UNREPRESENTABLE_FAMILIES = [
+  // common/payment_authentication -- its "actions" attachment redeclares
+  // checkout's "actions" property with BOTH fixed named keys (the new Action
+  // types) AND an inherited open catch-all (checkout's own actions.json is a
+  // schema-typed additionalProperties map). Verified by direct, minimal
+  // reproduction (a single top-level { properties: {...}, additionalProperties:
+  // <schema> } object, no allOf, no cross-file $refs) that quicktype's
+  // typescript-zod target cannot represent "named keys plus a schema-typed
+  // catch-all on the same object" AT ALL -- "Internal error: ." with zero
+  // further detail, independent of the allOf-merge machinery in this repo.
+  "common/payment_authentication",
+];
+
+export function checkCompleteness(failedFamilies) {
+  const unjustified = failedFamilies.filter(
+    (family) => !KNOWN_UNREPRESENTABLE_FAMILIES.includes(family)
+  );
+  const reviewed = failedFamilies.filter((family) =>
+    KNOWN_UNREPRESENTABLE_FAMILIES.includes(family)
+  );
+  return { unjustified, reviewed };
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  const failedFamilies = process.argv.slice(2);
+  const { unjustified, reviewed } = checkCompleteness(failedFamilies);
+
+  for (const family of reviewed) {
+    console.error(
+      `generate_models.sh: WARNING -- excluding "${family}" (reviewed, see KNOWN_UNREPRESENTABLE_FAMILIES in scripts/check-generation-completeness.mjs) -- left out of this regeneration; still recorded in generated-src-manifest.json for follow-up.`
+    );
+  }
+
+  if (unjustified.length > 0) {
+    console.error(
+      `generate_models.sh: FAILED -- ${unjustified.length} newly-discovered capability(ies) could not be generated and are not on the reviewed exclusion list: ${unjustified.join(", ")}`
+    );
+    console.error(
+      "  A silent skip here is exactly the fail-open this check exists to prevent. Either fix the underlying schema shape/mechanism, or (only after confirming quicktype genuinely cannot represent it) add the family to KNOWN_UNREPRESENTABLE_FAMILIES in scripts/check-generation-completeness.mjs with a comment citing the exact failure."
+    );
+    process.exit(1);
+  }
+}

--- a/scripts/merge-generated-fragment.mjs
+++ b/scripts/merge-generated-fragment.mjs
@@ -1,0 +1,98 @@
+// Copyright 2026 UCP Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Appends the NEW declarations from a separately-generated quicktype
+// fragment into the main generated file, skipping anything the main file
+// already declares.
+//
+// Why this exists: quicktype's typescript-zod output has an internal
+// type-ordering pass with a fixed iteration budget ("Exceeded maximum
+// number of passes when determining output order"). Handing it the full
+// combined 2026-08-25 schema graph in ONE invocation (the base nine pinned
+// resources plus every newly-discovered capability and transport) exceeds
+// that budget and silently drops several types rather than failing loudly.
+// Generating each newly-discovered family in its OWN small quicktype
+// invocation (already proven to stay well under the budget -- see the
+// per-capability probe in generate_models.sh) and merging the result here
+// keeps every invocation small while still producing one combined file.
+//
+// Declarations are split on blank lines, which is how quicktype's raw
+// (pre-prettier) typescript-zod output separates each `export const ... /
+// export type ...` pair. A chunk is skipped if ANY name it exports already
+// exists in the main file -- both because the shared discovery/*.json
+// types (CapabilityDiscoverySchema, UcpServiceSchema, ...) are included in
+// every fragment invocation on purpose (they are what let quicktype resolve
+// $refs into the fragment's own file) and are expected to duplicate the
+// main file's copies exactly, and as a safety net against ever silently
+// shadowing an existing export with a same-named but differently-shaped one.
+
+import fs from "node:fs";
+
+const [, , mainPath, fragmentPath] = process.argv;
+
+if (!mainPath || !fragmentPath) {
+  console.error(
+    "Usage: node scripts/merge-generated-fragment.mjs <main.ts> <fragment.ts>"
+  );
+  process.exit(1);
+}
+
+const EXPORT_NAME_RE = /^export (?:const|type) (\w+)/;
+
+function exportedNames(chunk) {
+  const names = [];
+  for (const line of chunk.split("\n")) {
+    const match = line.match(EXPORT_NAME_RE);
+    if (match) {
+      names.push(match[1]);
+    }
+  }
+  return names;
+}
+
+const mainContent = fs.readFileSync(mainPath, "utf8");
+const mainNames = new Set(exportedNames(mainContent));
+
+const fragmentContent = fs.readFileSync(fragmentPath, "utf8");
+const chunks = fragmentContent.split(/\n{2,}/).map((chunk) => chunk.trim());
+
+const newChunks = [];
+let skipped = 0;
+for (const chunk of chunks) {
+  const names = exportedNames(chunk);
+  if (names.length === 0) {
+    // Not a declaration (e.g. a leading comment banner) -- drop it; the
+    // main file already carries any header it needs.
+    continue;
+  }
+  if (names.some((name) => mainNames.has(name))) {
+    skipped++;
+    continue;
+  }
+  newChunks.push(chunk);
+  for (const name of names) {
+    mainNames.add(name);
+  }
+}
+
+if (newChunks.length > 0) {
+  fs.writeFileSync(
+    mainPath,
+    `${mainContent.replace(/\s*$/, "")}\n\n${newChunks.join("\n\n")}\n`
+  );
+}
+
+console.error(
+  `merge-generated-fragment: ${fragmentPath}: ${newChunks.length} new declaration(s) merged, ${skipped} already present (skipped).`
+);

--- a/scripts/project-current-ucp-schemas.mjs
+++ b/scripts/project-current-ucp-schemas.mjs
@@ -192,6 +192,79 @@ function hasKeyword(value, key) {
   return Object.values(value).some((entry) => hasKeyword(entry, key));
 }
 
+// True when a schema contains a BARE same-document root back-reference
+// ("$ref": "#", pointing at the whole document, not a fragment INTO it)
+// ANYWHERE within itself -- the hallmark of a genuinely self-referential/
+// recursive type (e.g. 2026-08-25's new common/types/constraint_expression.json:
+// an Object Constraint whose own `properties.additionalProperties.oneOf` and
+// `anyOf.items` both `"$ref": "#"`, letting a constraint expression nest
+// arbitrarily deep inside itself). This deliberately does NOT match an
+// ordinary "#/$defs/..." fragment reference into a named sub-schema (e.g.
+// common/types/actions.json's `additionalProperties.items` $refs
+// "#/$defs/instance") -- that is a completely normal, quicktype-safe JSON
+// Schema idiom (define a reusable shape once, reference it by name) and
+// must not be flagged just because it also starts with "#".
+//
+// quicktype's typescript-zod target cannot place a genuinely root-recursive
+// type at all -- verified by isolating constraint_expression.json (and
+// everything that reaches it, e.g. available_payment_instrument.json's
+// "constraints" property) with ZERO other schema content in the invocation:
+// quicktype still exhausts its type-ordering pass budget and silently
+// emits NOTHING for it ("Exceeded maximum number of passes when
+// determining output order", zero exports). This is not an interaction
+// with the rest of the graph, and not something a bigger invocation or
+// per-family isolation (the mechanism used for discovered capabilities)
+// can fix -- the type is unrepresentable by itself. See
+// dropSelfReferentialProperties below for where this is used.
+function containsRootSelfRef(node) {
+  if (Array.isArray(node)) {
+    return node.some((entry) => containsRootSelfRef(entry));
+  }
+  if (!node || typeof node !== "object") {
+    return false;
+  }
+  if (node.$ref === "#") {
+    return true;
+  }
+  return Object.values(node).some((value) => containsRootSelfRef(value));
+}
+
+// Drops any property whose value is a $ref to a self-referential schema
+// (see containsRootSelfRef) before quicktype ever sees it, logging loudly
+// so the omission is never silent. Scoped to exactly this shape -- a
+// property that is ONLY a $ref (optionally with sibling annotation keys
+// like "description"), resolved by basename against schemaCache the same
+// way every other cross-file lookup in this script already tolerates a
+// reorg moving files -- so it cannot misfire on an ordinary, quicktype-
+// representable property that merely happens to live near a recursive type.
+function dropSelfReferentialProperties(properties, schemaCache, contextLabel) {
+  if (!schemaCache) {
+    return properties;
+  }
+  const kept = {};
+  for (const [propertyName, propertySchema] of Object.entries(properties)) {
+    const ref = propertySchema?.$ref;
+    if (typeof ref === "string" && !ref.startsWith("#")) {
+      const [refFile] = ref.split("#");
+      const baseName = path.posix.basename(refFile);
+      const candidates = [...schemaCache.keys()].filter(
+        (rel) => path.posix.basename(rel) === baseName
+      );
+      if (candidates.length === 1 && containsRootSelfRef(schemaCache.get(candidates[0]))) {
+        console.error(
+          `project-current-ucp-schemas.mjs: dropping "${propertyName}"${contextLabel ? ` on ${contextLabel}` : ""} -- ` +
+            `it $refs "${baseName}", a self-referential schema quicktype's typescript-zod target cannot represent ` +
+            `(verified in total isolation: zero exports, "Exceeded maximum number of passes"). Left out rather than ` +
+            "silently corrupting the rest of the invocation it's generated alongside."
+        );
+        continue;
+      }
+    }
+    kept[propertyName] = propertySchema;
+  }
+  return kept;
+}
+
 function normalizeRequestRule(rule) {
   if (!rule) {
     return undefined;
@@ -326,12 +399,17 @@ function projectSchemaNode(node, context) {
     }
 
     if (key === "properties" && value && typeof value === "object") {
+      const filteredValue = dropSelfReferentialProperties(
+        value,
+        context.schemaCache,
+        context.outputRel
+      );
       const properties = {};
       const required = new Set(
         Array.isArray(node.required) ? node.required : []
       );
 
-      for (const [propertyName, propertySchema] of Object.entries(value)) {
+      for (const [propertyName, propertySchema] of Object.entries(filteredValue)) {
         const requestRule = effectiveRequestRule(
           propertySchema,
           context.variant
@@ -361,6 +439,15 @@ function projectSchemaNode(node, context) {
       }
 
       output.properties = properties;
+
+      // A property dropped by dropSelfReferentialProperties above must not
+      // linger in "required" -- that would leave the schema demanding a
+      // property it no longer declares.
+      for (const requiredName of required) {
+        if (!(requiredName in properties)) {
+          required.delete(requiredName);
+        }
+      }
 
       if (required.size > 0) {
         output.required = Array.from(required);
@@ -432,45 +519,110 @@ function applyVariantTitles(node, suffix) {
   return output;
 }
 
+// Walk every .json file under `root` recursively, keyed by its POSIX path
+// relative to `sourceSchemasRoot`. This is a strict superset of the old
+// three-directory read (shopping/types, shopping/, common/types): those keys
+// come out identically, so nothing that worked before changes. What changes
+// is that root-level extension/capability files that live directly under
+// common/ (or any future sibling directory) -- invisible to the old
+// three-directory allowlist -- are now cached too, by construction, with no
+// per-directory list to keep in sync as the spec tree reorganizes.
+function walkJsonFiles(root, baseDir, out) {
+  if (!fs.existsSync(baseDir)) {
+    return out;
+  }
+
+  for (const entry of fs.readdirSync(baseDir, { withFileTypes: true })) {
+    const fullPath = path.join(baseDir, entry.name);
+
+    if (entry.isDirectory()) {
+      walkJsonFiles(root, fullPath, out);
+      continue;
+    }
+
+    if (!entry.isFile() || !entry.name.endsWith(".json")) {
+      continue;
+    }
+
+    const relKey = path.posix.relative(
+      root.split(path.sep).join(path.posix.sep),
+      fullPath.split(path.sep).join(path.posix.sep)
+    );
+    out.set(relKey, readJson(fullPath));
+  }
+
+  return out;
+}
+
 function loadSchemaCache() {
-  const cache = new Map();
+  return walkJsonFiles(sourceSchemasRoot, sourceSchemasRoot, new Map());
+}
 
-  for (const fileName of fs.readdirSync(sourceTypesRoot)) {
-    if (!fileName.endsWith(".json")) {
-      continue;
+// A basename -> sourceRel index built lazily from the cache, used as the
+// fallback when a hardcoded sourceRel no longer exists (the file moved
+// directories but kept its filename -- e.g. shopping/payment.json ->
+// common/types/payment.json in the 2026-08-25 reorg).
+function buildBasenameIndex(schemaCache) {
+  const index = new Map();
+  for (const sourceRel of schemaCache.keys()) {
+    const baseName = path.posix.basename(sourceRel);
+    if (!index.has(baseName)) {
+      index.set(baseName, []);
     }
+    index.get(baseName).push(sourceRel);
+  }
+  return index;
+}
 
-    cache.set(
-      `shopping/types/${fileName}`,
-      readJson(path.join(sourceTypesRoot, fileName))
+// Find a cached schema by its declared reverse-domain `name` field, matching
+// on the LAST dot-separated segment (e.g. "ap2_mandate" matches both
+// "dev.ucp.shopping.ap2_mandate" and "dev.ucp.common.payment.ap2_mandate").
+// Used when a schema was renamed as well as relocated, so even a basename
+// match would miss it -- the capability's declared identity is the one thing
+// a reorg is expected to preserve.
+function findSchemaByNameSuffix(schemaCache, suffix) {
+  for (const [sourceRel, schema] of schemaCache.entries()) {
+    if (
+      schema &&
+      typeof schema.name === "string" &&
+      schema.name.split(".").pop() === suffix
+    ) {
+      return [sourceRel, schema];
+    }
+  }
+  return [undefined, undefined];
+}
+
+// Resolve a schema that a hardcoded sourceRel points at, tolerating the
+// file having moved (basename fallback) or having been renamed as well
+// (nameSuffix fallback). Returns [actualSourceRel, schema], or
+// [undefined, undefined] if the schema cannot be found by any of them --
+// callers are expected to fail loudly rather than silently degrade, the
+// same "unknown registry entity fails loudly" posture already used by
+// buildResponseEnvelopeSchema below.
+function resolveSourceSchema(schemaCache, sourceRel, { nameSuffix } = {}) {
+  if (schemaCache.has(sourceRel)) {
+    return [sourceRel, schemaCache.get(sourceRel)];
+  }
+
+  const baseName = path.posix.basename(sourceRel);
+  const basenameIndex = buildBasenameIndex(schemaCache);
+  const candidates = basenameIndex.get(baseName) ?? [];
+  if (candidates.length === 1) {
+    return [candidates[0], schemaCache.get(candidates[0])];
+  }
+
+  if (nameSuffix) {
+    const [foundRel, foundSchema] = findSchemaByNameSuffix(
+      schemaCache,
+      nameSuffix
     );
-  }
-
-  for (const fileName of fs.readdirSync(sourceShoppingRoot)) {
-    if (!fileName.endsWith(".json")) {
-      continue;
-    }
-
-    cache.set(
-      `shopping/${fileName}`,
-      readJson(path.join(sourceShoppingRoot, fileName))
-    );
-  }
-
-  if (fs.existsSync(sourceCommonTypesRoot)) {
-    for (const fileName of fs.readdirSync(sourceCommonTypesRoot)) {
-      if (!fileName.endsWith(".json")) {
-        continue;
-      }
-
-      cache.set(
-        `common/types/${fileName}`,
-        readJson(path.join(sourceCommonTypesRoot, fileName))
-      );
+    if (foundSchema) {
+      return [foundRel, foundSchema];
     }
   }
 
-  return cache;
+  return [undefined, undefined];
 }
 
 function writeProjectedFile(
@@ -711,23 +863,53 @@ function writeCompatibilityDiscoverySchemas() {
   const entityProperties = ucpSchema.$defs.entity.properties;
   const serviceEndpoint = serviceSchema.$defs.base.allOf[1].properties.endpoint;
 
-  const signingKey = {
-    $schema: "https://json-schema.org/draft/2020-12/schema",
-    title: "Signing Key",
-    type: "object",
-    required: ["kid", "kty"],
-    properties: {
-      alg: { type: "string" },
-      crv: { type: "string" },
-      e: { type: "string" },
-      kid: { type: "string" },
-      kty: { type: "string" },
-      n: { type: "string" },
-      use: { type: "string", enum: ["enc", "sig"] },
-      x: { type: "string" },
-      y: { type: "string" },
-    },
-  };
+  // No spec file formally defined the "publish your signing keys" wrapper
+  // document at 2026-04-08, so this hand-authored placeholder guessed both
+  // the property name (signing_keys) and the key item's shape. 2026-08-25
+  // published profile.json, which canonically names the field `keys`
+  // ("Canonical UCP profile field for publishing signing keys... this is
+  // where every UCP verifier reads them") and defines the real item shape
+  // (jwk_public_key, with EC/OKP conditional requirements the hand-authored
+  // version never had). When profile.json exists, derive both the property
+  // name and the item schema from it instead of the guess -- the same class
+  // of fix as the merged capability.extends duplicate (js-sdk#55/#63): stop
+  // hand-authoring what the source now defines, derive it instead. When it
+  // does not exist (2026-04-08 and earlier), fall back to the original
+  // hand-authored shape unchanged, so the committed 2026-04-08 models do not
+  // move a single byte.
+  const profileSchema = loadRootSchema("profile.json");
+  const derivedKeysProperty = profileSchema?.$defs?.base?.properties?.keys;
+  const derivedJwkPublicKey = profileSchema?.$defs?.jwk_public_key;
+  const usingDerivedProfile = Boolean(derivedKeysProperty && derivedJwkPublicKey);
+
+  const keysPropertyName = usingDerivedProfile ? "keys" : "signing_keys";
+  const keyItemOutputFile = usingDerivedProfile
+    ? "jwk_public_key.json"
+    : "signing_key.json";
+
+  const signingKey = usingDerivedProfile
+    ? clone(derivedJwkPublicKey)
+    : {
+        $schema: "https://json-schema.org/draft/2020-12/schema",
+        title: "Signing Key",
+        type: "object",
+        required: ["kid", "kty"],
+        properties: {
+          alg: { type: "string" },
+          crv: { type: "string" },
+          e: { type: "string" },
+          kid: { type: "string" },
+          kty: { type: "string" },
+          n: { type: "string" },
+          use: { type: "string", enum: ["enc", "sig"] },
+          x: { type: "string" },
+          y: { type: "string" },
+        },
+      };
+  if (usingDerivedProfile) {
+    signingKey.$schema = "https://json-schema.org/draft/2020-12/schema";
+    signingKey.title = "Jwk Public Key";
+  }
 
   // Derived from payment_handler.json#/$defs/response_schema (allOf: entity +
   // {required:[id]} + available_instruments). Required {id, version}; carries
@@ -846,9 +1028,9 @@ function writeCompatibilityDiscoverySchemas() {
           },
         },
       },
-      signing_keys: {
+      [keysPropertyName]: {
         type: "array",
-        items: { $ref: "signing_key.json" },
+        items: { $ref: keyItemOutputFile },
       },
       ucp: {
         type: "object",
@@ -868,7 +1050,7 @@ function writeCompatibilityDiscoverySchemas() {
     },
   };
 
-  writeJson(path.join(outputDiscoveryRoot, "signing_key.json"), signingKey);
+  writeJson(path.join(outputDiscoveryRoot, keyItemOutputFile), signingKey);
   writeJson(
     path.join(outputDiscoveryRoot, "payment_handler_resp.json"),
     paymentHandlerResponse
@@ -898,22 +1080,70 @@ function writeCompatibilityDiscoverySchemas() {
 }
 
 function writeCompatibilityCoreSchemas() {
+  // This compat ucp.json is what every response schema's `../ucp.json#/$defs/
+  // response_*_schema` $ref actually resolves against once projected. The
+  // previous version hand-listed exactly the four response_*_schema keys
+  // that existed in the 2026-04-08 spec (checkout/order/cart/catalog). When
+  // 2026-08-25 added response_location_schema (for the new location lookup/
+  // search capability), any new capability whose response envelope $refs it
+  // hit an unresolvable $ref (quicktype: "Key  not in schema object at
+  // .../ucp.json#response_location_schema") -- reproduced while wiring up
+  // the location capabilities discovered by discoverAdditionalCapabilities.
+  // Deriving the key list from the REAL ucp.json's own $defs, instead of
+  // hand-listing them, means a future response_*_schema addition needs no
+  // edit here: response_checkout_schema keeps its distinct envelope (it
+  // alone requires payment_handlers -- see buildResponseEnvelopeSchema's
+  // extraRequired parameter above); every other response_*_schema key maps
+  // to the generic envelope, whatever its name.
+  const realUcpSchema = loadRootSchema("ucp.json");
+  const defs = {};
+  for (const key of Object.keys(realUcpSchema?.$defs ?? {})) {
+    if (!/^response_.*_schema$/.test(key)) {
+      continue;
+    }
+    defs[key] = {
+      $ref:
+        key === "response_checkout_schema"
+          ? "../discovery/ucp_checkout_response.json"
+          : "../discovery/ucp_response.json",
+    };
+  }
+
   const ucpSchema = {
     $schema: "https://json-schema.org/draft/2020-12/schema",
-    $defs: {
-      response_checkout_schema: {
-        $ref: "../discovery/ucp_checkout_response.json",
-      },
-      response_order_schema: { $ref: "../discovery/ucp_response.json" },
-      response_cart_schema: { $ref: "../discovery/ucp_response.json" },
-      response_catalog_schema: { $ref: "../discovery/ucp_response.json" },
-    },
+    $defs: defs,
   };
 
   writeJson(path.join(outputSchemasRoot, "ucp.json"), ucpSchema);
 }
 
-function writeCompatibilityPaymentDataSchema() {
+function writeCompatibilityPaymentDataSchema(schemaCache) {
+  // payment_instrument.json moved from shopping/types/ to common/types/ in
+  // the 2026-08-25 reorg. Rather than hardcode either location, resolve
+  // wherever it actually lives today and compute the $ref from that --
+  // the same resolve-by-basename fallback used for the AP2 and top-level
+  // sourceRel lookups, applied here to a $ref TARGET instead of a $ref
+  // SOURCE, since this is a hand-authored schema, not a projected one.
+  const [targetSourceRel, targetSchema] = resolveSourceSchema(
+    schemaCache,
+    "shopping/types/payment_instrument.json"
+  );
+  if (!targetSchema) {
+    throw new Error(
+      'Could not locate "payment_instrument.json" anywhere under the schema tree.'
+    );
+  }
+
+  const outputRel = "shopping/payment_data.json";
+  const targetOutputRel = mapOutputPathForTarget(
+    targetSourceRel,
+    "response",
+    targetSchema
+  );
+  const relRef =
+    path.posix.relative(path.posix.dirname(outputRel), targetOutputRel) ||
+    ".";
+
   const paymentDataSchema = {
     $schema: "https://json-schema.org/draft/2020-12/schema",
     title: "Payment Data",
@@ -921,15 +1151,12 @@ function writeCompatibilityPaymentDataSchema() {
     required: ["payment_data"],
     properties: {
       payment_data: {
-        $ref: "types/payment_instrument.json",
+        $ref: relRef,
       },
     },
   };
 
-  writeJson(
-    path.join(outputShoppingRoot, "payment_data.json"),
-    paymentDataSchema
-  );
+  writeJson(path.join(outputSchemasRoot, outputRel), paymentDataSchema);
 }
 
 function writeProjectedTypeSchemas(schemaCache) {
@@ -994,32 +1221,79 @@ function writeProjectedTypeSchemas(schemaCache) {
   }
 }
 
-function renameExtensionCheckoutDef(projectedSchema) {
+// Extension capabilities (buyer_consent, discount, fulfillment, ap2, and any
+// capability discovered by discoverExtensionCapabilities below) declare the
+// fields they attach to a host resource under a reverse-domain $defs key
+// ending in the host's name -- "dev.ucp.shopping.checkout", or "...order",
+// "...cart". quicktype needs a stable fragment name to extract, so this
+// renames EVERY such key to its bare host name ("checkout"/"order"/"cart").
+// Renaming every match (not just the first) is what makes this correct for
+// a capability like payment_terms, which attaches to both checkout and
+// order at once -- the original single-match version only handled a
+// capability with exactly one attachment point, which held for every
+// extension in the 2026-04-08 tree but is not a rule the spec makes.
+const ATTACHMENT_TARGETS = ["checkout", "order", "cart"];
+
+function renameExtensionAttachmentDefs(projectedSchema) {
   const schema = clone(projectedSchema);
   if (!schema.$defs) {
     return schema;
   }
 
   for (const key of Object.keys(schema.$defs)) {
-    if (key.endsWith(".checkout")) {
-      schema.$defs.checkout = schema.$defs[key];
-      delete schema.$defs[key];
-      break;
+    for (const target of ATTACHMENT_TARGETS) {
+      if (key.endsWith(`.${target}`)) {
+        schema.$defs[target] = schema.$defs[key];
+        delete schema.$defs[key];
+        break;
+      }
     }
   }
 
   return schema;
 }
 
-function writeProjectedTopLevelSchemas(schemaCache) {
-  for (const [sourceRel, variants] of Object.entries(topLevelVariantMap)) {
-    const sourceSchema = schemaCache.get(sourceRel);
+// Back-compat alias: writeCompatibilityAp2Schema (below) still calls this
+// under its original name.
+function renameExtensionCheckoutDef(projectedSchema) {
+  return renameExtensionAttachmentDefs(projectedSchema);
+}
+
+// True when a (projected) schema declares a $defs key ending in one of the
+// known host attachment points. Used instead of a hardcoded sourceRel list
+// (the whack-a-mole this replaces: sourceRel === "shopping/buyer_consent.json"
+// || ... one clause per extension, requiring an edit for every new one) so
+// that any capability with this SHAPE gets the same treatment regardless of
+// which file it lives in or when it was added to the spec.
+function hasAttachmentDef(schema) {
+  if (!schema?.$defs) {
+    return false;
+  }
+  return Object.keys(schema.$defs).some((key) =>
+    ATTACHMENT_TARGETS.some((target) => key.endsWith(`.${target}`))
+  );
+}
+
+function writeProjectedTopLevelSchemas(schemaCache, variantMap) {
+  for (const [sourceRel, variants] of Object.entries(
+    variantMap ?? topLevelVariantMap
+  )) {
+    const [actualSourceRel, sourceSchema] = resolveSourceSchema(
+      schemaCache,
+      sourceRel
+    );
+    if (!sourceSchema) {
+      throw new Error(
+        `Could not locate "${sourceRel}" (or a same-named file elsewhere) under the schema ` +
+          "tree; it may have moved or been removed upstream -- update topLevelVariantMap."
+      );
+    }
 
     for (const [variant, outputRel] of Object.entries(variants)) {
       let projected = projectSchemaNode(sourceSchema, {
         outputRel,
         schemaCache,
-        sourceRel,
+        sourceRel: actualSourceRel,
         variant,
       });
 
@@ -1028,12 +1302,8 @@ function writeProjectedTopLevelSchemas(schemaCache) {
         titleSuffixForOutput(outputRel)
       );
 
-      if (
-        sourceRel === "shopping/buyer_consent.json" ||
-        sourceRel === "shopping/discount.json" ||
-        sourceRel === "shopping/fulfillment.json"
-      ) {
-        projected = renameExtensionCheckoutDef(projected);
+      if (hasAttachmentDef(projected)) {
+        projected = renameExtensionAttachmentDefs(projected);
       }
 
       writeJson(path.join(outputSchemasRoot, outputRel), projected);
@@ -1042,8 +1312,25 @@ function writeProjectedTopLevelSchemas(schemaCache) {
 }
 
 function writeCompatibilityAp2Schema(schemaCache) {
-  const sourceRel = "shopping/ap2_mandate.json";
-  const sourceSchema = schemaCache.get(sourceRel);
+  // The AP2 mandate extension moved AND was renamed by the 2026-08-25 reorg
+  // (shopping/ap2_mandate.json -> common/payment_ap2_mandate.json), so a
+  // basename fallback alone would miss it. Its declared capability name
+  // ("dev.ucp.shopping.ap2_mandate" -> "dev.ucp.common.payment.ap2_mandate")
+  // still ends in "ap2_mandate" in both, which is the one thing a rename for
+  // a reorg is expected to preserve, so that is the fallback identity.
+  const [sourceRel, sourceSchema] = resolveSourceSchema(
+    schemaCache,
+    "shopping/ap2_mandate.json",
+    { nameSuffix: "ap2_mandate" }
+  );
+  if (!sourceSchema) {
+    throw new Error(
+      'Could not locate the AP2 mandate extension schema anywhere under the schema tree ' +
+        '(looked for "shopping/ap2_mandate.json" and any schema whose declared "name" ends ' +
+        'in ".ap2_mandate"). It may have moved or been renamed again upstream -- update the ' +
+        "lookup in writeCompatibilityAp2Schema()."
+    );
+  }
 
   const responseProjection = projectSchemaNode(sourceSchema, {
     outputRel: "shopping/ap2_mandate.json",
@@ -1140,12 +1427,258 @@ function writeProjectedCommonTypeSchemas(schemaCache) {
   }
 }
 
+// --- Capability discovery (root cause for symptom (c): the --src allowlist
+// missing new capabilities/transports) --------------------------------------
+//
+// checkout/payment/order/buyer_consent/discount/fulfillment/cart/
+// catalog_lookup/catalog_search are a DELIBERATE, curated set: they are the
+// resources with their own real request/response lifecycle (topLevelVariantMap
+// above), not something to auto-derive -- adding or removing one is a product
+// decision, not a filesystem fact. That set is kept as-is.
+//
+// What generate_models.sh got wrong was hand-enumerating every capability
+// BEYOND that set as --src flags, which is a filesystem fact: any new
+// extension or lookup/search capability the reorg adds under common/ (or
+// anywhere else) is invisible until someone edits the allowlist by hand.
+// This walks the now-complete schemaCache (see loadSchemaCache) and finds
+// them by SHAPE, using signals the spec itself publishes:
+//   - a declared reverse-domain `name` (dev.ucp.*) marks a capability schema,
+//     as opposed to a shared type -- verified present on every capability
+//     file in both the 2026-04-08 and 2026-08-25 trees, and absent from the
+//     four core registry files and from every schemas/*/types/* file.
+//   - $defs.lookup_request + $defs.lookup_response (or search_request/
+//     search_response) marks a read-only lookup/search capability -- the
+//     exact shape catalog_lookup.json/catalog_search.json already use.
+//   - a $defs key ending in ".checkout"/".order"/".cart" marks an extension
+//     capability that attaches fields to a host resource -- the exact shape
+//     buyer_consent/discount/fulfillment/ap2_mandate already use.
+// A capability matching none of these (e.g. identity_linking, whose $defs is
+// its own config shape, not an attachment or a lookup pair) is left alone:
+// it is a pre-existing, documented gap in BOTH pins (see the PR body), not a
+// 2026-08-25 regression, and modeling it would also change the 2026-04-08
+// output -- out of scope for a root-cause-the-generator fix.
+function isCoreRegistryFile(sourceRel) {
+  return [
+    "ucp.json",
+    "capability.json",
+    "service.json",
+    "payment_handler.json",
+    "profile.json",
+  ].includes(sourceRel);
+}
+
+function isTypeFile(sourceRel) {
+  return /(^|\/)types\//.test(sourceRel);
+}
+
+function classifyCapability(schema) {
+  const defs = schema?.$defs ?? {};
+  if (defs.lookup_request && defs.lookup_response) {
+    return "lookup";
+  }
+  if (defs.search_request && defs.search_response) {
+    return "search";
+  }
+  if (hasAttachmentDef(schema)) {
+    return "extension";
+  }
+  return "none";
+}
+
+// Discover capability schemas not already covered by topLevelVariantMap or
+// the AP2 extension, and return:
+//   - variantMap: additional topLevelVariantMap-shaped entries to run
+//     through the existing writeProjectedTopLevelSchemas machinery
+//     (lookup/search get a single "response" self-mapping, exactly like
+//     catalog_lookup/catalog_search; extensions get create/update/response,
+//     exactly like buyer_consent/discount/fulfillment).
+//   - manifest: the list of quicktype --src fragment specs (relative to the
+//     projected schemas root) generate_models.sh must add for these to
+//     actually reach the generated output, mirroring the hardcoded
+//     buyer_consent/discount/fulfillment/catalog_lookup/catalog_search
+//     entries already in generate_models.sh.
+//   - skipped: name-bearing capability schemas that matched no known shape,
+//     reported so the accounting is honest rather than silent (Phase 3
+//     doctrine: every hit converted or explicitly out-of-scope with a
+//     reason).
+function discoverAdditionalCapabilities(schemaCache, excludedSourceRels) {
+  const variantMap = {};
+  const manifest = [];
+  const skipped = [];
+
+  for (const [sourceRel, schema] of schemaCache.entries()) {
+    if (
+      excludedSourceRels.has(sourceRel) ||
+      isCoreRegistryFile(sourceRel) ||
+      isTypeFile(sourceRel)
+    ) {
+      continue;
+    }
+    if (typeof schema?.name !== "string" || !schema.name.startsWith("dev.ucp.")) {
+      continue;
+    }
+
+    const kind = classifyCapability(schema);
+    const dir = path.posix.dirname(sourceRel);
+    const baseName = path.posix.basename(sourceRel, ".json");
+
+    if (kind === "lookup" || kind === "search") {
+      const outputRel = sourceRel;
+      const fragments =
+        kind === "lookup"
+          ? ["lookup_request", "lookup_response", "get_product_request", "get_product_response"]
+          : ["search_request", "search_response"];
+
+      // catalog_lookup.json/catalog_search.json (the pre-existing, hardcoded
+      // entries) already name their fragments plainly ("lookup_request" ->
+      // LookupRequestSchema) with no title, because until this discovery
+      // mechanism existed there was only ever one schema using each name.
+      // quicktype names a schema-mode fragment from its own `title` if
+      // present, otherwise from the $ref fragment name -- so a second
+      // capability reusing the same untitled fragment name (confirmed:
+      // location_lookup.json also defines "lookup_request"/"lookup_response")
+      // collides and silently loses one shape's fields (reproduced: without
+      // this, the generated LookupRequestSchema carried location's
+      // {distance, serves, ...} and dropped catalog's `attribution`). Titling
+      // ONLY the newly-discovered capability's copy -- never touching
+      // catalog_lookup/catalog_search's own untitled defs, which stay on the
+      // topLevelVariantMap path unchanged -- fixes the collision without
+      // moving the 2026-04-08 output, since no discovered capability can
+      // exist in that tree to collide in the first place.
+      const projected = clone(schema);
+      for (const fragment of fragments) {
+        if (!projected.$defs?.[fragment]) {
+          continue;
+        }
+        // "lookup"/"search" already echo the capability's own title (e.g.
+        // "Location Lookup"), so only append it for the "get_product_*"
+        // pair, which does not -- avoids a stuttering "Location Lookup
+        // Lookup Request" in favor of "Location Lookup Request".
+        const suffix = fragment
+          .replace(/^(lookup|search)_/, "")
+          .split("_")
+          .map((word) => word[0].toUpperCase() + word.slice(1))
+          .join(" ");
+        projected.$defs[fragment] = {
+          ...projected.$defs[fragment],
+          title: `${schema.title ?? baseName} ${suffix}`,
+        };
+        manifest.push(`${outputRel}#/$defs/${fragment}`);
+      }
+      writeJson(path.join(outputSchemasRoot, outputRel), projected);
+      continue;
+    }
+
+    if (kind === "extension") {
+      const attachmentTargets = ATTACHMENT_TARGETS.filter((target) =>
+        Object.keys(schema.$defs).some((key) => key.endsWith(`.${target}`))
+      );
+      const outputs = {
+        create: `${dir}/${baseName}.create_req.json`,
+        update: `${dir}/${baseName}.update_req.json`,
+        response: `${dir}/${baseName}_resp.json`,
+      };
+      variantMap[sourceRel] = outputs;
+      for (const outputRel of Object.values(outputs)) {
+        for (const target of attachmentTargets) {
+          manifest.push(`${outputRel}#/$defs/${target}`);
+        }
+      }
+      continue;
+    }
+
+    skipped.push({ sourceRel, name: schema.name });
+  }
+
+  return { variantMap, manifest, skipped };
+}
+
+// Transport envelopes (source/schemas/transports/*.json) are a separate
+// concern from capabilities: they have no `name` field and no request/
+// response split. Only "envelope" schemas (a top-level `oneOf` -- the shape
+// of every message envelope: a2a_message, embedded_message, jsonrpc,
+// mcp_tool_call) are modeled; embedded_config.json (a plain `type: object`
+// config schema, present since 2026-04-08) is deliberately left alone --
+// per the existing writeCompatibilityDiscoverySchemas comment, per-transport
+// config typing is a separate, already-documented scope exclusion, and
+// modeling it here would also change the 2026-04-08 output. The envelope/
+// config distinction is a structural fact about each schema, not a version
+// check, so it draws the line correctly for both pins without hardcoding
+// which transports are "new".
+function discoverTransportEnvelopes(schemaCache) {
+  const manifest = [];
+  for (const [sourceRel, schema] of schemaCache.entries()) {
+    if (!sourceRel.startsWith("transports/")) {
+      continue;
+    }
+    if (!Array.isArray(schema?.oneOf)) {
+      continue;
+    }
+    const projected = projectSchemaNode(schema, {
+      outputRel: sourceRel,
+      schemaCache,
+      sourceRel,
+      variant: "response",
+    });
+    writeJson(path.join(outputSchemasRoot, sourceRel), projected);
+    manifest.push(sourceRel);
+  }
+  return manifest;
+}
+
 const schemaCache = loadSchemaCache();
+
+// Resolve where the deliberately-curated top-level resources and the AP2
+// extension actually live today, so discovery below does not re-model them
+// under a second name.
+const knownSourceRels = new Set();
+for (const sourceRel of Object.keys(topLevelVariantMap)) {
+  const [actualSourceRel] = resolveSourceSchema(schemaCache, sourceRel);
+  if (actualSourceRel) {
+    knownSourceRels.add(actualSourceRel);
+  }
+}
+{
+  const [ap2SourceRel] = resolveSourceSchema(schemaCache, "shopping/ap2_mandate.json", {
+    nameSuffix: "ap2_mandate",
+  });
+  if (ap2SourceRel) {
+    knownSourceRels.add(ap2SourceRel);
+  }
+}
+
+const { variantMap: discoveredVariantMap, manifest: discoveredManifest, skipped } =
+  discoverAdditionalCapabilities(schemaCache, knownSourceRels);
+const transportManifest = discoverTransportEnvelopes(schemaCache);
 
 writeCompatibilityDiscoverySchemas();
 writeCompatibilityCoreSchemas();
 writeProjectedTypeSchemas(schemaCache);
 writeProjectedCommonTypeSchemas(schemaCache);
-writeProjectedTopLevelSchemas(schemaCache);
-writeCompatibilityPaymentDataSchema();
+writeProjectedTopLevelSchemas(schemaCache, {
+  ...topLevelVariantMap,
+  ...discoveredVariantMap,
+});
+writeCompatibilityPaymentDataSchema(schemaCache);
 writeCompatibilityAp2Schema(schemaCache);
+
+// generate_models.sh cannot know the discovered --src fragments ahead of
+// time (they depend on which capabilities the checked-out spec tree
+// declares), so hand them across as a manifest instead of a second hardcoded
+// list. Written unconditionally (possibly empty) so the bash side never has
+// to special-case "no manifest file".
+writeJson(path.join(outputRoot, "generated-src-manifest.json"), {
+  capabilities: discoveredManifest,
+  transports: transportManifest,
+});
+
+if (skipped.length > 0) {
+  console.error(
+    `project-current-ucp-schemas.mjs: ${skipped.length} name-bearing capability schema(s) ` +
+      "matched no known shape (lookup/search/checkout-order-cart-extension) and were left " +
+      "unmodeled -- pre-existing gap, not this pass's concern:"
+  );
+  for (const { sourceRel, name } of skipped) {
+    console.error(`  - ${sourceRel} (${name})`);
+  }
+}

--- a/tests/check-generation-completeness.test.js
+++ b/tests/check-generation-completeness.test.js
@@ -1,0 +1,131 @@
+// Copyright 2026 UCP Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Regression coverage for the "never silently drop a discovered family"
+// completeness gate. generate_models.sh's per-family isolation mechanism
+// (each newly-discovered capability gets its own quicktype invocation, so
+// one unrepresentable shape cannot abort generation for every other family)
+// was itself found to be a fail-open: a family that failed its invocation
+// was logged and skipped, but the whole script still exited 0. That means a
+// genuinely fixable regression -- or the isolation mechanism itself
+// breaking -- could silently ship an incomplete src/spec_generated.ts with
+// no red anywhere.
+//
+// scripts/check-generation-completeness.mjs is the fix: every family that
+// fails must be on KNOWN_UNREPRESENTABLE_FAMILIES (a short, reviewed list,
+// each entry citing the exact quicktype failure) or the run exits non-zero.
+// This is tested here directly, independent of quicktype or any spec tree
+// (fixture or real), because the decision itself is pure string-list logic
+// -- exercising it through the full pipeline would make this test depend on
+// the fixture tree being complete enough for generate_models.sh's hardcoded
+// pinned --src list, which is a separate, pre-existing concern unrelated to
+// this gate.
+
+const { test } = require("node:test");
+const assert = require("node:assert/strict");
+const { execFileSync } = require("node:child_process");
+const path = require("node:path");
+
+const REPO_ROOT = path.resolve(__dirname, "..");
+const SCRIPT = path.join(
+  REPO_ROOT,
+  "scripts/check-generation-completeness.mjs"
+);
+
+const {
+  checkCompleteness,
+  KNOWN_UNREPRESENTABLE_FAMILIES,
+} = require("../scripts/check-generation-completeness.mjs");
+
+test("KNOWN_UNREPRESENTABLE_FAMILIES contains exactly the one reviewed exclusion", () => {
+  // Not a rule against ever growing this list -- but any addition should be
+  // a deliberate, reviewed PR change, not something that silently creeps.
+  // If this test starts failing because a new entry was added, update it as
+  // part of reviewing that addition.
+  assert.deepEqual(KNOWN_UNREPRESENTABLE_FAMILIES, [
+    "common/payment_authentication",
+  ]);
+});
+
+test("checkCompleteness: no failed families is trivially complete", () => {
+  const { unjustified, reviewed } = checkCompleteness([]);
+  assert.deepEqual(unjustified, []);
+  assert.deepEqual(reviewed, []);
+});
+
+test("checkCompleteness: a reviewed failure is NOT unjustified", () => {
+  const { unjustified, reviewed } = checkCompleteness([
+    "common/payment_authentication",
+  ]);
+  assert.deepEqual(unjustified, []);
+  assert.deepEqual(reviewed, ["common/payment_authentication"]);
+});
+
+test("checkCompleteness: an unreviewed failure IS unjustified", () => {
+  const { unjustified, reviewed } = checkCompleteness([
+    "common/some_new_capability",
+  ]);
+  assert.deepEqual(unjustified, ["common/some_new_capability"]);
+  assert.deepEqual(reviewed, []);
+});
+
+test("checkCompleteness: a mix separates reviewed from unjustified correctly", () => {
+  const { unjustified, reviewed } = checkCompleteness([
+    "common/payment_authentication",
+    "common/some_new_capability",
+  ]);
+  assert.deepEqual(unjustified, ["common/some_new_capability"]);
+  assert.deepEqual(reviewed, ["common/payment_authentication"]);
+});
+
+test("CLI: exits 0 with no arguments (nothing failed)", () => {
+  assert.doesNotThrow(() =>
+    execFileSync("node", [SCRIPT], { stdio: ["ignore", "pipe", "pipe"] })
+  );
+});
+
+test("CLI: exits 0, with a WARNING, when the only failure is the reviewed exclusion", () => {
+  const result = execFileSync(
+    "node",
+    [SCRIPT, "common/payment_authentication"],
+    { stdio: ["ignore", "pipe", "pipe"] }
+  );
+  assert.ok(result); // did not throw -- exit 0
+});
+
+test("CLI: exits non-zero, with an ERROR naming the family, for an unreviewed failure", () => {
+  assert.throws(
+    () =>
+      execFileSync("node", [SCRIPT, "common/some_new_capability"], {
+        stdio: ["ignore", "pipe", "pipe"],
+      }),
+    (error) => {
+      const output = `${error.stdout ?? ""}${error.stderr ?? ""}`;
+      assert.match(output, /FAILED/);
+      assert.match(output, /common\/some_new_capability/);
+      assert.match(output, /not on the reviewed exclusion list/);
+      return true;
+    }
+  );
+});
+
+test("CLI: a reviewed exclusion alongside an unreviewed failure still fails overall", () => {
+  assert.throws(() =>
+    execFileSync(
+      "node",
+      [SCRIPT, "common/payment_authentication", "common/some_new_capability"],
+      { stdio: ["ignore", "pipe", "pipe"] }
+    )
+  );
+});

--- a/tests/fixtures/reorg-spec/source/schemas/capability.json
+++ b/tests/fixtures/reorg-spec/source/schemas/capability.json
@@ -1,0 +1,48 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ucp.dev/schemas/capability.json",
+  "title": "UCP Capability",
+  "description": "Schema for UCP capabilities and extensions. Extensions are capabilities with an 'extends' field. Uses reverse-domain naming for governance.",
+
+  "$defs": {
+    "base": {
+      "allOf": [
+        { "$ref": "ucp.json#/$defs/entity" },
+        {
+          "type": "object",
+          "properties": {
+            "extends": {
+              "oneOf": [
+                { "$ref": "common/types/reverse_domain_name.json" },
+                {
+                  "type": "array",
+                  "items": { "$ref": "common/types/reverse_domain_name.json" },
+                  "minItems": 1
+                }
+              ],
+              "description": "Parent capability(s) this extends. Present for extensions, absent for root capabilities. Use array for multi-parent extensions."
+            }
+          }
+        }
+      ]
+    },
+
+    "platform_schema": {
+      "title": "Capability (Platform Schema)",
+      "description": "Full capability declaration for platform-level discovery. Includes spec/schema URLs for agent fetching.",
+      "allOf": [{ "$ref": "#/$defs/base" }, { "required": ["spec", "schema"] }]
+    },
+
+    "business_schema": {
+      "title": "Capability (Business Schema)",
+      "description": "Capability declaration for business/merchant discovery. Requires the `schema` URL so platforms can fetch and compose it during negotiation; may also include business-specific config overrides.",
+      "allOf": [{ "$ref": "#/$defs/base" }, { "required": ["schema"] }]
+    },
+
+    "response_schema": {
+      "title": "Capability (Response Schema)",
+      "description": "Capability reference in responses. Only name/version required to confirm active capabilities.",
+      "allOf": [{ "$ref": "#/$defs/base" }]
+    }
+  }
+}

--- a/tests/fixtures/reorg-spec/source/schemas/common/location_lookup.json
+++ b/tests/fixtures/reorg-spec/source/schemas/common/location_lookup.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ucp.dev/schemas/common/location_lookup.json",
+  "name": "dev.ucp.common.location.lookup",
+  "title": "Location Lookup",
+  "$defs": {
+    "lookup_request": { "type": "object", "properties": { "id": { "type": "string" }, "location_radius_marker": { "type": "string" } } },
+    "lookup_response": { "type": "object", "properties": { "id": { "type": "string" }, "location_radius_marker": { "type": "string" } } }
+  }
+}

--- a/tests/fixtures/reorg-spec/source/schemas/common/payment_ap2_mandate.json
+++ b/tests/fixtures/reorg-spec/source/schemas/common/payment_ap2_mandate.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ucp.dev/schemas/common/payment_ap2_mandate.json",
+  "name": "dev.ucp.common.payment.ap2_mandate",
+  "title": "Payment AP2 Mandate Extension",
+  "$defs": {
+    "merchant_authorization": { "type": "object", "properties": { "jwt": { "type": "string" } } },
+    "checkout_mandate": { "type": "object", "properties": { "jwt": { "type": "string" } } },
+    "ap2_with_merchant_authorization": { "type": "object", "properties": { "merchant_authorization": { "type": "string" } } },
+    "ap2_with_checkout_mandate": { "type": "object", "properties": { "checkout_mandate": { "type": "string" } } },
+    "dev.ucp.shopping.checkout": {
+      "type": "object",
+      "properties": {
+        "ap2": { "type": "object", "ucp_request": "optional" }
+      }
+    },
+    "error_code": { "type": "string", "enum": ["ap2_mandate_invalid"] }
+  }
+}

--- a/tests/fixtures/reorg-spec/source/schemas/common/payment_terms.json
+++ b/tests/fixtures/reorg-spec/source/schemas/common/payment_terms.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ucp.dev/schemas/common/payment_terms.json",
+  "name": "dev.ucp.common.payment.terms",
+  "title": "Payment Terms Extension",
+  "$defs": {
+    "payment_term": { "type": "object", "properties": { "due_date": { "type": "string" } } },
+    "dev.ucp.shopping.checkout": {
+      "type": "object",
+      "properties": {
+        "terms": { "type": "array", "items": { "$ref": "#/$defs/payment_term" }, "ucp_request": "optional" }
+      }
+    },
+    "dev.ucp.shopping.order": {
+      "type": "object",
+      "properties": {
+        "terms": { "type": "array", "items": { "$ref": "#/$defs/payment_term" }, "ucp_response": "optional" }
+      }
+    }
+  }
+}

--- a/tests/fixtures/reorg-spec/source/schemas/common/types/pan_credential.json
+++ b/tests/fixtures/reorg-spec/source/schemas/common/types/pan_credential.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ucp.dev/schemas/common/types/pan_credential.json",
+  "title": "Pan Credential",
+  "type": "object",
+  "properties": {
+    "pan": { "type": "string" }
+  }
+}

--- a/tests/fixtures/reorg-spec/source/schemas/common/types/payment.json
+++ b/tests/fixtures/reorg-spec/source/schemas/common/types/payment.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ucp.dev/schemas/common/types/payment.json",
+  "title": "Payment",
+  "type": "object",
+  "properties": {
+    "instruments": { "type": "array", "items": { "type": "string" } },
+    "constraints": {
+      "$ref": "test_recursive_constraint.json",
+      "description": "A self-referential constraint expression, mirroring 2026-08-25's real constraint_expression.json shape, that quicktype's typescript-zod target cannot represent."
+    }
+  }
+}

--- a/tests/fixtures/reorg-spec/source/schemas/common/types/payment_instrument.json
+++ b/tests/fixtures/reorg-spec/source/schemas/common/types/payment_instrument.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ucp.dev/schemas/common/types/payment_instrument.json",
+  "title": "Payment Instrument",
+  "$defs": {
+    "selected_payment_instrument": {
+      "type": "object",
+      "properties": {
+        "handler_id": { "type": "string" }
+      }
+    }
+  }
+}

--- a/tests/fixtures/reorg-spec/source/schemas/common/types/test_recursive_constraint.json
+++ b/tests/fixtures/reorg-spec/source/schemas/common/types/test_recursive_constraint.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ucp.dev/schemas/common/types/test_recursive_constraint.json",
+  "title": "Test Recursive Constraint",
+  "description": "Minimal stand-in for 2026-08-25's real common/types/constraint_expression.json, used only to exercise dropSelfReferentialProperties in project-current-ucp-schemas.mjs. Genuinely self-referential ($ref: \"#\" pointing at the whole document, not a $defs fragment), the exact shape quicktype's typescript-zod target cannot place.",
+  "type": "object",
+  "properties": {
+    "anyOf": {
+      "type": "array",
+      "items": { "$ref": "#" }
+    }
+  }
+}

--- a/tests/fixtures/reorg-spec/source/schemas/payment_handler.json
+++ b/tests/fixtures/reorg-spec/source/schemas/payment_handler.json
@@ -1,0 +1,47 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ucp.dev/schemas/payment_handler.json",
+  "title": "Payment Handler",
+  "description": "Schema for UCP payment handlers. Handlers define how payment instruments are processed.",
+
+  "$defs": {
+    "base": {
+      "allOf": [
+        { "$ref": "ucp.json#/$defs/entity" },
+        {
+          "type": "object",
+          "required": ["id"]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "available_instruments": {
+              "type": "array",
+              "items": { "$ref": "common/types/available_payment_instrument.json" },
+              "description": "Instrument types this handler supports, with optional constraints. When absent, every instrument should be considered available.",
+              "minItems": 1
+            }
+          }
+        }
+      ]
+    },
+
+    "platform_schema": {
+      "title": "Payment Handler (Platform Schema)",
+      "description": "Platform declaration for discovery profiles. May include partial config state required for discovery.",
+      "allOf": [{ "$ref": "#/$defs/base" }, { "required": ["spec", "schema"] }]
+    },
+
+    "business_schema": {
+      "title": "Payment Handler (Business Schema)",
+      "description": "Business declaration for discovery profiles. May include partial config state required for discovery.",
+      "allOf": [{ "$ref": "#/$defs/base" }]
+    },
+
+    "response_schema": {
+      "title": "Payment Handler (Response Schema)",
+      "description": "Handler reference in responses. May include full config state for runtime usage of the handler.",
+      "allOf": [{ "$ref": "#/$defs/base" }]
+    }
+  }
+}

--- a/tests/fixtures/reorg-spec/source/schemas/profile.json
+++ b/tests/fixtures/reorg-spec/source/schemas/profile.json
@@ -1,0 +1,134 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ucp.dev/schemas/profile.json",
+  "title": "UCP Profile Document",
+  "description": "Variant-neutral wrapper schema for UCP profile documents. Use the business_schema definition to validate business profiles and the platform_schema definition to validate platform profiles.",
+  "allOf": [{ "$ref": "#/$defs/base" }],
+
+  "$defs": {
+    "jwk_public_key": {
+      "type": "object",
+      "description": "Public JSON Web Key used for HTTP Message Signatures and signed webhook verification. UCP profiles publish public keys only; private key material MUST NOT appear in a profile. Well-known key types: EC (ECDSA P-256, P-384) and OKP (EdDSA Ed25519); OKP keys are RECOMMENDED for signers opting into Web Bot Auth (WBA) interop on HTTP transport. A single profile MAY publish keys of either or both types; consumers select keys by kid. The kty, crv, and alg vocabularies are OPEN: verifiers MUST tolerate key types, curves, and algorithms they do not recognize, selecting keys by kid at verification time. An unsupported key affects only the signature that references it (algorithm_unsupported) and MUST NOT cause whole-profile rejection. Additional public JWK members are permitted; consumers ignore unknown members.",
+      "required": ["kid", "kty"],
+      "properties": {
+        "kid": {
+          "type": "string",
+          "description": "Key identifier referenced by Signature-Input keyid. For keys used in dual-audience (Web Bot Auth) signatures, the kid MUST be the key's JWK SHA-256 Thumbprint (RFC 7638) so UCP-Agent and Signature-Agent lookups resolve the same key; otherwise the kid MAY be any stable string."
+        },
+        "kty": {
+          "type": "string",
+          "examples": ["EC", "OKP"],
+          "description": "JWK key type. Well-known values: EC for ECDSA (P-256, P-384); OKP for EdDSA (Ed25519). Open vocabulary; verifiers tolerate unrecognized types and select keys by kid."
+        },
+        "crv": {
+          "type": "string",
+          "examples": ["P-256", "P-384", "Ed25519"],
+          "description": "Curve name. Well-known values: P-256, P-384 (EC); Ed25519 (OKP). Open vocabulary."
+        },
+        "x": {
+          "type": "string",
+          "description": "Public key value, base64url-encoded. For EC, the x coordinate (RFC 7518 §6.2); for OKP, the public key (RFC 8037 §2)."
+        },
+        "y": {
+          "type": "string",
+          "description": "EC public key y coordinate, base64url-encoded (RFC 7518 §6.2). Not used by OKP keys."
+        },
+        "alg": {
+          "type": "string",
+          "examples": ["ES256", "ES384", "EdDSA"],
+          "description": "JWA algorithm associated with this public key. Optional; verifiers derive the algorithm from crv when alg is omitted. When present for a well-known curve it MUST match: ES256 with P-256, ES384 with P-384, EdDSA with Ed25519."
+        },
+        "use": {
+          "type": "string",
+          "description": "JWK public key use. UCP examples use sig for signatures."
+        }
+      },
+      "allOf": [
+        {
+          "title": "EC keys carry crv, x, y",
+          "if": { "properties": { "kty": { "const": "EC" } }, "required": ["kty"] },
+          "then": { "required": ["crv", "x", "y"] }
+        },
+        {
+          "title": "OKP keys carry crv, x",
+          "if": { "properties": { "kty": { "const": "OKP" } }, "required": ["kty"] },
+          "then": { "required": ["crv", "x"] }
+        },
+        {
+          "title": "P-256 pairs with ES256",
+          "if": { "properties": { "crv": { "const": "P-256" } }, "required": ["crv"] },
+          "then": { "properties": { "alg": { "const": "ES256" } } }
+        },
+        {
+          "title": "P-384 pairs with ES384",
+          "if": { "properties": { "crv": { "const": "P-384" } }, "required": ["crv"] },
+          "then": { "properties": { "alg": { "const": "ES384" } } }
+        },
+        {
+          "title": "Ed25519 pairs with EdDSA",
+          "if": { "properties": { "crv": { "const": "Ed25519" } }, "required": ["crv"] },
+          "then": { "properties": { "alg": { "const": "EdDSA" } } }
+        }
+      ],
+      "not": {
+        "anyOf": [
+          { "required": ["d"] },
+          { "required": ["p"] },
+          { "required": ["q"] },
+          { "required": ["dp"] },
+          { "required": ["dq"] },
+          { "required": ["qi"] },
+          { "required": ["oth"] },
+          { "required": ["k"] }
+        ]
+      },
+      "additionalProperties": true
+    },
+
+    "base": {
+      "type": "object",
+      "description": "Common wrapper for UCP profile documents.",
+      "required": ["ucp"],
+      "properties": {
+        "ucp": {
+          "$ref": "ucp.json#/$defs/base",
+          "description": "Protocol metadata, capabilities, services, and payment handlers advertised by this party."
+        },
+        "keys": {
+          "type": "array",
+          "description": "Canonical UCP profile field for publishing signing keys, as a JWK Set per RFC 7517. When a profile publishes signing keys, they MUST appear here; this is where every UCP verifier reads them. Publishing keys[] makes the UCP profile a valid JWK Set that a signer can reuse as its Web Bot Auth key source: a WBA-shape verifier resolving via Signature-Agent type=jwks_uri pointed at this profile reads these keys, and the cimd and directory variants reach them through their own documents. See the Deployment Patterns for WBA Interop section in the overview for hosting patterns.",
+          "items": { "$ref": "#/$defs/jwk_public_key" }
+        }
+      },
+      "additionalProperties": true
+    },
+
+    "business_schema": {
+      "title": "UCP Business Profile Document",
+      "description": "Profile document hosted by a business at /.well-known/ucp.",
+      "allOf": [
+        { "$ref": "#/$defs/base" },
+        {
+          "type": "object",
+          "properties": {
+            "ucp": { "$ref": "ucp.json#/$defs/business_schema" }
+          }
+        }
+      ]
+    },
+
+    "platform_schema": {
+      "title": "UCP Platform Profile Document",
+      "description": "Profile document hosted by a platform and advertised to businesses via UCP-Agent.",
+      "allOf": [
+        { "$ref": "#/$defs/base" },
+        {
+          "type": "object",
+          "properties": {
+            "ucp": { "$ref": "ucp.json#/$defs/platform_schema" }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/tests/fixtures/reorg-spec/source/schemas/service.json
+++ b/tests/fixtures/reorg-spec/source/schemas/service.json
@@ -1,0 +1,115 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ucp.dev/schemas/service.json",
+  "title": "UCP Service",
+  "description": "Service declaration with one transport binding. Each transport binding is a separate entry in the service array; `version` identifies the service, not the transport.",
+
+  "$defs": {
+    "base": {
+      "allOf": [
+        { "$ref": "ucp.json#/$defs/entity" },
+        {
+          "type": "object",
+          "required": ["transport"],
+          "properties": {
+            "transport": {
+              "type": "string",
+              "enum": ["rest", "mcp", "a2a", "embedded"],
+              "description": "Transport protocol for this service binding."
+            },
+            "endpoint": {
+              "type": "string",
+              "format": "uri",
+              "description": "Endpoint URL for this transport binding."
+            }
+          }
+        }
+      ]
+    },
+
+    "platform_schema": {
+      "title": "Service (Platform Schema)",
+      "description": "Full service declaration for platform-level discovery. All transports require `version`, `spec`, and `transport`. REST, MCP, and embedded additionally require `schema`.",
+      "allOf": [
+        { "$ref": "#/$defs/base" },
+        { "required": ["spec"] },
+        {
+          "anyOf": [
+            {
+              "properties": { "transport": { "const": "rest" } },
+              "required": ["schema"]
+            },
+            {
+              "properties": { "transport": { "const": "mcp" } },
+              "required": ["schema"]
+            },
+            {
+              "properties": { "transport": { "const": "a2a" } }
+            },
+            {
+              "properties": { "transport": { "const": "embedded" } },
+              "required": ["schema"]
+            }
+          ]
+        }
+      ]
+    },
+
+    "business_schema": {
+      "title": "Service (Business Schema)",
+      "description": "Service binding for business/merchant configuration. May override platform endpoints.",
+      "allOf": [
+        { "$ref": "#/$defs/base" },
+        {
+          "anyOf": [
+            {
+              "properties": { "transport": { "const": "rest" } },
+              "required": ["endpoint"]
+            },
+            {
+              "properties": { "transport": { "const": "mcp" } },
+              "required": ["endpoint"]
+            },
+            {
+              "properties": { "transport": { "const": "a2a" } },
+              "required": ["endpoint"]
+            },
+            {
+              "properties": {
+                "transport": { "const": "embedded" },
+                "config": { "$ref": "transports/embedded_config.json" }
+              }
+            }
+          ]
+        }
+      ]
+    },
+
+    "response_schema": {
+      "title": "Service (Response Schema)",
+      "description": "Service binding in API responses. Includes per-resource transport configuration via typed config.",
+      "allOf": [
+        { "$ref": "#/$defs/base" },
+        {
+          "anyOf": [
+            {
+              "properties": { "transport": { "const": "rest" } }
+            },
+            {
+              "properties": { "transport": { "const": "mcp" } }
+            },
+            {
+              "properties": { "transport": { "const": "a2a" } }
+            },
+            {
+              "properties": {
+                "transport": { "const": "embedded" },
+                "config": { "$ref": "transports/embedded_config.json" }
+              }
+            }
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/tests/fixtures/reorg-spec/source/schemas/shopping/buyer_consent.json
+++ b/tests/fixtures/reorg-spec/source/schemas/shopping/buyer_consent.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ucp.dev/schemas/shopping/buyer_consent.json",
+  "name": "dev.ucp.shopping.buyer_consent",
+  "title": "Buyer Consent Extension",
+  "$defs": {
+    "dev.ucp.shopping.checkout": {
+      "type": "object",
+      "properties": {
+        "consent": { "type": "boolean", "ucp_request": "optional" }
+      }
+    }
+  }
+}

--- a/tests/fixtures/reorg-spec/source/schemas/shopping/cart.json
+++ b/tests/fixtures/reorg-spec/source/schemas/shopping/cart.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ucp.dev/schemas/shopping/cart.json",
+  "name": "dev.ucp.shopping.cart",
+  "title": "Cart",
+  "type": "object",
+  "properties": {
+    "id": { "type": "string" }
+  }
+}

--- a/tests/fixtures/reorg-spec/source/schemas/shopping/catalog_lookup.json
+++ b/tests/fixtures/reorg-spec/source/schemas/shopping/catalog_lookup.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ucp.dev/schemas/shopping/catalog_lookup.json",
+  "name": "dev.ucp.shopping.catalog.lookup",
+  "title": "Catalog Lookup",
+  "$defs": {
+    "lookup_request": { "type": "object", "properties": { "id": { "type": "string" }, "catalog_handle_marker": { "type": "string" } } },
+    "lookup_response": { "type": "object", "properties": { "id": { "type": "string" }, "catalog_handle_marker": { "type": "string" } } },
+    "get_product_request": { "type": "object", "properties": { "id": { "type": "string" } } },
+    "get_product_response": { "type": "object", "properties": { "id": { "type": "string" } } }
+  }
+}

--- a/tests/fixtures/reorg-spec/source/schemas/shopping/catalog_search.json
+++ b/tests/fixtures/reorg-spec/source/schemas/shopping/catalog_search.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ucp.dev/schemas/shopping/catalog_search.json",
+  "name": "dev.ucp.shopping.catalog.search",
+  "title": "Catalog Search",
+  "$defs": {
+    "search_request": { "type": "object", "properties": { "q": { "type": "string" } } },
+    "search_response": { "type": "object", "properties": { "q": { "type": "string" } } }
+  }
+}

--- a/tests/fixtures/reorg-spec/source/schemas/shopping/checkout.json
+++ b/tests/fixtures/reorg-spec/source/schemas/shopping/checkout.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ucp.dev/schemas/shopping/checkout.json",
+  "name": "dev.ucp.shopping.checkout",
+  "title": "Checkout",
+  "type": "object",
+  "properties": {
+    "id": { "type": "string" }
+  }
+}

--- a/tests/fixtures/reorg-spec/source/schemas/shopping/discount.json
+++ b/tests/fixtures/reorg-spec/source/schemas/shopping/discount.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ucp.dev/schemas/shopping/discount.json",
+  "name": "dev.ucp.shopping.discount",
+  "title": "Discount Extension",
+  "$defs": {
+    "dev.ucp.shopping.checkout": {
+      "type": "object",
+      "properties": {
+        "code": { "type": "string", "ucp_request": "optional" }
+      }
+    }
+  }
+}

--- a/tests/fixtures/reorg-spec/source/schemas/shopping/fulfillment.json
+++ b/tests/fixtures/reorg-spec/source/schemas/shopping/fulfillment.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ucp.dev/schemas/shopping/fulfillment.json",
+  "name": "dev.ucp.shopping.fulfillment",
+  "title": "Fulfillment Extension",
+  "$defs": {
+    "dev.ucp.shopping.checkout": {
+      "type": "object",
+      "properties": {
+        "method": { "type": "string", "ucp_request": "optional" }
+      }
+    }
+  }
+}

--- a/tests/fixtures/reorg-spec/source/schemas/shopping/order.json
+++ b/tests/fixtures/reorg-spec/source/schemas/shopping/order.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ucp.dev/schemas/shopping/order.json",
+  "name": "dev.ucp.shopping.order",
+  "title": "Order",
+  "type": "object",
+  "properties": {
+    "id": { "type": "string" }
+  }
+}

--- a/tests/fixtures/reorg-spec/source/schemas/transports/embedded_config.json
+++ b/tests/fixtures/reorg-spec/source/schemas/transports/embedded_config.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ucp.dev/schemas/transports/embedded_config.json",
+  "title": "Embedded Transport Config",
+  "type": "object",
+  "properties": {
+    "channel": { "type": "string" }
+  }
+}

--- a/tests/fixtures/reorg-spec/source/schemas/transports/mcp_tool_call.json
+++ b/tests/fixtures/reorg-spec/source/schemas/transports/mcp_tool_call.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ucp.dev/schemas/transports/mcp_tool_call.json",
+  "title": "MCP Tool Call Envelope",
+  "description": "Envelope for MCP tool calls.",
+  "oneOf": [{ "$ref": "#/$defs/call" }],
+  "$defs": {
+    "call": { "type": "object", "properties": { "tool": { "type": "string" } } }
+  }
+}

--- a/tests/fixtures/reorg-spec/source/schemas/ucp.json
+++ b/tests/fixtures/reorg-spec/source/schemas/ucp.json
@@ -1,0 +1,341 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ucp.dev/schemas/ucp.json",
+  "title": "UCP Metadata",
+  "description": "Protocol metadata for discovery profiles and responses. Uses slim schema pattern with context-specific required fields.",
+
+  "$defs": {
+    "version": {
+      "type": "string",
+      "pattern": "^\\d{4}-\\d{2}-\\d{2}$",
+      "description": "Version identifier in YYYY-MM-DD format."
+    },
+
+    "version_constraint": {
+      "type": "object",
+      "description": "Version range requirement with minimum and optional maximum.",
+      "properties": {
+        "min": {
+          "$ref": "#/$defs/version",
+          "description": "Minimum required version (inclusive)."
+        },
+        "max": {
+          "$ref": "#/$defs/version",
+          "description": "Maximum compatible version (inclusive). When absent, no upper bound."
+        }
+      },
+      "required": ["min"],
+      "additionalProperties": true
+    },
+
+    "requires": {
+      "type": "object",
+      "description": "Version requirements for extension schemas. Declares minimum (and optionally maximum) protocol and capability versions needed for correct operation.",
+      "properties": {
+        "protocol": {
+          "$ref": "#/$defs/version_constraint",
+          "description": "Required range for the selected `ucp.version`."
+        },
+        "capabilities": {
+          "type": "object",
+          "description": "Required capability versions, keyed by capability name. Keys must be a subset of the extension's $defs keys.",
+          "propertyNames": { "$ref": "common/types/reverse_domain_name.json" },
+          "additionalProperties": { "$ref": "#/$defs/version_constraint" }
+        }
+      },
+      "additionalProperties": true
+    },
+
+    "map_order": {
+      "type": "object",
+      "description": "Preferred key order for map-valued fields in the scope annotated by the containing `ucp` member. Each property names a target map, and its array lists target keys in preferred order. Lists may be partial and are not allowlists.",
+      "additionalProperties": {
+        "type": "array",
+        "items": { "type": "string" }
+      }
+    },
+
+    "members": {
+      "type": "object",
+      "description": "Members defined inside the reserved `ucp` protocol object. The object is open for forward compatibility: consumers MUST ignore unrecognized members. Only UCP core defines members, and every defined member MUST be safe to ignore.",
+      "properties": {
+        "map_order": {
+          "$ref": "#/$defs/map_order",
+          "ucp_request": "omit"
+        },
+        "request_constraints": {
+          "$ref": "common/types/request_constraints.json",
+          "ucp_request": "omit"
+        }
+      },
+      "additionalProperties": true
+    },
+
+    "entity": {
+      "type": "object",
+      "description": "Shared foundation for all UCP entities.",
+      "required": ["version"],
+      "properties": {
+        "version": {
+          "$ref": "#/$defs/version",
+          "description": "Entity version in YYYY-MM-DD format."
+        },
+        "spec": {
+          "type": "string",
+          "format": "uri",
+          "description": "URL to human-readable specification document."
+        },
+        "schema": {
+          "type": "string",
+          "format": "uri",
+          "description": "URL to JSON Schema defining this entity's structure and payloads."
+        },
+        "id": {
+          "type": "string",
+          "description": "Unique identifier for this entity instance. Used to disambiguate when multiple instances exist."
+        },
+        "config": {
+          "type": "object",
+          "description": "Entity-specific configuration. Structure defined by each entity's schema.",
+          "additionalProperties": true
+        }
+      }
+    },
+
+    "base": {
+      "description": "Base UCP metadata with shared properties for all schema types.",
+      "type": "object",
+      "required": ["version"],
+      "properties": {
+        "version": { "$ref": "#/$defs/version" },
+        "map_order": {
+          "$ref": "#/$defs/map_order",
+          "description": "Preferred key-traversal order for sibling registry fields inside the root `ucp` envelope (`services`, `capabilities`, and `payment_handlers`).",
+          "ucp_request": "omit"
+        },
+        "status": {
+          "type": "string",
+          "enum": ["success", "error"],
+          "default": "success",
+          "description": "Application-level status of the UCP operation."
+        },
+        "services": {
+          "type": "object",
+          "description": "Service registry keyed by reverse-domain name.",
+          "propertyNames": { "$ref": "common/types/reverse_domain_name.json" },
+          "additionalProperties": {
+            "type": "array",
+            "items": { "$ref": "service.json#/$defs/base" }
+          }
+        },
+        "capabilities": {
+          "type": "object",
+          "description": "Capability registry keyed by reverse-domain name.",
+          "propertyNames": { "$ref": "common/types/reverse_domain_name.json" },
+          "additionalProperties": {
+            "type": "array",
+            "items": { "$ref": "capability.json#/$defs/base" }
+          }
+        },
+        "payment_handlers": {
+          "type": "object",
+          "description": "Payment handler registry keyed by reverse-domain name.",
+          "propertyNames": { "$ref": "common/types/reverse_domain_name.json" },
+          "additionalProperties": {
+            "type": "array",
+            "items": { "$ref": "payment_handler.json#/$defs/base" }
+          }
+        }
+      }
+    },
+
+    "success": {
+      "description": "UCP metadata with status 'success'. Use for response branches that carry the expected payload.",
+      "allOf": [
+        { "$ref": "#/$defs/base" },
+        {
+          "properties": { "status": { "const": "success" } },
+          "required": ["status"]
+        }
+      ]
+    },
+
+    "error": {
+      "description": "UCP metadata with status 'error'. Use for response branches that carry error information.",
+      "allOf": [
+        { "$ref": "#/$defs/base" },
+        {
+          "properties": { "status": { "const": "error" } },
+          "required": ["status"]
+        }
+      ]
+    },
+
+    "platform_schema": {
+      "title": "UCP Platform Schema",
+      "description": "Full UCP metadata for platform-level configuration. Hosted at a URI advertised by the platform in request headers.",
+      "allOf": [
+        { "$ref": "#/$defs/base" },
+        {
+          "required": ["services", "payment_handlers"],
+          "properties": {
+            "services": {
+              "additionalProperties": {
+                "items": { "$ref": "service.json#/$defs/platform_schema" }
+              }
+            },
+            "capabilities": {
+              "additionalProperties": {
+                "items": { "$ref": "capability.json#/$defs/platform_schema" }
+              }
+            },
+            "payment_handlers": {
+              "additionalProperties": {
+                "items": {
+                  "$ref": "payment_handler.json#/$defs/platform_schema"
+                }
+              }
+            }
+          }
+        }
+      ]
+    },
+
+    "business_schema": {
+      "title": "UCP Business Schema",
+      "description": "UCP metadata for business/merchant-level configuration. Subset of platform schema with business-specific settings.",
+      "allOf": [
+        { "$ref": "#/$defs/base" },
+        {
+          "required": ["services", "payment_handlers"],
+          "properties": {
+            "supported_versions": {
+              "type": "object",
+              "description": "Previous protocol versions this business supports, mapped to profile URIs. Businesses that support older protocol versions SHOULD advertise each version and link to its profile. Each URI points to a complete, self-contained profile for that version. When omitted, only `version` is supported.",
+              "propertyNames": { "$ref": "#/$defs/version" },
+              "additionalProperties": {
+                "type": "string",
+                "format": "uri"
+              }
+            },
+            "services": {
+              "additionalProperties": {
+                "items": { "$ref": "service.json#/$defs/business_schema" }
+              }
+            },
+            "capabilities": {
+              "additionalProperties": {
+                "items": { "$ref": "capability.json#/$defs/business_schema" }
+              }
+            },
+            "payment_handlers": {
+              "additionalProperties": {
+                "items": {
+                  "$ref": "payment_handler.json#/$defs/business_schema"
+                }
+              }
+            }
+          }
+        }
+      ]
+    },
+
+    "response_checkout_schema": {
+      "title": "UCP Checkout Response Schema",
+      "description": "UCP metadata for checkout responses.",
+      "allOf": [
+        { "$ref": "#/$defs/base" },
+        {
+          "required": ["payment_handlers"],
+          "properties": {
+            "services": {
+              "additionalProperties": {
+                "items": { "$ref": "service.json#/$defs/response_schema" }
+              }
+            },
+            "capabilities": {
+              "additionalProperties": {
+                "items": { "$ref": "capability.json#/$defs/response_schema" }
+              }
+            },
+            "payment_handlers": {
+              "additionalProperties": {
+                "items": {
+                  "$ref": "payment_handler.json#/$defs/response_schema"
+                }
+              }
+            }
+          }
+        }
+      ]
+    },
+
+    "response_order_schema": {
+      "title": "UCP Order Response Schema",
+      "description": "UCP metadata for order responses. No payment handlers needed post-purchase.",
+      "allOf": [
+        { "$ref": "#/$defs/base" },
+        {
+          "properties": {
+            "capabilities": {
+              "additionalProperties": {
+                "items": { "$ref": "capability.json#/$defs/response_schema" }
+              }
+            }
+          }
+        }
+      ]
+    },
+
+    "response_cart_schema": {
+      "title": "UCP Cart Response Schema",
+      "description": "UCP metadata for cart responses. No payment handlers needed pre-checkout.",
+      "allOf": [
+        { "$ref": "#/$defs/base" },
+        {
+          "properties": {
+            "capabilities": {
+              "additionalProperties": {
+                "items": { "$ref": "capability.json#/$defs/response_schema" }
+              }
+            }
+          }
+        }
+      ]
+    },
+
+    "response_catalog_schema": {
+      "title": "UCP Catalog Response Schema",
+      "description": "UCP metadata for catalog responses.",
+      "allOf": [
+        { "$ref": "#/$defs/base" },
+        {
+          "properties": {
+            "capabilities": {
+              "additionalProperties": {
+                "items": { "$ref": "capability.json#/$defs/response_schema" }
+              }
+            }
+          }
+        }
+      ]
+    },
+
+    "response_location_schema": {
+      "title": "UCP Location Response Schema",
+      "description": "UCP metadata for location responses.",
+      "allOf": [
+        { "$ref": "#/$defs/base" },
+        {
+          "properties": {
+            "capabilities": {
+              "additionalProperties": {
+                "items": { "$ref": "capability.json#/$defs/response_schema" }
+              }
+            }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/tests/generate-0825-projection.test.js
+++ b/tests/generate-0825-projection.test.js
@@ -1,0 +1,345 @@
+// Copyright 2026 UCP Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Regression coverage for the generation pipeline being broken at the root
+// against a reorganized spec tree (the 2026-08-25 release moved ~work
+// schemas from schemas/shopping/ to a new schemas/common/ tree, renamed the
+// AP2 mandate extension, and published a canonical `keys` profile document
+// where none existed before). tests/fixtures/reorg-spec is a small synthetic
+// tree reproducing that shape (NOT the full real spec) so this test is fast,
+// deterministic, and does not depend on network access or a real UCP
+// checkout.
+//
+// Before the fix in scripts/project-current-ucp-schemas.mjs, running this
+// against the fixture crashed:
+//   SyntaxError: "undefined" is not valid JSON
+//     at clone (scripts/project-current-ucp-schemas.mjs:176)
+//     at renameExtensionCheckoutDef (...:998)
+//     at writeCompatibilityAp2Schema (...:1076)
+// because writeCompatibilityAp2Schema hardcoded the AP2 extension's
+// pre-reorg path (shopping/ap2_mandate.json), and loadSchemaCache never
+// walked schemas/common/ root files at all, so the schema was never found
+// even by accident.
+
+const { test } = require("node:test");
+const assert = require("node:assert/strict");
+const { execFileSync } = require("node:child_process");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+
+const REPO_ROOT = path.resolve(__dirname, "..");
+const FIXTURE_SOURCE = path.join(REPO_ROOT, "tests/fixtures/reorg-spec/source");
+const PROJECTOR_SCRIPT = path.join(
+  REPO_ROOT,
+  "scripts/project-current-ucp-schemas.mjs"
+);
+
+function runProjector() {
+  const outDir = fs.mkdtempSync(
+    path.join(os.tmpdir(), "ucp-js-sdk-reorg-fixture-")
+  );
+  execFileSync("node", [PROJECTOR_SCRIPT, FIXTURE_SOURCE, outDir], {
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  return outDir;
+}
+
+function readJson(...segments) {
+  return JSON.parse(fs.readFileSync(path.join(...segments), "utf8"));
+}
+
+test("projects a reorganized (2026-08-25-shaped) spec tree without crashing", () => {
+  // The crash reproduction itself: before the fix this throws
+  // (execFileSync surfaces the child's non-zero exit as a thrown error).
+  assert.doesNotThrow(() => runProjector());
+});
+
+test("resolves the AP2 extension after it moved AND was renamed", () => {
+  const outDir = runProjector();
+  const ap2 = readJson(outDir, "schemas/shopping/ap2_mandate.json");
+  assert.ok(
+    ap2.$defs.complete_request_with_ap2,
+    "expected the synthesized complete_request_with_ap2 def"
+  );
+  assert.ok(
+    ap2.$defs.checkout_response_with_ap2,
+    "expected the synthesized checkout_response_with_ap2 def"
+  );
+  // The source's own dev.ucp.shopping.checkout attachment def must have been
+  // found and folded in -- not the empty-fallback shape writeCompatibilityAp2Schema
+  // uses when the source schema cannot be resolved at all.
+  assert.deepEqual(ap2.$defs.checkout_response_with_ap2.properties.ap2, {
+    type: "object",
+  });
+});
+
+test("resolves payment.json's relocation from shopping/ to common/types/", () => {
+  const outDir = runProjector();
+  const paymentData = readJson(outDir, "schemas/shopping/payment_data.json");
+  assert.equal(
+    paymentData.properties.payment_data.$ref,
+    "../common/types/payment_instrument.json",
+    "the $ref must point at payment_instrument.json's ACTUAL (relocated) output path"
+  );
+});
+
+test("discovers a new common/ lookup capability without a hand list", () => {
+  const outDir = runProjector();
+  const manifest = readJson(outDir, "generated-src-manifest.json");
+  assert.ok(
+    manifest.capabilities.includes(
+      "common/location_lookup.json#/$defs/lookup_request"
+    )
+  );
+  assert.ok(
+    manifest.capabilities.includes(
+      "common/location_lookup.json#/$defs/lookup_response"
+    )
+  );
+  assert.ok(
+    fs.existsSync(path.join(outDir, "schemas/common/location_lookup.json"))
+  );
+});
+
+test("discovers a new common/ extension capability attaching to BOTH checkout and order", () => {
+  const outDir = runProjector();
+  const manifest = readJson(outDir, "generated-src-manifest.json");
+  for (const target of ["checkout", "order"]) {
+    for (const suffix of [
+      "payment_terms.create_req.json",
+      "payment_terms.update_req.json",
+      "payment_terms_resp.json",
+    ]) {
+      assert.ok(
+        manifest.capabilities.includes(`common/${suffix}#/$defs/${target}`),
+        `expected common/${suffix}#/$defs/${target} in the manifest`
+      );
+    }
+  }
+
+  const createReq = readJson(
+    outDir,
+    "schemas/common/payment_terms.create_req.json"
+  );
+  assert.ok(
+    createReq.$defs.checkout,
+    "checkout attachment def must be renamed to the bare name"
+  );
+  assert.ok(
+    createReq.$defs.order,
+    "order attachment def must be renamed to the bare name"
+  );
+});
+
+test("does not model a pre-existing capability that matches no known shape (identity_linking is out of scope here)", () => {
+  // Not present in this fixture at all -- this documents the boundary: only
+  // lookup/search/extension-shaped capabilities are auto-discovered, so a
+  // capability like identity_linking (own config shape, no attachment def,
+  // no lookup/search pair) is correctly left as a residual rather than
+  // silently swept in. See discoverAdditionalCapabilities's module comment.
+  const outDir = runProjector();
+  const manifest = readJson(outDir, "generated-src-manifest.json");
+  assert.ok(
+    !manifest.capabilities.some((entry) => entry.includes("identity_linking"))
+  );
+});
+
+test("models only transport ENVELOPES (oneOf), not the pre-existing config schema", () => {
+  const outDir = runProjector();
+  const manifest = readJson(outDir, "generated-src-manifest.json");
+  assert.deepEqual(manifest.transports, ["transports/mcp_tool_call.json"]);
+  assert.ok(
+    fs.existsSync(path.join(outDir, "schemas/transports/mcp_tool_call.json"))
+  );
+  assert.ok(
+    !fs.existsSync(
+      path.join(outDir, "schemas/transports/embedded_config.json")
+    ),
+    "embedded_config.json must not be copied/modeled -- it is a pre-existing, deliberate scope exclusion"
+  );
+});
+
+test("derives the discovery profile's `keys` field from profile.json when it exists", () => {
+  const outDir = runProjector();
+  const profile = readJson(outDir, "discovery/ucp_discovery_profile.json");
+  assert.ok(profile.properties.keys, 'expected a "keys" property');
+  assert.ok(
+    !profile.properties.signing_keys,
+    'the hand-authored "signing_keys" guess must not survive once profile.json publishes the canonical field'
+  );
+  assert.equal(profile.properties.keys.items.$ref, "jwk_public_key.json");
+
+  const jwk = readJson(outDir, "discovery/jwk_public_key.json");
+  assert.ok(
+    Array.isArray(jwk.allOf) && jwk.allOf.length > 0,
+    "the derived key schema must carry profile.json's EC/OKP conditional rules, not the flat hand-authored shape"
+  );
+});
+
+test("a discovered lookup capability does not collide with catalog_lookup's identically-named fragment", () => {
+  // Reproduces a regression found while building this fix: catalog_lookup.json
+  // and a newly-discovered lookup-shaped capability (location_lookup.json)
+  // both define $defs.lookup_request/lookup_response with NO title. quicktype
+  // names an untitled schema-mode fragment from the $ref fragment name alone,
+  // so both compiled to the same "LookupRequestSchema" and one shape's fields
+  // silently vanished (observed against the real spec: catalog's `attribution`
+  // field was dropped, replaced by location's `distance`/`serves`). This runs
+  // the actual quicktype step (not just the projector) to prove the fix
+  // (title the newly-discovered capability's copy) keeps both intact.
+  const outDir = runProjector();
+  const manifest = readJson(outDir, "generated-src-manifest.json");
+  const locationFragments = manifest.capabilities.filter((entry) =>
+    entry.startsWith("common/location_lookup.json#")
+  );
+  assert.ok(
+    locationFragments.length > 0,
+    "expected location_lookup fragments in the manifest"
+  );
+
+  const outputTs = path.join(outDir, "combined.ts");
+  execFileSync(
+    "npx",
+    [
+      "quicktype",
+      "--lang",
+      "typescript-zod",
+      "--src-lang",
+      "schema",
+      "--src",
+      path.join(
+        outDir,
+        "schemas/shopping/catalog_lookup.json#/$defs/lookup_request"
+      ),
+      "--src",
+      path.join(
+        outDir,
+        "schemas/shopping/catalog_lookup.json#/$defs/lookup_response"
+      ),
+      ...locationFragments.flatMap((entry) => [
+        "--src",
+        path.join(outDir, "schemas", entry),
+      ]),
+      "-o",
+      outputTs,
+    ],
+    { cwd: REPO_ROOT, stdio: ["ignore", "pipe", "pipe"] }
+  );
+
+  const generated = fs.readFileSync(outputTs, "utf8");
+  assert.match(
+    generated,
+    /catalog_handle_marker/,
+    "catalog_lookup's own field must survive -- it must not be silently replaced by the colliding capability's shape"
+  );
+  assert.match(
+    generated,
+    /location_radius_marker/,
+    "the newly-discovered capability's field must also be present, under its own (titled, non-colliding) type"
+  );
+  // Exactly one exported const is literally named LookupRequestSchema
+  // (catalog's, untouched); location's must have been disambiguated.
+  const lookupRequestExports =
+    generated.match(/^export const \w*LookupRequestSchema/gm) ?? [];
+  assert.ok(
+    lookupRequestExports.length >= 2,
+    "expected two distinct *LookupRequestSchema exports, not a collision"
+  );
+  assert.ok(
+    lookupRequestExports.includes("export const LookupRequestSchema"),
+    "catalog_lookup's untitled, pre-existing name must be unaffected"
+  );
+});
+
+test("still cross-references common/types (already-working blindness) alongside the newly-fixed common/ root", () => {
+  const outDir = runProjector();
+  assert.ok(
+    fs.existsSync(
+      path.join(outDir, "schemas/common/types/pan_credential.json")
+    ),
+    "common/types/* must remain reachable exactly as before this fix"
+  );
+});
+
+test("drops a property that $refs a self-referential schema, loudly, without disturbing its siblings", () => {
+  // Reproduces a regression found while building this fix: 2026-08-25 added
+  // common/types/constraint_expression.json, a genuinely self-referential
+  // schema ($ref: "#" pointing at its own whole document, letting a
+  // constraint expression nest inside itself). quicktype's typescript-zod
+  // target cannot place a type like this AT ALL -- verified in total
+  // isolation, zero other schema content, it just exhausts its ordering-pass
+  // budget and silently emits nothing. Worse, that failure was not confined
+  // to the recursive type itself: it also silently deleted unrelated types
+  // elsewhere in the SAME invocation (the real-world case: the whole
+  // discovery-profile envelope, including the very "keys" field this lane
+  // exists to fix, vanished because it shared an invocation with
+  // available_payment_instrument.json's "constraints" property).
+  //
+  // tests/fixtures/reorg-spec/source/schemas/common/types/payment.json now
+  // carries a "constraints" property $ref'ing a fixture recursive schema
+  // (test_recursive_constraint.json) that mirrors this exact shape. The fix
+  // (dropSelfReferentialProperties, hooked into projectSchemaNode) must
+  // remove ONLY that property before quicktype ever sees it, logging the
+  // omission loudly rather than letting it silently propagate into a hole
+  // in some unrelated type down the pipeline.
+  const { spawnSync } = require("node:child_process");
+  const probeResult = spawnSync(
+    "node",
+    [
+      PROJECTOR_SCRIPT,
+      FIXTURE_SOURCE,
+      fs.mkdtempSync(path.join(os.tmpdir(), "ucp-js-sdk-selfref-fixture-")),
+    ],
+    { encoding: "utf8" }
+  );
+  const output = `${probeResult.stdout}${probeResult.stderr}`;
+  assert.match(
+    output,
+    /dropping "constraints".*payment\.json.*test_recursive_constraint\.json/s,
+    "expected a loud, specific message naming the dropped property and file"
+  );
+
+  const outDir = runProjector();
+  const payment = readJson(outDir, "schemas/common/types/payment.json");
+  assert.ok(
+    !("constraints" in payment.properties),
+    "the self-referential property must be gone from the projected output"
+  );
+  assert.ok(
+    "instruments" in payment.properties,
+    "an unrelated sibling property must survive untouched"
+  );
+
+  // Prove quicktype itself now succeeds on the projected file (the actual
+  // failure mode this fix targets), and that "instruments" still generates.
+  const outputTs = path.join(outDir, "payment-combined.ts");
+  execFileSync(
+    "npx",
+    [
+      "quicktype",
+      "--lang",
+      "typescript-zod",
+      "--src-lang",
+      "schema",
+      "--src",
+      path.join(outDir, "schemas/common/types/payment.json"),
+      "-o",
+      outputTs,
+    ],
+    { cwd: REPO_ROOT, stdio: ["ignore", "pipe", "pipe"] }
+  );
+  const generated = fs.readFileSync(outputTs, "utf8");
+  assert.match(generated, /instruments/);
+  assert.doesNotMatch(generated, /constraints/);
+});


### PR DESCRIPTION
## Summary

`npm run generate` against a 2026-08-25-shaped spec tree crashes
immediately, and once that crash is fixed, silently produces an incomplete
`src/spec_generated.ts` with no error at all. This fixes both, generically
(no hand lists, no new hardcoded paths), and proves the regeneration
completes end to end against the real 2026-08-25 spec with every exclusion
explicit and reviewed, not just a synthetic fixture.

## Root causes (all against upstream/main at 44c448d)

1. **AP2 mandate path hardcode**
   (`scripts/project-current-ucp-schemas.mjs:1044-1045`).
   `writeCompatibilityAp2Schema` hardcodes
   `sourceRel = "shopping/ap2_mandate.json"`. The reorg moved AND renamed
   this extension (`common/payment_ap2_mandate.json`,
   `dev.ucp.shopping.ap2_mandate` -> `dev.ucp.common.payment.ap2_mandate`),
   so the hardcoded path resolves to nothing and the function crashes:
   `SyntaxError: "undefined" is not valid JSON` at `clone()`. Fixed by
   resolving the extension with a basename fallback, then a
   declared-name-suffix fallback (`resolveSourceSchema`), so a further
   move or rename does not need another hardcoded path.

2. **common/ root blindness**
   (`scripts/project-current-ucp-schemas.mjs:435,449`). `loadSchemaCache`
   walks `schemas/shopping/` and `schemas/common/types/` but never the
   `schemas/common/` root. Every root-level file the reorg introduced there
   was invisible to the generator, not merely unmodeled. Fixed by walking the whole `schemas/` tree.

3. **Capability/transport allowlist** (`generate_models.sh:69-108`). The
   2026-04-08 set of extension/lookup/search capabilities and transport
   envelopes was hand-enumerated as `--src` flags. Any capability the
   reorg added beyond that fixed set never reached quicktype. Fixed with
   `discoverAdditionalCapabilities`/`discoverTransportEnvelopes`:
   capabilities are found by SHAPE (a declared `dev.ucp.*` name plus a
   `lookup_request`/`lookup_response` pair, a `search_request`/
   `search_response` pair, or a `$defs` key ending in
   `.checkout`/`.order`/`.cart`) rather than by name, so a future spec
   release adding another one needs no script edit. A capability matching
   none of these shapes (`identity_linking`, `permalink`) is left alone
   and reported. `identity_linking` exists in BOTH the 2026-04-08 and
   2026-08-25 trees and was never modeled at either pin, so it is a
   pre-existing, documented residual; `permalink` is new in 2026-08-25 and
   matches no modelable shape, so it is reported rather than dropped.

4. **Core response_*_schema hand-list**
   (`scripts/project-current-ucp-schemas.mjs:900-909`).
   `writeCompatibilityCoreSchemas` hand-listed exactly four
   `response_*_schema` keys; 2026-08-25 added a fifth
   (`response_location_schema`) that the hand-list silently excluded.
   Fixed by deriving the full set from the real `ucp.json`.

## Discovery-driven fix design

The common thread across all four root causes is the same failure mode:
the 2026-04-08 spec specific SET of capabilities, files, and keys got
hand-enumerated somewhere in the generator, so anything the next spec
release adds is invisible until someone edits the generator by hand. The
fix is not four unrelated patches -- it is one design applied four times:
**discover by shape, from the schema tree itself, never from a fixed
list.** A capability schema declares its own identity (a `dev.ucp.*` name)
and its own shape (lookup/search/attachment/envelope); the generator now
reads that instead of assuming it already knows the full set. This is why
the fix generalizes forward: a 2026-11 spec release adding a sixth
capability needs no generator change at all, as long as it uses one of the
shapes this generator already recognizes.

One further derivation joined the same design: the discovery profile
`signing_keys` field was a hand-authored guess in the projection script;
it is now derived from `profile.json` itself (property name and item
schema both), with the 2026-04-08 hand-authored shape as the fallback, so
the pinned output does not move while a spec that publishes the canonical
`keys` field (RFC 7517) gets it derived rather than guessed.

Two more gaps surfaced only once this discovery mechanism ran against the
REAL spec end to end (not the synthetic fixture, which cannot reproduce
scale-dependent quicktype behavior):

- **Fragment name collision.** quicktype names an untitled schema-mode
  fragment from its `$ref` fragment name. `location_lookup.json` reuses
  the same untitled `lookup_request`/`lookup_response` fragment names as
  the pre-existing `catalog_lookup.json`, colliding and silently dropping
  the fields of one shape. Fixed by titling only its own copy of the
  fragment for the newly discovered capability, leaving the pre-existing,
  already-working untitled fragments untouched.

- **A per-family isolation gap, and a genuinely recursive schema.**
  quicktype cannot represent every JSON Schema shape, and its
  type-ordering pass has a fixed iteration budget it can silently exceed
  (dropping types with no non-zero exit -- not a crash, just a hole).
  Each discovered capability now generates in its own bounded quicktype
  invocation, merged into the main output via
  `scripts/merge-generated-fragment.mjs`, so one unrepresentable family
  cannot corrupt the rest of the regeneration. That isolation mechanism
  was ITSELF found to be a fail-open during this work (log a failure and
  continue, exit 0 regardless) -- fixed with
  `scripts/check-generation-completeness.mjs`: a family that fails must be
  on a short, reviewed `KNOWN_UNREPRESENTABLE_FAMILIES` allowlist (each
  entry citing the exact quicktype failure) or the whole run now exits
  non-zero. Separately, 2026-08-25 adds
  `common/types/constraint_expression.json`, a genuinely self-referential
  schema (`"$ref": "#"` pointing at its own whole document) that
  quicktype cannot place at all, verified in total isolation. That failure
  silently deleted UNRELATED types sharing the same invocation, including
  the entire discovery-profile envelope carrying the new `keys` field (see
  the signing_keys derivation above). Fixed by dropping any property whose value is a `$ref`
  to a schema containing a bare `"$ref": "#"` before quicktype ever sees
  it, logged loudly -- deliberately NOT matching an ordinary
  `"#/$defs/..."` fragment reference, which is a normal, already-working
  JSON Schema idiom.

## Both-pin verification

- **2026-04-08 stays byte-identical.** Re-run and diffed against the
  actual git-committed `src/spec_generated.ts` (via `git show
  HEAD:src/spec_generated.ts`, not a working-tree copy): clean diff,
  confirmed twice.
  None of the fixes above can move it -- the AP2/response-envelope/
  discovery fixes are additive fallbacks that only engage when the
  2026-04-08 shape is absent; the fragment-titling fix only engages on a
  real name collision (none exists in the 2026-04-08 tree); the
  self-referential-property fix only engages on a property that is solely
  a `$ref` to a schema containing a bare `"$ref": "#"` -- the 2026-04-08
  run logs zero such drops and its output stays byte-identical.

- **2026-08-25 completes.** The real regeneration (not the fixture) now
  succeeds end to end: 242 exported schema constants (the committed
  2026-04-08 output has 151). Family-count evidence:
  `PaymentTerms` 21 references, `Loyalty` 31, `PaymentSplit` 18,
  `Location*` 32, `signing_keys` 0 (fully replaced by the new `keys`
  field, present on `UcpDiscoveryProfileSchema`). `identity_linking` and
  the four credential subtype schemas (card/PAN/network-token/token) are
  confirmed absent in BOTH pins for the same reason (an out-of-scope
  capability shape, and orphaned/unreferenced type files respectively) --
  not something this PR introduces or is expected to fix.
  `payment_authentication` is the one reviewed exclusion: its named
  Action keys plus a schema-typed additionalProperties catch-all on one
  object hit a quicktype typescript-zod internal error
  (`Error: Internal error: .`), verified with a minimal isolated repro.

## Kill test

Reverted `generate_models.sh` and `scripts/project-current-ucp-schemas.mjs`
to their pre-fix `upstream/main` versions, keeping the tests from this
PR: all 11 tests in `tests/generate-0825-projection.test.js` fail, the 9
allowlist-gate tests stay green (they exercise the untouched new script
by design), and the real
2026-08-25 regeneration crashes with the exact original error
(`SyntaxError: "undefined" is not valid JSON`). Restoring the fix returns
both to green. This confirms the tests actually exercise the fix, not just
its surface.

## Tests

129/129 (`npm run pretest && npm test`), `npm run build`, and
`npm run build:noEmit` all green. New coverage: 11 tests in
`tests/generate-0825-projection.test.js` (each root cause, the fragment
collision, and the self-referential-property drop, all against the
fixture spec tree) plus 9 tests in
`tests/check-generation-completeness.test.js` (the allowlist gate, direct
and via CLI, no quicktype or spec tree needed).

## Coexistence with #61

#61 also targets the 2026-08-25 spec: it extends the generator hand lists
far enough to produce an output and commits that output. The two PRs
overlap in two places:

- `src/spec_generated.ts` itself: this PR does not touch it (the
  2026-08-25 regeneration output is deliberately left uncommitted here,
  out of scope for a generator fix) while #61 does. No conflict on this
  file either way.
- `generate_models.sh` / `scripts/project-current-ucp-schemas.mjs`: #61
  edits the same regions this PR rewrites (the QUICKTYPE_ARGS block and
  the schema-cache/type-list areas), so whichever PR lands second needs a
  rebase of these two scripts plus a regeneration. The substance is
  complementary rather than competing: once the discovery mechanism from
  this PR is in the tree, a 2026-08-25 regeneration completes with every
  family present or explicitly excluded, which is the property the
  checked-in output from #61 needs in order to be complete on the next
  regeneration.

Fixes #64
